### PR TITLE
Replace `noGap` in `PageHeading` with `gap` 

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.test.tsx
@@ -62,3 +62,32 @@ describe('PageHeading', () => {
     expect(foo.includes('bar')).toBe(true)
   })
 })
+
+describe('PageHeading gap', () => {
+  test('Should have gap top and bottom', () => {
+    const { element } = setup({
+      id: 'heading',
+      title: 'My Page Heading'
+    })
+    expect(element).toHaveClass('pt-10 pb-14')
+  })
+
+  test('Should have gap only on top', () => {
+    const { element } = setup({
+      id: 'heading',
+      title: 'My Page Heading',
+      gap: 'only-top'
+    })
+    expect(element).toHaveClass('pt-10')
+    expect(element).not.toHaveClass('pb-14')
+  })
+
+  test('Should have no vertical gap', () => {
+    const { element } = setup({
+      id: 'heading',
+      title: 'My Page Heading',
+      gap: 'none'
+    })
+    expect(element.classList.toString()).toBe('w-full')
+  })
+})

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -20,7 +20,7 @@ export interface PageHeadingProps {
   /**
    * If `true` removes element vertical paddings
    */
-  noGap?: boolean
+  gap?: 'none' | 'only-top' | 'only-bottom' | 'both'
   /**
    * When set, it will render a badge (warning variant)
    */
@@ -36,7 +36,7 @@ export interface PageHeadingProps {
 }
 
 function PageHeading({
-  noGap = false,
+  gap = 'both',
   badgeLabel,
   onGoBack,
   title,
@@ -46,7 +46,17 @@ function PageHeading({
   ...rest
 }: PageHeadingProps): JSX.Element {
   return (
-    <div className={cn(['w-full', { 'pt-10 pb-14': !noGap }])} {...rest}>
+    <div
+      className={cn([
+        'w-full',
+        {
+          'pt-10 pb-14': gap === 'both',
+          'pt-10': gap === 'only-top',
+          'pb-14': gap === 'only-bottom'
+        }
+      ])}
+      {...rest}
+    >
       {(onGoBack != null || actionButton != null) && (
         <div
           className={cn(

--- a/packages/app-elements/src/ui/composite/PageLayout.tsx
+++ b/packages/app-elements/src/ui/composite/PageLayout.tsx
@@ -3,7 +3,10 @@ import { Container } from '#ui/atoms/Container'
 import { PageHeading, PageHeadingProps } from '#ui/atoms/PageHeading'
 
 export interface PageLayoutProps
-  extends Omit<PageHeadingProps, 'badgeVariant' | 'badgeLabel'> {
+  extends Pick<
+    PageHeadingProps,
+    'title' | 'description' | 'onGoBack' | 'actionButton' | 'gap'
+  > {
   /**
    * Page content
    */
@@ -21,6 +24,7 @@ function PageLayout({
   children,
   actionButton,
   mode,
+  gap,
   ...rest
 }: PageLayoutProps): JSX.Element {
   return (
@@ -32,6 +36,7 @@ function PageLayout({
         actionButton={actionButton}
         badgeLabel={mode === 'test' ? 'TEST DATA' : undefined}
         badgeVariant={mode === 'test' ? 'warning-solid' : undefined}
+        gap={gap}
       />
       {children}
     </Container>


### PR DESCRIPTION
Replace `noGap` in `<PageHeading>` with `gap`  to control top and bottom spacing.
The default gap is `both` to keep back compatibility.

This PR also exposes `gap` to `<PageLayout>`