### PR TITLE
Export downloadJsonAsFile as standalone helper

### DIFF
--- a/packages/core-app-elements/src/helpers/downloadJsonAsFile.ts
+++ b/packages/core-app-elements/src/helpers/downloadJsonAsFile.ts
@@ -1,0 +1,26 @@
+import isEmpty from 'lodash/isEmpty'
+
+/**
+ * Trigger the download of requested JSON object as user defined file
+ * @param json - optional JSON object that will be the content of downloaded file
+ * @param filename - string to define the downloaded file name
+ */
+export function downloadJsonAsFile({
+  json,
+  filename
+}: {
+  json?: object
+  filename: string
+}): void {
+  if (isEmpty(json)) {
+    json = {}
+  }
+  const dataUri =
+    'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(json))
+  const tag = document.createElement('a')
+  tag.setAttribute('href', dataUri)
+  tag.setAttribute('download', filename)
+  document.body.appendChild(tag)
+  tag.click()
+  tag.remove()
+}

--- a/packages/core-app-elements/src/main.ts
+++ b/packages/core-app-elements/src/main.ts
@@ -68,4 +68,5 @@ export { default as ListItemTask } from '#ui/lists/ListItemTask'
 export { default as TableData } from '#ui/tables/TableData'
 
 // Helpers
+export { downloadJsonAsFile } from '#helpers/downloadJsonAsFile'
 export { formatDate } from '#helpers/date'

--- a/packages/core-app-elements/src/ui/composite/Report.tsx
+++ b/packages/core-app-elements/src/ui/composite/Report.tsx
@@ -1,4 +1,4 @@
-import isEmpty from 'lodash/isEmpty'
+import { downloadJsonAsFile } from '#helpers/downloadJsonAsFile'
 import { ReactNode } from 'react'
 import { Label } from '#ui/forms/Label'
 import { Skeleton, SkeletonItem } from '#ui/atoms/Skeleton'
@@ -91,27 +91,6 @@ export function Report({
       </div>
     </div>
   )
-}
-
-// create a fake download element on the fly to avoid to pollute the dom with a large data-uri string
-const downloadJsonAsFile = ({
-  json,
-  filename
-}: {
-  json?: object
-  filename: string
-}): void => {
-  if (isEmpty(json)) {
-    json = {}
-  }
-  const dataUri =
-    'data:text/json;charset=utf-8,' + encodeURIComponent(JSON.stringify(json))
-  const tag = document.createElement('a')
-  tag.setAttribute('href', dataUri)
-  tag.setAttribute('download', filename)
-  document.body.appendChild(tag)
-  tag.click()
-  tag.remove()
 }
 
 export default Report


### PR DESCRIPTION
### What does this PR do?
Extract from `Report` component previously defined `downloadJsonAsFile` method to have it as an exported helper.