### PR TITLE
Icon-related components now render properly when inside a list item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ yarn-debug.log*
 yarn-error.log*
 lerna-debug.log*
 
+# System
+.DS_Store
+
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
 

--- a/packages/app-elements/src/ui/atoms/Stack.tsx
+++ b/packages/app-elements/src/ui/atoms/Stack.tsx
@@ -14,7 +14,7 @@ function renderChild(child: string | JSX.Element): JSX.Element {
 
 function Stack({ children, ...props }: StackProps): JSX.Element {
   return (
-    <div {...props} className='border-t border-b border-gray-100 py-6 mb-14'>
+    <div {...props} className='border-t border-b border-gray-100 py-6'>
       <div className='flex'>
         {Children.map(children, (child) => renderChild(child))}
       </div>

--- a/packages/app-elements/src/ui/lists/ListItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.tsx
@@ -44,7 +44,7 @@ function ListItem({
       )}
     >
       <div className='flex gap-4 flex-1'>
-        {icon != null && <div>{icon}</div>}
+        {icon != null && <div className='flex-shrink-0'>{icon}</div>}
         <FlexRow alignItems={alignItems}>{children}</FlexRow>
       </div>
     </div>

--- a/packages/docs/src/stories/examples/OrderHistory.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderHistory.stories.tsx
@@ -6,7 +6,7 @@ import { ListItem } from '#ui/lists/ListItem'
 import { ComponentStory, Meta } from '@storybook/react'
 
 const setup: Meta = {
-  title: 'Examples/Order History',
+  title: 'Examples/OrderHistory',
   parameters: {
     layout: 'padded'
   }


### PR DESCRIPTION
Before:
<img width="568" alt="before the fix" src="https://user-images.githubusercontent.com/1681269/223178691-1cb40656-b912-463d-bcda-9131b395f16f.png">

After:
<img width="565" alt="after the fix" src="https://user-images.githubusercontent.com/1681269/223178895-3e4cc964-9454-47f5-bbb5-e73ca074f59e.png">
