### PR TITLE
Remove `weight` and `size` props in `<Icon>` to handle them internally

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon.tsx
@@ -16,15 +16,6 @@ export interface IconProps extends React.HTMLAttributes<HTMLDivElement> {
    */
   gap?: 'none' | 'small' | 'large'
   /**
-   * Icon size as css unit (eg: 32px, 4rem) or number as pixels value.
-   */
-  size?: string | number
-  /**
-   * Icon weight.
-   * @default bold
-   */
-  weight?: phosphor.IconWeight
-  /**
    * CSS classes
    */
   className?: string
@@ -35,8 +26,6 @@ function Icon({
   className,
   background = 'none',
   gap = 'none',
-  size,
-  weight = 'bold',
   ...rest
 }: IconProps): JSX.Element {
   const IconSvg = useMemo(() => iconMapping[name], [iconMapping, name])
@@ -61,7 +50,10 @@ function Icon({
       ])}
       {...rest}
     >
-      <IconSvg size={getIconSize({ size, gap })} weight={weight} />
+      <IconSvg
+        size={gap === 'large' ? '1.25rem' : undefined}
+        weight={background !== 'none' ? 'bold' : undefined}
+      />
     </div>
   )
 }
@@ -70,10 +62,10 @@ Icon.displayName = 'Icon'
 export { Icon }
 
 const iconMapping = {
+  arrowCircleDown: phosphor.ArrowCircleDown,
   arrowClockwise: phosphor.ArrowClockwise,
   arrowDown: phosphor.ArrowDown,
   arrowLeft: phosphor.ArrowLeft,
-  arrowCircleDown: phosphor.ArrowCircleDown,
   caretRight: phosphor.CaretRight,
   check: phosphor.Check,
   cloud: phosphor.CloudArrowUp,
@@ -86,15 +78,4 @@ const iconMapping = {
   user: phosphor.User,
   warning: phosphor.Warning,
   x: phosphor.X
-}
-
-function getIconSize({
-  size,
-  gap
-}: Pick<IconProps, 'size' | 'gap'>): string | number | undefined {
-  if (size != null) {
-    return size
-  }
-
-  return gap === 'large' ? '1.25rem' : undefined
 }

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -1,6 +1,6 @@
 import cn from 'classnames'
 import { ReactNode } from 'react'
-import { Icon } from './Icon'
+import { ArrowLeft } from 'phosphor-react'
 import { Badge, BadgeVariant } from './Badge'
 
 export interface PageHeadingProps {
@@ -59,7 +59,7 @@ function PageHeading({
         >
           {onGoBack != null ? (
             <button onClick={onGoBack}>
-              <Icon name='arrowLeft' size={32} />
+              <ArrowLeft className='text-2.5xl' />
             </button>
           ) : null}
           {actionButton != null ? <div>{actionButton}</div> : null}

--- a/packages/app-elements/src/ui/composite/ContextMenu.tsx
+++ b/packages/app-elements/src/ui/composite/ContextMenu.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 function ContextMenu({
-  menuLabel = <DotsThreeCircle className='w-6 h-6' />,
+  menuLabel = <DotsThreeCircle className='text-2.5xl' />,
   menuItems,
   ...rest
 }: Props): JSX.Element {


### PR DESCRIPTION
### What does this PR do?
`<Icon>` does not expose anymore `weight` and `size` props.
Those rules are now handled internally, so we can better control design consistency