### PR TITLE
Add compatibility with preact

### DIFF
--- a/packages/core-app-elements/vite.config.ts
+++ b/packages/core-app-elements/vite.config.ts
@@ -6,7 +6,9 @@ import dts from 'vite-plugin-dts'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
-    react(),
+    react({
+      jsxRuntime: 'classic'
+    }),
     dts({
       insertTypesEntry: true
     })


### PR DESCRIPTION
### What does this PR do?
Update vite config and set jsxRuntime as `classic` to avoid conflicts when the library is used with Preact.
Without this, the bundled file was including all react jsx-runtime methods that are not compatible with preact.
