### PR TITLE
fix: expose `mode` from TokenProvider to checks if token is used for live or test mode

### DIFF
--- a/packages/core-app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/validateToken.ts
@@ -39,6 +39,7 @@ export async function isValidTokenForCurrentApp({
 }): Promise<{
   isValidToken: boolean
   permissions?: RolePermissions
+  isTestMode?: boolean
 }> {
   const { slug, kind } = getInfoFromJwt(accessToken)
   const isValidKind = kind === clientKind
@@ -61,7 +62,8 @@ export async function isValidTokenForCurrentApp({
       permissions:
         tokenInfo?.permissions != null
           ? preparePermissions(tokenInfo.permissions)
-          : undefined
+          : undefined,
+      isTestMode: Boolean(tokenInfo?.token.test)
     }
   } catch {
     return {


### PR DESCRIPTION
### What does this PR do?
TokenProvider now exposes a new `mode` flag.

```ts
const { mode } = useTokenProvider()  // live or test
```
