### PR TITLE
Add `tag` prop to render `ListItem` as `<div>` or `<a>`

### DIFF
--- a/packages/app-elements/src/ui/lists/ListItem.test.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.test.tsx
@@ -1,3 +1,4 @@
+import { act } from 'react-dom/test-utils'
 import { ListItem, ListItemProps } from './ListItem'
 import { render, RenderResult } from '@testing-library/react'
 
@@ -15,11 +16,29 @@ const setup = (props: ListItemProps): SetupResult => {
 }
 
 describe('ListItem', () => {
-  test('Should be rendered', () => {
+  test('Should be rendered as div', async () => {
+    const onClick = vi.fn()
     const { element } = setup({
-      onClick: () => undefined,
+      tag: 'div',
+      onClick,
       children: <div>Content</div>
     })
     expect(element).toBeInTheDocument()
+    expect(element.tagName).toBe('DIV')
+    await act(() => {
+      element.click()
+    })
+    expect(onClick).toBeCalledTimes(1)
+  })
+
+  test('Should be rendered as anchor', () => {
+    const { element } = setup({
+      tag: 'a',
+      href: 'https://www.commercelayer.io',
+      children: <div>Content</div>
+    })
+    expect(element).toBeInTheDocument()
+    expect(element.tagName).toBe('A')
+    expect(element.getAttribute('href')).toBe('https://www.commercelayer.io')
   })
 })

--- a/packages/app-elements/src/ui/lists/ListItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.tsx
@@ -1,9 +1,8 @@
 import cn from 'classnames'
 import { FlexRow, FlexRowProps } from '#ui/atoms/FlexRow'
+import { FC, useMemo } from 'react'
 
-export interface ListItemProps
-  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>,
-    Pick<FlexRowProps, 'alignItems' | 'children'> {
+type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
   /**
    * Icon component
    * Example: `<Icon>` or `<RadialProgress>` or `<Avatar>`
@@ -19,37 +18,67 @@ export interface ListItemProps
   borderStyle?: 'dashed' | 'solid'
 }
 
-function ListItem({
+export type ListItemProps = Props &
+  (
+    | ({
+        /**
+         * HTML tag to render
+         */
+        tag: 'div'
+      } & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>)
+    | ({
+        /**
+         * HTML tag to render
+         */
+        tag: 'a'
+      } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'>)
+  )
+
+const ListItem: FC<ListItemProps> = ({
   icon,
   children,
   className,
-  onClick,
   gutter,
   alignItems = 'center',
   borderStyle = 'solid',
+  tag = 'div',
   ...rest
-}: ListItemProps): JSX.Element {
+}) => {
+  const JsxTag = useMemo(
+    // enforce allowed tags only
+    () => enforceAllowedTags(tag),
+    [tag]
+  )
+  const hasHover = rest.onClick != null || tag === 'a'
+
   return (
-    <div
-      {...rest}
-      onClick={onClick}
+    <JsxTag
       className={cn(
         'flex gap-4 py-4 border-b border-gray-100',
         {
           'px-4': gutter !== 'none',
           'border-dashed': borderStyle === 'dashed',
-          'cursor-pointer hover:bg-gray-50': onClick != null
+          'cursor-pointer hover:bg-gray-50': hasHover
         },
         className
       )}
+      {...(rest as any)}
     >
       <div className='flex gap-4 flex-1'>
         {icon != null && <div className='flex-shrink-0'>{icon}</div>}
         <FlexRow alignItems={alignItems}>{children}</FlexRow>
       </div>
-    </div>
+    </JsxTag>
   )
 }
 
 ListItem.displayName = 'ListItem'
 export { ListItem }
+
+const allowedTags = ['a', 'div'] as const
+type AllowedTag = typeof allowedTags[number]
+function enforceAllowedTags(
+  tag: AllowedTag
+): Extract<keyof JSX.IntrinsicElements, AllowedTag> {
+  return allowedTags.includes(tag) ? tag : 'div'
+}

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -52,6 +52,7 @@ const children = (
     </ForwardRefComponent>
     <WithSkeletonComponentB>C</WithSkeletonComponentB>
     <ListItem
+      tag='div'
       borderStyle='dashed'
       onClick={() => alert('Hello world!')}
       icon={
@@ -66,7 +67,7 @@ const children = (
       <Icon name='check' background='green' gap='large' />
       <RadialProgress percentage={42} />
     </ListItem>
-    <ListItem borderStyle='dashed'>
+    <ListItem tag='div' borderStyle='dashed'>
       <div>
         <Text tag='div'>Ehi there!</Text>
         <Badge label='APPROVED' variant='primary' />

--- a/packages/docs/src/stories/examples/ListResources.stories.tsx
+++ b/packages/docs/src/stories/examples/ListResources.stories.tsx
@@ -45,7 +45,7 @@ const Template: ComponentStory<typeof List> = (args) => (
           'Tax rules',
           'Wire transfers'
         ].map((resource) => (
-          <ListItem key={resource} onClick={() => {}}>
+          <ListItem tag='a' key={resource} href='#' target='_blank'>
             <Text weight='semibold'>{resource}</Text>
             <Icon name='caretRight' />
           </ListItem>

--- a/packages/docs/src/stories/examples/ListSkus.stories.tsx
+++ b/packages/docs/src/stories/examples/ListSkus.stories.tsx
@@ -33,7 +33,7 @@ const Template: ComponentStory<typeof List> = (args) => (
         }}
       >
         {[...Array(10).keys()].map((_, idx) => (
-          <ListItem key={idx} onClick={() => {}}>
+          <ListItem tag='div' key={idx} onClick={() => {}}>
             <div>
               <Text weight='semibold' tag='div'>
                 WGDMSMNOwJ

--- a/packages/docs/src/stories/examples/ListTasks.stories.tsx
+++ b/packages/docs/src/stories/examples/ListTasks.stories.tsx
@@ -41,7 +41,7 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => {
             pageCount: 5
           }}
         >
-          <ListItem icon={<RadialProgress percentage={45} />}>
+          <ListItem tag='div' icon={<RadialProgress percentage={45} />}>
             <div>
               <Text tag='div' weight='semibold'>
                 Prices
@@ -53,7 +53,7 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => {
             <Button variant='danger'>Cancel</Button>
           </ListItem>
 
-          <ListItem icon={<RadialProgress />}>
+          <ListItem tag='div' icon={<RadialProgress />}>
             <div>
               <Text tag='div' weight='semibold'>
                 Orders
@@ -65,7 +65,10 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => {
             <Icon name='caretRight' />
           </ListItem>
 
-          <ListItem icon={<Icon gap='large' name='check' background='green' />}>
+          <ListItem
+            tag='div'
+            icon={<Icon gap='large' name='check' background='green' />}
+          >
             <div>
               <Text tag='div' weight='semibold'>
                 SKUs
@@ -77,7 +80,10 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => {
             <Icon name='caretRight' />
           </ListItem>
 
-          <ListItem icon={<Icon gap='large' name='x' background='red' />}>
+          <ListItem
+            tag='div'
+            icon={<Icon gap='large' name='x' background='red' />}
+          >
             <div>
               <Text tag='div' weight='semibold'>
                 SKUs

--- a/packages/docs/src/stories/examples/OrderHistory.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderHistory.stories.tsx
@@ -17,6 +17,7 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => (
   <Spacer bottom='14'>
     <List title='Results · 13,765'>
       <ListItem
+        tag='div'
         icon={<Icon name='arrowDown' background='orange' gap='large' />}
       >
         <div>
@@ -40,7 +41,10 @@ export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => (
         </div>
       </ListItem>
 
-      <ListItem icon={<Icon name='x' background='gray' gap='large' />}>
+      <ListItem
+        tag='div'
+        icon={<Icon name='x' background='gray' gap='large' />}
+      >
         <div>
           <Text tag='div' weight='semibold'>
             US online #19346523

--- a/packages/docs/src/stories/lists/ListDetails.stories.tsx
+++ b/packages/docs/src/stories/lists/ListDetails.stories.tsx
@@ -45,6 +45,7 @@ export const WithListItem: ComponentStory<typeof ListDetails> = (args) => (
   <ListDetails {...args}>
     {Array(3).fill(
       <ListItem
+        tag='div'
         gutter='none'
         borderStyle='dashed'
         icon={

--- a/packages/docs/src/stories/lists/ListItem.stories.tsx
+++ b/packages/docs/src/stories/lists/ListItem.stories.tsx
@@ -26,7 +26,7 @@ Simple.args = {
   }
 }
 
-export const WithIcon: ComponentStory<typeof ListItem> = (args) => (
+const WithIconTemplate: ComponentStory<typeof ListItem> = (args) => (
   <ListItem {...args}>
     <div>
       <Text tag='div' weight='semibold'>
@@ -49,8 +49,18 @@ export const WithIcon: ComponentStory<typeof ListItem> = (args) => (
     </div>
   </ListItem>
 )
+
+export const WithIcon = WithIconTemplate.bind({})
 WithIcon.args = {
-  onClick: () => undefined,
+  tag: 'div',
+  icon: <Icon name='arrowDown' background='orange' gap='large' />
+}
+
+export const AsAnchor = WithIconTemplate.bind({})
+AsAnchor.args = {
+  tag: 'a',
+  href: 'https://www.commercelayer.io',
+  target: '_blank',
   icon: <Icon name='arrowDown' background='orange' gap='large' />
 }
 


### PR DESCRIPTION
### What does this PR do?
`<ListItem>` now requires a `tag` prop to be defined as `div` or `a`.
Is not possible to define a default type in the interface since we need to use it as a discriminated union. But when a wrong `tag` is passed (eg: in a non-typescript project) we enforce the `div` usage.

### Examples:

Good
<img width="383" alt="image" src="https://user-images.githubusercontent.com/30926550/227192687-0de0bb40-9f97-46fc-b685-a93049ab0dda.png">

Wrong
<img width="362" alt="image" src="https://user-images.githubusercontent.com/30926550/227192815-c9c586d6-1a6e-4415-a8ec-06cbf857ce5e.png">

Good
<img width="396" alt="image" src="https://user-images.githubusercontent.com/30926550/227192917-db755336-562f-4b7e-9035-2020e3f2fa4e.png">

Good
<img width="458" alt="image" src="https://user-images.githubusercontent.com/30926550/227193288-27aacf68-749c-4bda-89a6-18f450a15eb4.png">

