### PR TITLE
Hook Form - remove wrapper `div` in InputToggle

### DIFF
--- a/packages/app-elements-hook-form/src/components/InputToggleBox.tsx
+++ b/packages/app-elements-hook-form/src/components/InputToggleBox.tsx
@@ -8,16 +8,24 @@ interface Props extends InputToggleBoxProps {
    * field name to match hook-form state
    */
   name: string
+  /**
+   * show validation error message underneath
+   */
+  showValidation: boolean
 }
 
-function InputToggleBox({ name, ...props }: Props): JSX.Element {
+function InputToggleBox({
+  name,
+  showValidation,
+  ...props
+}: Props): JSX.Element {
   const { register } = useFormContext()
 
   return (
-    <div>
+    <>
       <InputToggleBoxUI {...props} {...register(name)} />
-      <ValidationError name={name} />
-    </div>
+      {showValidation && <ValidationError name={name} />}
+    </>
   )
 }
 

--- a/packages/app-elements-hook-form/src/components/InputToggleListBox.tsx
+++ b/packages/app-elements-hook-form/src/components/InputToggleListBox.tsx
@@ -8,16 +8,24 @@ interface Props extends InputToggleListBoxProps {
    * field name to match hook-form state
    */
   name: string
+  /**
+   * show validation error message underneath
+   */
+  showValidation: boolean
 }
 
-function InputToggleListBox({ name, ...props }: Props): JSX.Element {
+function InputToggleListBox({
+  name,
+  showValidation,
+  ...props
+}: Props): JSX.Element {
   const { register } = useFormContext()
 
   return (
-    <div>
+    <>
       <InputToggleListBoxUi {...props} {...register(name)} />
-      <ValidationError name={name} />
-    </div>
+      {showValidation && <ValidationError name={name} />}
+    </>
   )
 }
 


### PR DESCRIPTION
### What does this PR do?
An extra `<div>` was breaking the staking of multiple `<InputToggle...>` components.
ValidationError should not be required in majority of cases, so we show it on request using `showValidation` prop
