### PR TITLE
Add `pathToValue` prop in InputSelect (`elements-hook-form`)

### DIFF
--- a/packages/app-elements-hook-form/src/components/Form.test.tsx
+++ b/packages/app-elements-hook-form/src/components/Form.test.tsx
@@ -7,7 +7,7 @@ import { InputDate } from './InputDate'
 import { InputDateRange } from './InputDateRange'
 import { InputCheckbox } from './InputCheckbox'
 import { InputSelect } from './InputSelect'
-import { ToggleButtons } from '#components/ToggleButtons'
+import { ToggleButtons } from './ToggleButtons'
 
 type SetupResult = RenderResult & {
   element: HTMLElement
@@ -21,7 +21,12 @@ function FullFormScreen({ id }: { id: string }): JSX.Element {
         <Input name='companyName' label='Company name' />
         <InputDate name='dateSingle' label='Date' />
         <InputDateRange name='dateRange' label='Date range' />
-        <InputSelect name='select' label='Choose one city' initialValues={[]} />
+        <InputSelect
+          name='select'
+          label='Choose one city'
+          initialValues={[{ value: 'foo', label: 'foobar' }]}
+          pathToValue='label'
+        />
         <InputToggleBox name='toggle' label='Toggle me' id='toggle' />
         <InputCheckbox name='checkbox' icon={<div />}>
           check me

--- a/packages/app-elements-hook-form/src/components/InputSelect.tsx
+++ b/packages/app-elements-hook-form/src/components/InputSelect.tsx
@@ -1,6 +1,8 @@
-import { InputSelect as InputSelectUi } from '@commercelayer/app-elements'
+import {
+  InputSelect as InputSelectUi,
+  flatSelectValues
+} from '@commercelayer/app-elements'
 import { InputSelectProps } from '@commercelayer/app-elements/dist/ui/forms/InputSelect'
-
 import { Controller, useFormContext } from 'react-hook-form'
 import { useValidationFeedback } from '#components/useValidationFeedback'
 
@@ -9,9 +11,29 @@ interface Props extends Omit<InputSelectProps, 'onSelect' | 'defaultValue'> {
    * field name to match hook-form state
    */
   name: string
+  /**
+   * Specify the path (in the `SelectValue` object) to reach the value to store in field.
+   * @default
+   * "value"
+   *
+   * Example:
+   * ```
+   * // single mode
+   * {value: 'ff0000', label: 'Red'} // set field value as 'ff0000'
+   *
+   * // multi mode
+   * [{value: 'ff0000', label: 'Red'}, {value: 'ffff00', label: 'Yellow'}]
+   * // set field value as ['ff0000', 'ffff00']
+   * ```
+   */
+  pathToValue?: string
 }
 
-function InputSelect({ name, ...props }: Props): JSX.Element {
+function InputSelect({
+  name,
+  pathToValue = 'value',
+  ...props
+}: Props): JSX.Element {
   const { control } = useFormContext()
   const feedback = useValidationFeedback(name)
 
@@ -25,7 +47,7 @@ function InputSelect({ name, ...props }: Props): JSX.Element {
           onBlur={onBlur}
           defaultValue={value}
           onSelect={(values) => {
-            onChange(values)
+            onChange(flatSelectValues(values, pathToValue))
           }}
           feedback={feedback}
         />

--- a/packages/app-elements/src/ui/forms/InputSelect/flatSelectValue.test.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/flatSelectValue.test.ts
@@ -1,0 +1,79 @@
+import { flatSelectValues, SelectValue } from './index'
+
+const singleValue: SelectValue = {
+  value: 'sku001',
+  label: 'Sku Item 001',
+  meta: {
+    color: 'red',
+    shippable: true
+  }
+}
+const multiValue: SelectValue[] = [
+  {
+    value: 'sku001',
+    label: 'Sku Item 001',
+    meta: {
+      color: 'red',
+      shippable: true
+    }
+  },
+  {
+    value: 'sku002',
+    label: 'Sku Item 002',
+    meta: {
+      color: 'yellow'
+    }
+  }
+]
+
+describe('flatSelectValues - single mode', () => {
+  test('should return single value for default path', () => {
+    expect(flatSelectValues(singleValue)).toBe('sku001')
+  })
+
+  test('should return single value for specific path', () => {
+    expect(flatSelectValues(singleValue, 'label')).toBe('Sku Item 001')
+  })
+
+  test('should return what it gets when path is reached', () => {
+    expect(flatSelectValues(singleValue, 'meta')).toEqual({
+      color: 'red',
+      shippable: true
+    })
+  })
+
+  test('should return single value using dot-notation', () => {
+    expect(flatSelectValues(singleValue, 'meta.shippable')).toBe(true)
+  })
+
+  test('should return undefined for non existing path path', () => {
+    expect(flatSelectValues(singleValue, 'not.existing.path')).toBe(undefined)
+  })
+})
+
+describe('flatSelectValues - multi mode', () => {
+  test('should return multiple values for default path', () => {
+    expect(flatSelectValues(multiValue)).toEqual(['sku001', 'sku002'])
+  })
+
+  test('should return multiple values for specific path', () => {
+    expect(flatSelectValues(multiValue, 'label')).toEqual([
+      'Sku Item 001',
+      'Sku Item 002'
+    ])
+  })
+
+  test('should return multiple values using dot-notation as path', () => {
+    expect(flatSelectValues(multiValue, 'meta.color')).toEqual([
+      'red',
+      'yellow'
+    ])
+  })
+
+  test('should return some undefined where path is not always found', () => {
+    expect(flatSelectValues(multiValue, 'meta.shippable')).toEqual([
+      true,
+      undefined
+    ])
+  })
+})

--- a/packages/app-elements/src/ui/forms/InputSelect/index.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/index.tsx
@@ -4,6 +4,7 @@ import { SkeletonItem } from '#ui/atoms/Skeleton'
 import { getSelectStyles } from './styles'
 import { InputWrapper } from '../InputWrapper'
 import { InputWrapperBaseProps } from '#ui/forms/InputWrapper'
+import get from 'lodash/get'
 
 const LazyAsyncSelect = lazy(
   async () =>
@@ -137,31 +138,33 @@ export function isSingleValueSelected(
 }
 
 /**
- * Helper function to extract only the `value` from the  `SelectValue`
+ * Helper function to extract only a specific property from the `SelectValue`
  * @param selectedValue possible value returned from select component
+ * @param path path.to.property. Default is `value`
  * @returns a string or an array of strings.
  * Examples:
  * ```
- * {value: 'ABCD', label: 'T-Shirt XL'}
+ * flatSelectValues({value: 'ABCD', label: 'T-Shirt XL'})
  * // returns 'ABCD'
  *
- * [
+ * flatSelectValues([
  *   {value: 'ABCD', label: 'T-Shirt M'},
  *   {value: '1234', label: 'T-Shirt XL'},
- * ]
- * // returns ['ABCD', '1234']
+ * ], 'label')
+ * // returns ['T-Shirt M', 'T-Shirt XL']
  * ```
  */
 export function flatSelectValues(
-  selectedValue: PossibleSelectValue
+  selectedValue: PossibleSelectValue,
+  pathToValue = 'value'
 ): null | string | Array<string | number> {
   if (selectedValue == null) {
-    return null
+    return selectedValue
   }
 
   return isSingleValueSelected(selectedValue)
-    ? `${selectedValue.value}`
-    : selectedValue.map((o) => o.value)
+    ? get(selectedValue, pathToValue)
+    : selectedValue.map((item) => get(item, pathToValue))
 }
 
 InputSelect.displayName = 'InputSelect'


### PR DESCRIPTION
### What does this PR do?
Add a new prop to decide the value of which property of `SelectValue` to store in the form context.
By default will use the `value` key.

Example:
```
// single mode
{value: 'ff0000', label: 'Red'} // set field value as 'ff0000'

// multi mode
[{value: 'ff0000', label: 'Red'}, {value: 'ffff00', label: 'Yellow'}]
 // set field value as ['ff0000', 'ffff00']
```


Usage:
```
 <InputSelect
  name='myField'
  label='Choose one city'
  initialValues={[{ value: 'foo', label: 'foobar' }]}
  pathToValue='label'
/>
// myField will contain `foobar` because  pathToValue='label'
``