### PR TITLE
Add `arrow-circle-down` phosphor icon

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon.tsx
@@ -73,6 +73,7 @@ const iconMapping = {
   arrowClockwise: phosphor.ArrowClockwise,
   arrowDown: phosphor.ArrowDown,
   arrowLeft: phosphor.ArrowLeft,
+  arrowCircleDown: phosphor.ArrowCircleDown,
   caretRight: phosphor.CaretRight,
   check: phosphor.Check,
   cloud: phosphor.CloudArrowUp,


### PR DESCRIPTION
### What does this PR do?
Add `arrow-circle-down` phosphor icon mapping in `Icon` component