### PR TITLE
Expose user timezone in `<TokenProvider>`

### DIFF
--- a/packages/core-app-elements/mocks/handlers.ts
+++ b/packages/core-app-elements/mocks/handlers.ts
@@ -41,6 +41,15 @@ export const handlers = [
           name: 'MyApplicationCredentials',
           core: false
         },
+        owner: {
+          id: 'kdRvPYzXfy',
+          type: 'User',
+          first_name: 'Ringo',
+          last_name: 'Starr',
+          email: 'ringostarr@domain.com',
+          owner: false,
+          time_zone: 'Europe/Rome'
+        },
         permissions: {
           imports: { actions: ['create', 'destroy', 'read', 'update'] }
         }

--- a/packages/core-app-elements/src/providers/TokenProvider/index.test.tsx
+++ b/packages/core-app-elements/src/providers/TokenProvider/index.test.tsx
@@ -23,9 +23,10 @@ const setup = ({ id, ...props }: SetupProps): SetupResult => {
   const utils = render(
     <div data-test-id={id}>
       <TokenProvider {...props}>
-        {({ settings: { mode } }) => (
+        {({ settings: { mode, timezone } }) => (
           <div>
             <p>mode: {mode}</p>
+            <p>timezone: {timezone}</p>
             <p>content</p>
           </div>
         )}
@@ -72,6 +73,7 @@ describe('TokenProvider', () => {
     expect(getByText('Loading...')).toBeVisible()
     await waitFor(() => expect(getByText('content')).toBeVisible())
     expect(getByText('mode: test')).toBeVisible()
+    expect(getByText('timezone: Europe/Rome')).toBeVisible()
     expect(onInvalidAuth).toBeCalledTimes(0)
   })
 

--- a/packages/core-app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/core-app-elements/src/providers/TokenProvider/index.tsx
@@ -160,7 +160,8 @@ function TokenProvider({
               accessToken: tokenInfo.accessToken,
               organizationSlug: tokenInfo.organizationSlug,
               mode: tokenInfo.mode,
-              domain
+              domain,
+              timezone: tokenInfo.timezone
             },
             rolePermissions: tokenInfo.permissions ?? {}
           }

--- a/packages/core-app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/types.ts
@@ -140,6 +140,15 @@ export interface TokenProviderTokenInfo {
     TokenProviderResourceType,
     { actions: TokenProviderRoleActions[] }
   >
+  owner?: {
+    id: string
+    type: 'User'
+    first_name?: string
+    last_name?: string
+    email?: string
+    owner?: boolean
+    time_zone?: string
+  }
 }
 
 export type Mode = 'live' | 'test'
@@ -149,4 +158,5 @@ export interface TokenProviderAuthSettings {
   organizationSlug: string
   domain: string
   mode: Mode
+  timezone?: string
 }

--- a/packages/core-app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/core-app-elements/src/providers/TokenProvider/validateToken.ts
@@ -32,6 +32,7 @@ interface ValidToken {
   mode: Mode
   organizationSlug: string
   permissions?: TokenProviderRolePermissions
+  timezone?: string
 }
 interface InvalidToken {
   isValidToken: false
@@ -79,7 +80,8 @@ export async function isValidTokenForCurrentApp({
       permissions:
         tokenInfo?.permissions != null
           ? preparePermissions(tokenInfo.permissions)
-          : undefined
+          : undefined,
+      timezone: tokenInfo?.owner?.time_zone
     }
   } catch {
     return {


### PR DESCRIPTION
### What does this PR do?
When available from `token/info`, we can expose timezone from `<TokenProvider>`.
In this way, any app can retrieve it by doing:
```
  const {
    settings: { timezone }
  } = useTokenProvider()
  
  console.log(timezone)   // "Europe/Rome" or undefined
```