### PR TITLE
Compute dashboard url considering mode and domain

### DIFF
--- a/packages/core-app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/core-app-elements/src/providers/TokenProvider/index.tsx
@@ -71,7 +71,10 @@ export interface TokenProviderProps {
 }
 
 export const AuthContext = createContext<TokenProviderValue>({
-  dashboardUrl: makeDashboardUrl(),
+  dashboardUrl: makeDashboardUrl({
+    domain: initialTokenProviderState.settings.domain,
+    mode: initialTokenProviderState.settings.mode
+  }),
   canUser: () => false,
   emitInvalidAuth: () => undefined,
   settings: initialTokenProviderState.settings
@@ -164,7 +167,10 @@ function TokenProvider({
   )
 
   const value: TokenProviderValue = {
-    dashboardUrl: makeDashboardUrl(),
+    dashboardUrl: makeDashboardUrl({
+      domain,
+      mode: _state.settings.mode
+    }),
     settings: _state.settings,
     canUser,
     emitInvalidAuth

--- a/packages/core-app-elements/src/providers/TokenProvider/slug.test.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/slug.test.ts
@@ -25,6 +25,15 @@ describe('Get org slug from URL', () => {
 
   test('Compute proper dashboard url get subdomain as slug', () => {
     window.location.hostname = 'my-org.commercelayer.app'
-    expect(makeDashboardUrl()).toBe('https://dashboard.commercelayer.io/my-org')
+    expect(makeDashboardUrl({})).toBe(
+      'https://dashboard.commercelayer.io/live/my-org'
+    )
+  })
+
+  test('Compute proper dashboard url with custom domain and mode', () => {
+    window.location.hostname = 'my-org.commercelayer.app'
+    expect(makeDashboardUrl({ domain: 'commercelayer.co', mode: 'test' })).toBe(
+      'https://dashboard.commercelayer.co/test/my-org'
+    )
   })
 })

--- a/packages/core-app-elements/src/providers/TokenProvider/slug.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/slug.ts
@@ -1,7 +1,15 @@
+import { Mode } from './types'
+
 export function getOrgSlugFromCurrentUrl(): string {
   return window.location.hostname.split('.')[0]
 }
 
-export function makeDashboardUrl(): string {
-  return `https://dashboard.commercelayer.io/${getOrgSlugFromCurrentUrl()}`
+export function makeDashboardUrl({
+  domain = 'commercelayer.io',
+  mode = 'live'
+}: {
+  domain?: string
+  mode?: Mode
+}): string {
+  return `https://dashboard.${domain}/${mode}/${getOrgSlugFromCurrentUrl()}`
 }


### PR DESCRIPTION
### What does this PR do?

```
https://dashboard.<domain>/<mode>/<orgSlug>
```

example:
`https://dashboard.commercelayer.io/test/demo-store`

resolves #29 
