### PR TITLE
Set correct property name `rolePermissions`

### DIFF
--- a/packages/core-app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/core-app-elements/src/providers/TokenProvider/index.tsx
@@ -158,7 +158,7 @@ function TokenProvider({
               mode: tokenInfo.mode,
               domain
             },
-            permissions: tokenInfo.permissions ?? {}
+            rolePermissions: tokenInfo.permissions ?? {}
           }
         })
       })()

--- a/packages/core-app-elements/src/providers/TokenProvider/reducer.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/reducer.ts
@@ -32,7 +32,7 @@ type Action =
       type: 'validToken'
       payload: {
         settings: TokenProviderAuthSettings
-        permissions: TokenProviderRolePermissions
+        rolePermissions: TokenProviderRolePermissions
       }
     }
 


### PR DESCRIPTION
### What does this PR do?
`rolePermissions` was wrongly spread ad `permissions`