### PR TITLE
Allow `customTemplate` to be used in `formatDate` helper

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -1,11 +1,20 @@
 import { formatDate } from './date'
 
 describe('formatDate', () => {
+  test('Should return a nice date string', () => {
+    expect(
+      formatDate({
+        isoDate: '2022-10-14T14:32:00.000Z'
+      })
+    ).toBe('Oct 14, 2022')
+  })
+
   test('Should accept a date with time', () => {
     // AM
     expect(
       formatDate({
-        isoDate: '2023-02-22T10:32:47.284Z'
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'full'
       })
     ).toBe('Feb 22, 2023 · 10:32 AM')
 
@@ -16,15 +25,6 @@ describe('formatDate', () => {
         format: 'full'
       })
     ).toBe('Oct 26, 2022 · 4:16 PM')
-  })
-
-  test('Should return a nice date string', () => {
-    expect(
-      formatDate({
-        isoDate: '2022-10-14T14:32:00.000Z',
-        format: 'noTime'
-      })
-    ).toBe('Oct 14, 2022')
   })
 
   test('Should return a date without year', () => {
@@ -50,7 +50,8 @@ describe('formatDate', () => {
     expect(
       formatDate({
         isoDate: '2022-10-26T16:16:31.279Z',
-        timezone: 'Europe/Rome'
+        timezone: 'Europe/Rome',
+        format: 'full'
       })
     ).toBe('Oct 26, 2022 · 6:16 PM')
   })

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -19,6 +19,7 @@ type FormatDateOptions =
            * - full `Feb 28, 2023 · 5:30 PM`
            * - noTime `Feb 28, 2023`
            * - noYear `Feb 28`
+           * @default noTime
            */
           format?: Format
         }
@@ -63,7 +64,7 @@ export function formatDate({
   }
 }
 
-function getPresetFormatTemplate(format: Format = 'full'): string {
+function getPresetFormatTemplate(format: Format = 'noTime'): string {
   switch (format) {
     case 'noTime':
       return 'LLL dd, yyyy' // Feb 28, 2023


### PR DESCRIPTION
### What does this PR do?
Replaces `includeTime` boolean with a `format` union that can be discriminated to also pass a `customTemplate`.

This means that instead of using `includeTime` we must pass `format: 'full' | 'noTime' | 'noYear' | 'custom'`.
When `format` is not specified, default value is `noTime`.
When `format` is `custom` then `customTemplate` is required

### How to format the date:
* full `Feb 28, 2023 · 5:30 PM`
* noTime `Feb 28, 2023`
*  noYear `Feb 28`
```
formatDate({
  isoDate: '2023-02-27T16:00:00.000Z',
  format: 'full'
})
```
or 
```
formatDate({
  isoDate: '2023-02-27T16:00:00.000Z',
  format: 'custom',
  customTemplate: 'MM/dd/yyyy'
}) 
```

###  💥 Breaking change
`includeTime` in `dateFormat` does not exist anymore. use `format: "full"` if you also want to include time.



