### PR TITLE
Fix `DropdownMenu` arrow position

### DIFF
--- a/packages/app-elements/src/ui/atoms/dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/atoms/dropdown/DropdownMenu.tsx
@@ -9,11 +9,24 @@ function DropdownMenu({ children, arrow, ...rest }: Props): JSX.Element {
   const showArrow = arrow === undefined
   const showArrowMenuCss = showArrow && 'mt-[5px]'
 
+  // const arrowHeight = 5
+  // const arrowWidth = 12
+
+  const menuLabelSizeCss: Record<number, string[]> = {
+    32: [
+      'w-0 h-0',
+      `absolute top-[-5px] right-[10px]`, // arrowHeight / 2 & (menuLabelSize - arrowWidth) / 2
+      `border-b-[5px] border-b-black`, // arrowHeight / 2
+      `border-l-[6px] border-l-transparent`, // arrowWidth / 2
+      `border-r-[6px] border-r-transparent` // arrowWidth / 2
+    ]
+  }
+
+  const arrowCss = cn(menuLabelSizeCss[32])
+
   return (
     <div className='relative'>
-      {showArrow && (
-        <span className='w-0 h-0 border-l-[6px] border-l-transparent border-b-[5px] border-b-black border-r-[6px] border-r-transparent absolute top-[-5px] right-[8px]' />
-      )}
+      {showArrow && <span className={arrowCss} />}
       <div
         {...rest}
         className={cn([

--- a/packages/app-elements/src/ui/composite/ContextMenu.tsx
+++ b/packages/app-elements/src/ui/composite/ContextMenu.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 
 function ContextMenu({
-  menuLabel = <DotsThreeCircle className='text-2.5xl' />,
+  menuLabel = <DotsThreeCircle size={32} />,
   menuItems,
   ...rest
 }: Props): JSX.Element {
@@ -36,7 +36,7 @@ function ContextMenu({
   return (
     <div {...rest} ref={showDropdownMenu ? clickAwayRef : undefined}>
       <button
-        className='cursor-pointer select-none m-0 p-0 mr-[2px] block'
+        className='cursor-pointer select-none m-0 p-0 block'
         onClick={() => {
           toggleDropdownMenu()
         }}


### PR DESCRIPTION
### What does this PR do?
Fix `DropDownMenu` arrow position due to the new size (32px) set for `ContextMenu` icon.