### PR TITLE
Fix `InputFeedback` icon size and columns gap

### DIFF
--- a/packages/core-app-elements/src/ui/forms/InputFeedback.tsx
+++ b/packages/core-app-elements/src/ui/forms/InputFeedback.tsx
@@ -17,13 +17,13 @@ function InputFeedback({
 }: InputFeedbackProps): JSX.Element {
   const icons: Record<FeedbackVariant, JSX.Element> = {
     danger: (
-      <WarningCircle size={15} weight='bold' data-test-id='icon-danger' />
+      <WarningCircle size={20} weight='bold' data-test-id='icon-danger' />
     ),
     success: (
-      <CheckCircle size={15} weight='bold' data-test-id='icon-success' />
+      <CheckCircle size={20} weight='bold' data-test-id='icon-success' />
     ),
     warning: (
-      <WarningCircle size={15} weight='bold' data-test-id='icon-warning' />
+      <WarningCircle size={20} weight='bold' data-test-id='icon-warning' />
     )
   }
 
@@ -31,7 +31,7 @@ function InputFeedback({
     <div
       className={cn([
         className,
-        'flex items-center gap-[6px]',
+        'flex items-center gap-[5px]',
         {
           'text-red': variant === 'danger',
           'text-green': variant === 'success',


### PR DESCRIPTION
### What does this PR do?
Fix InputFeedback icon size and columns gap

### Description of Task to be completed
- Icon size is now set to `20` 
- Gap is set to `5px`