### PR TITLE
Add 'titleSize' and 'border' props to better customize the Legend component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Legend.tsx
+++ b/packages/app-elements/src/ui/atoms/Legend.tsx
@@ -7,6 +7,14 @@ interface LegendProps {
    */
   title?: ReactNode
   /**
+   * Size for the title prop
+   */
+  titleSize?: 'normal' | 'small'
+  /**
+   * Specify `none` to remove border
+   */
+  border?: 'none'
+  /**
    * This will render a button on the right side of the row
    */
   actionButton?: ReactNode
@@ -16,18 +24,38 @@ interface LegendProps {
   className?: string
 }
 
+// TODO: Do we want to manage headings? (h2, h3, hx)
+
 function Legend({
   title,
+  titleSize = 'normal',
   actionButton,
   className,
+  border,
   ...rest
 }: LegendProps): JSX.Element {
   return (
     <div
-      className={cn('flex justify-between items-center', className)}
+      className={cn(
+        'border-b pb-4 flex justify-between items-center',
+        {
+          // border
+          'border-gray-100': border == null,
+          'border-transparent': border === 'none'
+        },
+        className
+      )}
       {...rest}
     >
-      <h2 className='text-gray-500 font-medium'>{title}</h2>
+      <h2
+        className={cn({
+          // titleSize
+          'text-gray-500 font-medium': titleSize === 'small',
+          'text-lg font-semibold': titleSize === 'normal'
+        })}
+      >
+        {title}
+      </h2>
       <div>{actionButton}</div>
     </div>
   )

--- a/packages/app-elements/src/ui/lists/List.tsx
+++ b/packages/app-elements/src/ui/lists/List.tsx
@@ -89,16 +89,15 @@ function List({
   return (
     <div className='flex flex-col flex-1' {...rest}>
       {computedTitle != null || actionButton !== null ? (
-        <Spacer bottom='4'>
-          <Legend
-            title={computedTitle}
-            actionButton={actionButton}
-            data-test-id='list-task-legend'
-          />
-        </Spacer>
+        <Legend
+          title={computedTitle}
+          titleSize='small'
+          actionButton={actionButton}
+          data-test-id='list-task-legend'
+        />
       ) : null}
       <div
-        className={cn('border-t border-gray-100', {
+        className={cn({
           'opacity-40 pointer-events-none touch-none': isDisabled
         })}
       >

--- a/packages/app-elements/src/ui/lists/ListDetails.test.tsx
+++ b/packages/app-elements/src/ui/lists/ListDetails.test.tsx
@@ -32,7 +32,7 @@ describe('ListDetails', () => {
       title: 'Lorem ipsum'
     })
     expect(getByTestId('details-list-title')).toBeVisible()
-    expect(getByTestId('details-list-title').innerHTML).toBe('Lorem ipsum')
+    expect(getByTestId('details-list-title')).toHaveTextContent('Lorem ipsum')
   })
 
   test('Should display `isLoading` state with the specified number of `loadingLines`', () => {

--- a/packages/app-elements/src/ui/lists/ListDetails.tsx
+++ b/packages/app-elements/src/ui/lists/ListDetails.tsx
@@ -1,6 +1,7 @@
 import cn from 'classnames'
 import { ReactNode } from 'react'
 import { Skeleton, SkeletonItem } from '#ui/atoms/Skeleton'
+import { Legend } from '#ui/atoms/Legend'
 
 export interface DetailsListProps {
   /**
@@ -65,14 +66,9 @@ function ListDetails({
       ])}
       {...rest}
     >
-      {title != null ? (
-        <h4
-          className='text-lg font-semibold mb-4'
-          data-test-id='details-list-title'
-        >
-          {title}
-        </h4>
-      ) : null}
+      {title != null && (
+        <Legend data-test-id='details-list-title' title={title} />
+      )}
       <div data-test-id='details-list-rows'>{children}</div>
     </div>
   )

--- a/packages/app-elements/src/ui/lists/ListDetailsItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListDetailsItem.tsx
@@ -34,7 +34,7 @@ function ListDetailsItem({
 
   return (
     <div
-      className='border-t last-of-type:border-b border-gray-100 overflow-hidden flex flex-col md:!flex-row px-4 py-4 md:!py-2 md:!gap-4'
+      className='border-b border-gray-100 overflow-hidden flex flex-col md:!flex-row px-4 py-4 md:!py-2 md:!gap-4'
       {...rest}
     >
       <div className='text-gray-500 font-medium flex-none w-5/12 md:!py-2'>

--- a/packages/docs/src/stories/atoms/Legend.stories.tsx
+++ b/packages/docs/src/stories/atoms/Legend.stories.tsx
@@ -11,11 +11,16 @@ const setup: ComponentMeta<typeof Legend> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Legend> = (args) => (
-  <Legend {...args} actionButton={<A>New export</A>} />
-)
+const Template: ComponentStory<typeof Legend> = (args) => <Legend {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  title: 'All SKUs'
+  title: 'Addresses'
+}
+
+export const Small = Template.bind({})
+Small.args = {
+  title: 'All SKUs',
+  titleSize: 'small',
+  actionButton: <A> New export</A>
 }

--- a/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
@@ -1,0 +1,57 @@
+import { A } from '#app-elements/atoms/A'
+import { Legend } from '#app-elements/atoms/Legend'
+import { Stack } from '#app-elements/atoms/Stack'
+import { Spacer } from '#ui/atoms/Spacer'
+import { Text } from '#ui/atoms/Text'
+import { ListItem } from '#ui/lists/ListItem'
+import { ComponentStory, Meta } from '@storybook/react'
+
+const setup: Meta = {
+  title: 'Examples/Order Addresses',
+  parameters: {
+    layout: 'padded'
+  }
+}
+export default setup
+
+export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => (
+  <>
+    <Legend title='Addresses' border='none' />
+    <Stack>
+      <div>
+        <Spacer bottom='2'>
+          <Text tag='div' weight='bold'>
+            Shipping address
+          </Text>
+        </Spacer>
+        <Text tag='div' variant='info'>
+          Jack Kein
+          <br />
+          1209 Orange Street
+          <br />
+          Wilmington DE 19801 (US)
+        </Text>
+        <Spacer top='4'>
+          <A>Edit</A>
+        </Spacer>
+      </div>
+      <div>
+        <Spacer bottom='2'>
+          <Text tag='div' weight='bold'>
+            Billing address
+          </Text>
+        </Spacer>
+        <Text tag='div' variant='info'>
+          Jack Kein
+          <br />
+          1209 Orange Street
+          <br />
+          Wilmington DE 19801 (US)
+        </Text>
+        <Spacer top='4'>
+          <A>Edit</A>
+        </Spacer>
+      </div>
+    </Stack>
+  </>
+)

--- a/packages/docs/src/stories/examples/OrderHistory.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderHistory.stories.tsx
@@ -6,7 +6,7 @@ import { ListItem } from '#ui/lists/ListItem'
 import { ComponentStory, Meta } from '@storybook/react'
 
 const setup: Meta = {
-  title: 'Examples/OrderHistory',
+  title: 'Examples/Order History',
   parameters: {
     layout: 'padded'
   }

--- a/packages/docs/src/stories/lists/ListDetails.stories.tsx
+++ b/packages/docs/src/stories/lists/ListDetails.stories.tsx
@@ -1,3 +1,6 @@
+import { Avatar } from '#app-elements/atoms/Avatar'
+import { Text } from '#app-elements/atoms/Text'
+import { ListItem } from '#app-elements/lists/ListItem'
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
 import { ListDetails } from '#ui/lists/ListDetails'
 import { ListDetailsItem } from '#ui/lists/ListDetailsItem'
@@ -35,5 +38,41 @@ const Template: ComponentStory<typeof ListDetails> = (args) => (
 export const Default = Template.bind({})
 Default.args = {
   title: 'Attributes',
+  isLoading: false
+}
+
+export const WithListItem: ComponentStory<typeof ListDetails> = (args) => (
+  <ListDetails {...args}>
+    {Array(3).fill(
+      <ListItem
+        gutter='none'
+        borderStyle='dashed'
+        icon={
+          <Avatar
+            src='https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'
+            alt='Black Hat'
+          />
+        }
+      >
+        <div>
+          <Text size='small' weight='medium' variant='info' tag='div'>
+            SKU 543289
+          </Text>
+          <Text tag='div' weight='bold'>
+            Black Baby Short Sleeve with pink logo 12 months size XL
+          </Text>
+        </div>
+        <Text weight='medium' variant='info' tag='div' wrap='nowrap'>
+          $69,50 x 2
+        </Text>
+        <Text weight='bold' tag='div'>
+          $139,00
+        </Text>
+      </ListItem>
+    )}
+  </ListDetails>
+)
+WithListItem.args = {
+  title: 'Summary',
   isLoading: false
 }


### PR DESCRIPTION
This PR aims to add a `titleSize` prop and a `border` prop to better customize the `Legend` component. Components like `List` and `ListDetails` now are using the `Legend` component to render their title.

---

There's an open point that can be solved in a future PR: "_Do we need to manage headings like `h1`, `h2`, `hx` as prop?_" #86