### PR TITLE
Add `InputCheckbox` component

### DIFF
--- a/packages/app-elements-hook-form/src/components/Form.test.tsx
+++ b/packages/app-elements-hook-form/src/components/Form.test.tsx
@@ -5,6 +5,7 @@ import { Input } from './Input'
 import { InputToggleBox } from './InputToggleBox'
 import { InputDate } from './InputDate'
 import { InputDateRange } from './InputDateRange'
+import { InputCheckbox } from './InputCheckbox'
 import { InputSelect } from './InputSelect'
 
 type SetupResult = RenderResult & {
@@ -21,6 +22,9 @@ function FullFormScreen({ id }: { id: string }): JSX.Element {
         <InputDateRange name='dateRange' label='Date range' />
         <InputSelect name='select' label='Choose one city' initialValues={[]} />
         <InputToggleBox name='toggle' label='Toggle me' id='toggle' />
+        <InputCheckbox name='checkbox' icon={<div />}>
+          check me
+        </InputCheckbox>
       </Form>
     </div>
   )

--- a/packages/app-elements-hook-form/src/components/InputCheckbox.tsx
+++ b/packages/app-elements-hook-form/src/components/InputCheckbox.tsx
@@ -1,0 +1,19 @@
+import { InputCheckbox as InputCheckboxUI } from '@commercelayer/app-elements'
+import { InputCheckboxProps } from '@commercelayer/app-elements/dist/ui/forms/InputCheckbox'
+import { useFormContext } from 'react-hook-form'
+
+interface Props extends InputCheckboxProps {
+  /**
+   * field name to match hook-form state
+   */
+  name: string
+}
+
+function InputCheckbox({ name, ...props }: Props): JSX.Element {
+  const { register } = useFormContext()
+
+  return <InputCheckboxUI {...props} {...register(name)} />
+}
+
+InputCheckbox.displayName = 'InputCheckbox'
+export { InputCheckbox }

--- a/packages/app-elements-hook-form/src/main.ts
+++ b/packages/app-elements-hook-form/src/main.ts
@@ -2,6 +2,7 @@ export { Form } from '#components/Form'
 export { ValidationError } from '#components/ValidationError'
 
 export { Input } from '#components/Input'
+export { InputCheckbox } from '#components/InputCheckbox'
 export { InputDate } from '#components/InputDate'
 export { InputDateRange } from '#components/InputDateRange'
 export { InputSelect } from '#components/InputSelect'

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -54,6 +54,7 @@ export { Report } from '#ui/composite/Report'
 
 // Forms
 export { Input } from '#ui/forms/Input'
+export { InputCheckbox } from '#ui/forms/InputCheckbox'
 export { InputDate } from '#ui/forms/InputDate'
 export { InputDateRange } from '#ui/forms/InputDateRange'
 export { InputFeedback } from '#ui/forms/InputFeedback'

--- a/packages/app-elements/src/ui/atoms/Avatar.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.tsx
@@ -18,6 +18,12 @@ export interface AvatarProps extends React.HTMLAttributes<HTMLImageElement> {
    * @default "rounded"
    */
   shape?: 'rounded' | 'circle'
+  /**
+   * Image size
+   * (small: 48px, normal: 58px)
+   * @default "normal"
+   */
+  size?: 'small' | 'normal'
 }
 
 function Avatar({
@@ -25,6 +31,7 @@ function Avatar({
   alt,
   border,
   shape = 'rounded',
+  size = 'normal',
   className,
   ...rest
 }: AvatarProps): JSX.Element {
@@ -34,8 +41,11 @@ function Avatar({
       src={src}
       alt={alt}
       className={cn(
-        'border object-contain object-center min-w-[58px] min-h-[58px] w-[58px] h-[58px]',
+        'border object-contain object-center',
         {
+          // size
+          'min-w-[58px] min-h-[58px] w-[58px] h-[58px]': size === 'normal',
+          'min-w-[42px] min-h-[42px] w-[42px] h-[42px]': size === 'small',
           // shape
           rounded: shape === 'rounded',
           'rounded-full': shape === 'circle',

--- a/packages/app-elements/src/ui/forms/InputCheckbox.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox.test.tsx
@@ -1,0 +1,65 @@
+import { InputCheckbox } from './InputCheckbox'
+import { render, RenderResult, fireEvent } from '@testing-library/react'
+import { useState } from 'react'
+
+interface SetupProps {
+  checked?: boolean
+}
+
+type SetupResult = RenderResult & {
+  wrapper: HTMLElement
+  label: HTMLLabelElement
+  input: HTMLInputElement
+}
+
+const Component = ({ checked }: SetupProps): JSX.Element => {
+  const [state, setState] = useState(checked)
+  return (
+    <InputCheckbox checked={state} onChange={(e) => setState(e.target.checked)}>
+      Check me
+    </InputCheckbox>
+  )
+}
+
+const setup = ({ checked }: SetupProps): SetupResult => {
+  const utils = render(<Component checked={checked} />)
+  const wrapper = utils.getByTestId('checkbox-wrapper')
+  const input = utils.getByTestId('checkbox-input') as HTMLInputElement
+  const label = utils.getByTestId('checkbox-label') as HTMLLabelElement
+  return {
+    wrapper,
+    input,
+    label,
+    ...utils
+  }
+}
+
+describe('InputCheckbox', () => {
+  test('Should be rendered', () => {
+    const { wrapper, input } = setup({})
+    expect(wrapper).toBeInTheDocument()
+    expect(input).toBeInTheDocument()
+  })
+
+  test('Should update checked value', () => {
+    const { input } = setup({})
+    expect(input.checked).toBe(false)
+    fireEvent.click(input)
+    expect(input.checked).toBe(true)
+  })
+
+  test('Should accept initial checked value', () => {
+    const { input } = setup({ checked: true })
+    expect(input.checked).toBe(true)
+    fireEvent.click(input)
+    expect(input.checked).toBe(false)
+  })
+
+  test('Should be controlled on label', () => {
+    const { label, input } = setup({})
+    fireEvent.click(label)
+    expect(input.checked).toBe(true)
+    fireEvent.click(label)
+    expect(input.checked).toBe(false)
+  })
+})

--- a/packages/app-elements/src/ui/forms/InputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox.tsx
@@ -1,0 +1,59 @@
+import { InputWrapperBaseProps, getFeedbackStyle } from '#ui/forms/InputWrapper'
+import cn from 'classnames'
+import { ReactNode, forwardRef } from 'react'
+import { InputWrapper } from './InputWrapper'
+
+export interface InputCheckboxProps
+  extends Omit<InputWrapperBaseProps, 'label'>,
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type' | 'value'> {
+  /**
+   * Icon component
+   * Example: `<Avatar>`
+   */
+  icon?: JSX.Element
+  children: ReactNode
+}
+
+const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
+  (
+    { className, hint, feedback, icon, children, ...rest },
+    ref
+  ): JSX.Element => {
+    return (
+      <InputWrapper
+        hint={hint}
+        feedback={feedback}
+        data-test-id='checkbox-wrapper'
+      >
+        <div className={cn('flex items-center w-full', className)}>
+          <label
+            data-test-id='checkbox-label'
+            className={cn('flex items-center gap-4 select-none', className, {
+              'cursor-pointer': rest.disabled !== true
+            })}
+          >
+            <input
+              type='checkbox'
+              data-test-id='checkbox-input'
+              className={cn(
+                'border border-gray-300 rounded w-[18px] h-[18px] text-primary focus:ring-primary',
+                { 'cursor-pointer': rest.disabled !== true },
+                getFeedbackStyle(feedback)
+              )}
+              {...rest}
+              ref={ref}
+            />
+
+            <div className='flex items-center gap-4 flex-1'>
+              {icon != null ? icon : null}
+              {children}
+            </div>
+          </label>
+        </div>
+      </InputWrapper>
+    )
+  }
+)
+
+InputCheckbox.displayName = 'InputCheckbox'
+export { InputCheckbox }

--- a/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
+++ b/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
@@ -1,0 +1,98 @@
+import { Avatar } from '#ui/atoms/Avatar'
+import { Card } from '#ui/atoms/Card'
+import { Spacer } from '#ui/atoms/Spacer'
+import { Text } from '#ui/atoms/Text'
+import { PageLayout } from '#ui/composite/PageLayout'
+import { InputCheckbox } from '#ui/forms/InputCheckbox'
+import { ComponentStory, Meta } from '@storybook/react'
+import { useState } from 'react'
+
+const setup: Meta = {
+  title: 'Examples/Filters Checkboxes',
+  parameters: {
+    layout: 'fullscreen'
+  }
+}
+export default setup
+
+const options = [
+  {
+    id: 'rlEPzheRgO',
+    name: 'NY Store'
+  },
+  {
+    id: 'dlQbPhNNop',
+    name: 'Europe'
+  },
+  {
+    id: 'AlRevhXQga',
+    name: 'Milan'
+  },
+  {
+    id: 'AjRevhQOoa',
+    name: 'Market Special'
+  },
+  {
+    id: 'EjDkXhNEoD',
+    name: 'USA'
+  }
+]
+
+const Template: ComponentStory<typeof InputCheckbox> = (args) => {
+  const [selectedIds, setSelectedId] = useState<string[]>([])
+
+  return (
+    <PageLayout title='Filters' onGoBack={() => {}}>
+      <Spacer bottom='4'>
+        <Text variant='info' weight='medium'>
+          Markets{' '}
+          {selectedIds.length > 0
+            ? `${selectedIds.length} of ${options.length}`
+            : options.length}
+        </Text>
+      </Spacer>
+      <Card>
+        {options.map((opt, idx) => {
+          const isChecked = selectedIds.includes(opt.id)
+          return (
+            <Spacer
+              bottom={options.length === idx + 1 ? undefined : '4'}
+              key={opt.id}
+            >
+              <InputCheckbox
+                checked={isChecked}
+                onChange={() => {
+                  if (isChecked) {
+                    setSelectedId((prev) => prev.filter((id) => id !== opt.id))
+                  } else {
+                    setSelectedId((prev) => [...prev, opt.id])
+                  }
+                }}
+                icon={
+                  <Avatar
+                    size='small'
+                    shape='circle'
+                    border='none'
+                    src={makeGravatarUrl(opt.name, idx)}
+                    alt={opt.name}
+                  />
+                }
+              >
+                <Text weight='semibold'>{opt.name}</Text>
+              </InputCheckbox>
+            </Spacer>
+          )
+        })}
+      </Card>
+    </PageLayout>
+  )
+}
+
+export const Default = Template.bind({})
+
+function makeGravatarUrl(name: string, index: number): string {
+  const colors = ['FF656B', '055463', 'FFAB2E', '282929', '001993']
+  const bgColor = colors[Math.min(index, colors.length - 1)] ?? 'FF656B'
+  const letters = name.substring(0, 2)
+  return `https://ui-avatars.com/api/${letters}/160/${bgColor}/FFFFFF/2/0.33/false/true/true`
+}

--- a/packages/docs/src/stories/forms/InputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/InputCheckbox.stories.tsx
@@ -1,0 +1,51 @@
+import { Avatar } from '#ui/atoms/Avatar'
+import { Text } from '#ui/atoms/Text'
+import { InputCheckbox } from '#ui/forms/InputCheckbox'
+import { ComponentMeta, ComponentStory } from '@storybook/react'
+
+const setup: ComponentMeta<typeof InputCheckbox> = {
+  title: 'Forms/InputCheckbox',
+  component: InputCheckbox,
+  parameters: {
+    layout: 'padded'
+  }
+}
+export default setup
+
+const Template: ComponentStory<typeof InputCheckbox> = (args) => {
+  return <InputCheckbox {...args} />
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  children: 'Click me'
+}
+
+export const WithAvatar = Template.bind({})
+WithAvatar.args = {
+  icon: (
+    <Avatar
+      size='small'
+      shape='circle'
+      border='none'
+      src='https://ui-avatars.com/api/NY Store/160/101111/FFFFFF/2/0.33/false/true/true'
+      alt='market'
+      key='avatar'
+    />
+  ),
+  children: (
+    <Text key='text' weight='semibold'>
+      NY Store
+    </Text>
+  )
+}
+
+export const WithError = Template.bind({})
+WithError.args = {
+  ...WithAvatar.args,
+  disabled: true,
+  feedback: {
+    variant: 'danger',
+    message: 'Required field'
+  }
+}


### PR DESCRIPTION
### What does this PR do?
Adds a new checkbox component

![ezgif-4-445ec3b97d](https://user-images.githubusercontent.com/30926550/228569155-b3d6840e-35af-4baf-9367-d56ca5c51e22.gif)


### How to use it
```jsx
<InputCheckbox checked={state} onChange={setState(e.target.checked)}>
  Click me
</InputCheckbox>
```
<img width="164" alt="image" src="https://user-images.githubusercontent.com/30926550/228504025-999760f4-ca7f-4a17-b5d9-4e2360f41f9c.png">


It also exposes an `icon` prop:
```jsx
<InputCheckbox icon={<Avatar src={...}  />}>
    <Text weight='semibold'>NY Store</Text>
</InputCheckbox>
```
<img width="236" alt="image" src="https://user-images.githubusercontent.com/30926550/228501919-2db5be95-5092-465a-81f5-3ae3caa3826c.png">


