### PR TITLE
Add weight prop on Icon, default is bold

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon.tsx
@@ -20,6 +20,11 @@ export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   size?: string | number
   /**
+   * Icon weight.
+   * @default bold
+   */
+  weight?: phosphor.IconWeight
+  /**
    * CSS classes
    */
   className?: string
@@ -31,6 +36,7 @@ function Icon({
   background = 'none',
   gap = 'none',
   size,
+  weight = 'bold',
   ...rest
 }: IconProps): JSX.Element {
   const IconSvg = useMemo(() => iconMapping[name], [iconMapping, name])
@@ -55,7 +61,7 @@ function Icon({
       ])}
       {...rest}
     >
-      <IconSvg size={getIconSize({ size, gap })} weight='bold' />
+      <IconSvg size={getIconSize({ size, gap })} weight={weight} />
     </div>
   )
 }


### PR DESCRIPTION
### What does this PR do?
Adds `weight` proper to `<Icon>` component.
By default icons should have a bold path to follow our design system