### PR TITLE
Change `isTestMode` boolean into `mode` union type

### DIFF
--- a/packages/core-app-elements/src/ui/composite/PageLayout.test.tsx
+++ b/packages/core-app-elements/src/ui/composite/PageLayout.test.tsx
@@ -1,21 +1,21 @@
-import { PageLayout } from './PageLayout'
+import { PageLayout, PageLayoutProps } from './PageLayout'
 import { render, RenderResult } from '@testing-library/react'
+
+interface SetupProps extends Omit<PageLayoutProps, 'children'> {
+  id: string
+}
 
 type SetupResult = RenderResult & {
   element: HTMLElement
 }
 
-const setup = ({ isTestMode }: { isTestMode?: boolean }): SetupResult => {
+const setup = ({ id, ...rest }: SetupProps): SetupResult => {
   const utils = render(
-    <PageLayout
-      data-test-id='my-page'
-      title='Page title'
-      isTestMode={isTestMode}
-    >
+    <PageLayout data-test-id={id} {...rest}>
       <div>Content...</div>
     </PageLayout>
   )
-  const element = utils.getByTestId('my-page')
+  const element = utils.getByTestId(id)
   return {
     element,
     ...utils
@@ -24,13 +24,20 @@ const setup = ({ isTestMode }: { isTestMode?: boolean }): SetupResult => {
 
 describe('PageLayout', () => {
   test('Should be rendered', () => {
-    const { element } = setup({})
+    const { element } = setup({
+      title: 'Page title',
+      id: 'my-page'
+    })
     expect(element).toBeInTheDocument()
     expect(element).toMatchSnapshot()
   })
 
   test('Should render test mode badge', () => {
-    const { getByText } = setup({ isTestMode: true })
+    const { getByText } = setup({
+      title: 'Page title',
+      id: 'my-page',
+      mode: 'test'
+    })
     expect(getByText('TEST DATA')).toBeInTheDocument()
   })
 })

--- a/packages/core-app-elements/src/ui/composite/PageLayout.tsx
+++ b/packages/core-app-elements/src/ui/composite/PageLayout.tsx
@@ -2,16 +2,16 @@ import { ReactNode } from 'react'
 import { Container } from '#ui/atoms/Container'
 import { PageHeading, PageHeadingProps } from '#ui/atoms/PageHeading'
 
-interface PageLayoutProps
+export interface PageLayoutProps
   extends Omit<PageHeadingProps, 'badgeVariant' | 'badgeLabel'> {
   /**
    * Page content
    */
   children: ReactNode
   /**
-   * When `true` it will render a `TEST DATA` Badge to inform user test mode is on.
+   * When mode is `test`, it will render a `TEST DATA` Badge to inform user api is working in test mode.
    */
-  isTestMode?: boolean
+  mode?: 'test' | 'live'
 }
 
 export function PageLayout({
@@ -20,7 +20,7 @@ export function PageLayout({
   onGoBack,
   children,
   actionButton,
-  isTestMode,
+  mode,
   ...rest
 }: PageLayoutProps): JSX.Element {
   return (
@@ -30,8 +30,8 @@ export function PageLayout({
         description={description}
         onGoBack={onGoBack}
         actionButton={actionButton}
-        badgeLabel={isTestMode === true ? 'TEST DATA' : undefined}
-        badgeVariant={isTestMode === true ? 'warning-solid' : undefined}
+        badgeLabel={mode === 'test' ? 'TEST DATA' : undefined}
+        badgeVariant={mode === 'test' ? 'warning-solid' : undefined}
       />
       {children}
     </Container>

--- a/packages/storybook/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/storybook/src/stories/composite/PageLayout.stories.tsx
@@ -24,7 +24,7 @@ Default.args = {
   title: 'Resources',
   description: 'View all resources',
   onGoBack: () => undefined,
-  isTestMode: true
+  mode: 'test'
 }
 
 export const WithActionButton = Template.bind({})
@@ -32,6 +32,6 @@ WithActionButton.args = {
   title: 'Resources',
   description: 'View all resources',
   onGoBack: () => undefined,
-  isTestMode: false,
+  mode: 'live',
   actionButton: <A>Add new</A>
 }


### PR DESCRIPTION
### What does this PR do?

Instead of using `isTestMode`, we can now pass the same `mode: 'test' | 'live'` value returned from TokenProvider

Required to close:
- https://github.com/commercelayer/core-app-exports/pull/1

