### PR TITLE
Add loading status to `<OrderSummary />`

### DIFF
--- a/packages/app-elements/src/ui/atoms/DelayShow.test.tsx
+++ b/packages/app-elements/src/ui/atoms/DelayShow.test.tsx
@@ -1,34 +1,32 @@
 import { DelayShow } from './DelayShow'
-import { render, RenderResult } from '@testing-library/react'
-
-interface SetupProps {
-  delayMs: number
-}
-
-type SetupResult = RenderResult & {
-  element: HTMLElement
-}
-
-const setup = ({ delayMs }: SetupProps): SetupResult => {
-  const utils = render(
-    <DelayShow delayMs={delayMs}>
-      <div>Hello, I am some delayed content</div>
-    </DelayShow>
-  )
-  return {
-    element: utils.getByTestId('delay-show'),
-    ...utils
-  }
-}
+import { render } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
 
 describe('DelayShow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   test('Should render', async () => {
-    const { element } = setup({ delayMs: 500 })
+    const { getByTestId } = render(
+      <DelayShow delayMs={500}>
+        <div data-test-id='delay-show'>Hello, I am some delayed content</div>
+      </DelayShow>
+    )
+
+    const element = getByTestId('delay-show')
+
     expect(element).toBeInTheDocument()
     expect(element.style).to.have.property('opacity', '0')
-    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    await act(() => vi.advanceTimersByTime(499))
     expect(element.style).to.have.property('opacity', '0')
-    await new Promise((resolve) => setTimeout(resolve, 410))
+
+    await act(() => vi.advanceTimersByTime(1))
     expect(element.style).to.have.property('opacity', '1')
   })
 })

--- a/packages/app-elements/src/ui/atoms/DelayShow.tsx
+++ b/packages/app-elements/src/ui/atoms/DelayShow.tsx
@@ -1,4 +1,12 @@
-import { ReactNode, useState, useRef, useEffect } from 'react'
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState
+} from 'react'
 
 interface Props {
   delayMs: number
@@ -22,14 +30,20 @@ function DelayShow({ delayMs = 1000, children }: Props): JSX.Element | null {
   }, [delayMs])
 
   return (
-    <div
-      data-test-id='delay-show'
-      style={{
-        opacity: show ? 1 : 0
-      }}
-    >
-      {children}
-    </div>
+    <>
+      {Children.map(children, (child) => {
+        if (!isValidElement<any>(child)) {
+          return child
+        }
+
+        return cloneElement(child, {
+          style: {
+            ...(child.props.style ?? {}),
+            opacity: show ? 1 : 0
+          }
+        })
+      })}
+    </>
   )
 }
 

--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
@@ -31,19 +31,19 @@ describe('SkeletonTemplate', () => {
       </SkeletonTemplate>
     )
 
-    expect(getByText('Element #1')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByText('Element #1')).toHaveClass('animate-pulse', '!bg-gray-50')
     expect(getByText('Element #1').nodeName).toEqual('SPAN')
 
-    expect(getByText('Element #2')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByText('Element #2')).toHaveClass('animate-pulse', '!bg-gray-50')
     expect(getByText('Element #2').nodeName).toEqual('SPAN')
 
-    expect(getByText('Element #3')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByText('Element #3')).toHaveClass('animate-pulse', '!bg-gray-50')
     expect(getByText('Element #3').nodeName).toEqual('SPAN')
 
-    expect(getByText('Element #4')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByText('Element #4')).toHaveClass('animate-pulse', '!bg-gray-50')
     expect(getByText('Element #4').nodeName).toEqual('SPAN')
 
-    expect(getByTestId('button')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByTestId('button')).toHaveClass('animate-pulse', '!bg-gray-50')
   })
 
   test('Should render <Avatar> as "loading item"', () => {
@@ -57,7 +57,7 @@ describe('SkeletonTemplate', () => {
       </SkeletonTemplate>
     )
 
-    expect(getByTestId('element')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByTestId('element')).toHaveClass('animate-pulse', '!bg-gray-50')
   })
 
   test('Should render <Badge> as "loading item"', () => {
@@ -67,7 +67,7 @@ describe('SkeletonTemplate', () => {
       </SkeletonTemplate>
     )
 
-    expect(getByTestId('element')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByTestId('element')).toHaveClass('animate-pulse', '!bg-gray-50')
   })
 
   test('Should render <Icon> as "loading item"', () => {
@@ -77,7 +77,7 @@ describe('SkeletonTemplate', () => {
       </SkeletonTemplate>
     )
 
-    expect(getByTestId('element')).toHaveClass('animate-pulse', 'bg-gray-50')
+    expect(getByTestId('element')).toHaveClass('animate-pulse', '!bg-gray-50')
   })
 
   test('Should render RadialProgress as "loading item"', () => {
@@ -89,7 +89,7 @@ describe('SkeletonTemplate', () => {
 
     expect(getByTestId('radial-progress')).toHaveClass(
       'animate-pulse',
-      'bg-gray-50'
+      '!bg-gray-50'
     )
   })
 
@@ -102,7 +102,7 @@ describe('SkeletonTemplate', () => {
 
     expect(getByTestId('radial-progress')).toHaveClass(
       'animate-pulse',
-      'bg-gray-50'
+      '!bg-gray-50'
     )
   })
 })

--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
@@ -63,7 +63,7 @@ const SkeletonTemplate: FC<SkeletonTemplateProps> = ({
   delayMs = 500
 }) => {
   const skeletonClass =
-    'select-none !border-gray-50 pointer-events-none animate-pulse bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds'
+    'select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds'
 
   if (!isLoading) {
     return <>{children}</>
@@ -71,54 +71,52 @@ const SkeletonTemplate: FC<SkeletonTemplateProps> = ({
 
   return (
     <DelayShow delayMs={delayMs}>
-      <div data-test-id='skeleton-template'>
-        {recursiveMap(children, (child) => {
-          if (child == null) {
-            return child
-          }
+      {recursiveMap(children, (child) => {
+        if (child == null) {
+          return child
+        }
 
-          if (!isValidElement<any>(child)) {
-            return <span className={skeletonClass}>{child}</span>
-          }
+        if (!isValidElement<any>(child)) {
+          return <span className={skeletonClass}>{child}</span>
+        }
 
-          const props = Object.fromEntries(
-            Object.entries(child.props).map(([key, value]) => {
-              if (isValidElement(value)) {
-                const newValue = (
-                  <SkeletonTemplate delayMs={delayMs} isLoading={isLoading}>
-                    {value}
-                  </SkeletonTemplate>
-                )
+        const props = Object.fromEntries(
+          Object.entries(child.props).map(([key, value]) => {
+            if (isValidElement(value)) {
+              const newValue = (
+                <SkeletonTemplate delayMs={delayMs} isLoading={isLoading}>
+                  {value}
+                </SkeletonTemplate>
+              )
 
-                return [key, newValue]
-              }
+              return [key, newValue]
+            }
 
-              return [key, value]
-            })
-          )
+            return [key, value]
+          })
+        )
 
-          if (
-            isSpecificReactComponent(child, [
-              'Avatar',
-              'Badge',
-              'Button',
-              'Icon',
-              'RadialProgress'
-            ])
-          ) {
-            return cloneElement(child, {
-              ...props,
-              className: cn(props.className as string, skeletonClass),
-              isLoading: true
-            })
-          }
-
+        if (
+          isSpecificReactComponent(child, [
+            'Avatar',
+            'Badge',
+            'Button',
+            'Icon',
+            'RadialProgress'
+          ])
+        ) {
           return cloneElement(child, {
             ...props,
+            className: cn(props.className as string, skeletonClass),
             isLoading: true
           })
-        })}
-      </div>
+        }
+
+        return cloneElement(child, {
+          ...props,
+          isLoading: true
+        })
+      })}
     </DelayShow>
   )
 }

--- a/packages/app-elements/src/ui/composite/Report.test.tsx
+++ b/packages/app-elements/src/ui/composite/Report.test.tsx
@@ -25,7 +25,7 @@ describe('Report', () => {
   })
 
   afterEach(() => {
-    vi.useFakeTimers()
+    vi.useRealTimers()
   })
 
   test('Should render', () => {
@@ -68,7 +68,7 @@ describe('Report', () => {
   })
 
   test('Should display `isLoading` state with the specified number of `loadingLines`', async () => {
-    const { element, getAllByTestId } = setup({
+    const { element } = setup({
       id: 'my-report',
       isLoading: true,
       loadingLines: 4,
@@ -79,7 +79,6 @@ describe('Report', () => {
       vi.advanceTimersByTime(500)
     })
     expect(element).toBeVisible()
-    expect(getAllByTestId('skeleton-template').length).toBe(1)
     expect(
       element.querySelector(
         "[data-test-id='report-item-Record imported-count'] span"

--- a/packages/app-elements/src/ui/resources/OrderSummary.tsx
+++ b/packages/app-elements/src/ui/resources/OrderSummary.tsx
@@ -1,27 +1,24 @@
 import { Avatar } from '#ui/atoms/Avatar'
+import { withinSkeleton } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
 import type { Order } from '@commercelayer/sdk'
 import cn from 'classnames'
-import { FC, Fragment } from 'react'
+import { Fragment } from 'react'
 
-interface Props {
-  order: Order
-}
-
-const TotalRow: FC<{
+const TotalRow = withinSkeleton<{
   /** Displayed label */
   label: string
   /** Formatted amount */
   formattedAmount?: string
-  /** Whether the row is the last one (usually used to display the "**Total**") */
+  /** Whether the row is the last one (usually used to display the "**Total** ") */
   isLastRow?: boolean
 
   /**
-   * When `true` the row will be always printed.
+   * When `true` the row will be always  printed.
    * @default false
    */
   force?: boolean
-}> = ({ label, formattedAmount = '', force = false, isLastRow = false }) => {
+}>(({ label, formattedAmount = '', force = false, isLastRow = false }) => {
   const amountCents = parseInt(formattedAmount.replace(/[^0-9\-.,]+/g, ''))
   const showRow = force || amountCents < 0 || amountCents > 0
 
@@ -48,9 +45,11 @@ const TotalRow: FC<{
       </td>
     </tr>
   ) : null
-}
+})
 
-const OrderSummary: FC<Props> = ({ order }) => {
+const OrderSummary = withinSkeleton<{
+  order: Order
+}>(({ order }) => {
   return (
     <table className='w-full'>
       <tbody>
@@ -148,7 +147,7 @@ const OrderSummary: FC<Props> = ({ order }) => {
       </tbody>
     </table>
   )
-}
+})
 
 OrderSummary.displayName = 'OrderSummary'
 export { OrderSummary }

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -64,10 +64,16 @@ const Template: ComponentStory<typeof SkeletonTemplate> = ({
   children,
   ...args
 }) => (
-  <div className='flex gap-2'>
-    {children}
-    <SkeletonTemplate {...args}>{children}</SkeletonTemplate>
-  </div>
+  <>
+    <div className='flex gap-2'>
+      Hi there!
+      <SkeletonTemplate {...args}>Hi there!</SkeletonTemplate>
+    </div>
+    <div className='flex gap-2'>
+      {children}
+      <SkeletonTemplate {...args}>{children}</SkeletonTemplate>
+    </div>
+  </>
 )
 
 export const Default = Template.bind({})

--- a/packages/docs/src/stories/resources/OrderSummary.stories.tsx
+++ b/packages/docs/src/stories/resources/OrderSummary.stories.tsx
@@ -16,6 +16,7 @@ const Template: ComponentStory<typeof OrderSummary> = (args) => {
 
 export const Default = Template.bind({})
 Default.args = {
+  isLoading: false,
   order: {
     type: 'orders',
     id: '',


### PR DESCRIPTION
This is the loading status for the `<OrderSummary />`.

Wrapper components like `SkeletonTemplate` and `DelayShow` now are no more adding HTML elements.

<img width="575" alt="Order Summary in loading status" src="https://user-images.githubusercontent.com/1681269/226286879-0e49ef1b-0404-440b-acf3-bc704a75e865.png">
