### PR TITLE
Allow to uncheck selected ToggleButton in single mode

### DIFF
--- a/packages/app-elements/src/ui/forms/ToggleButtons.test.tsx
+++ b/packages/app-elements/src/ui/forms/ToggleButtons.test.tsx
@@ -103,7 +103,7 @@ describe('ToggleButtons single value mode', () => {
     expectChecked(getByText('Cancelled'))
   })
 
-  test('should not be able to unselect in single mode', async () => {
+  test('should be able to unselect in single mode', async () => {
     const { getByText } = setup({
       mode: 'single',
       options
@@ -117,7 +117,7 @@ describe('ToggleButtons single value mode', () => {
       // click again on current selected
       fireEvent.click(getByText('Placed'))
     })
-    expectChecked(getByText('Placed'))
+    expectNotChecked(getByText('Placed'))
   })
 
   test('should not be able to select disabled options', async () => {

--- a/packages/app-elements/src/ui/forms/ToggleButtons.tsx
+++ b/packages/app-elements/src/ui/forms/ToggleButtons.tsx
@@ -57,7 +57,7 @@ interface BaseProps
 interface SingleValueProps {
   mode: 'single'
   value?: ToggleButtonValue
-  onChange: (value: ToggleButtonValue) => void
+  onChange: (value?: ToggleButtonValue) => void
 }
 interface MultiValuesProps {
   mode: 'multi'
@@ -109,8 +109,8 @@ function ToggleButtons({
                   : [...currentValues, opt.value]
                 onChange(newValues)
               } else {
-                // when is single value mode, this works like a radio buttons
-                onChange(opt.value)
+                // when is single value mode, we need also to handle the un-check action
+                onChange(isChecked ? undefined : opt.value)
               }
             }
             return (


### PR DESCRIPTION
The `ToggleButtons` component does not need to work like radio buttons, but it always needs to behave like a checkbox
When working in `single` mode we can now uncheck the selected option.

![ezgif-4-22e439423d](https://user-images.githubusercontent.com/30926550/229732922-707c8ab0-04ed-4d22-a967-36bfd0a8e035.gif)
