### PR TITLE
Add new date format to the helper

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -1,59 +1,12 @@
-import { formatDate, isCurrentYear, isToday } from './date'
+import { formatDate } from './date'
 
 describe('formatDate', () => {
-  test('Should return a nice date string', () => {
-    expect(
-      formatDate({
-        isoDate: '2022-10-14T14:32:00.000Z'
-      })
-    ).toBe('Oct 14, 2022')
+  beforeEach(() => {
+    vi.useFakeTimers().setSystemTime('2023-12-25T14:30:00.000Z')
   })
 
-  test('Should accept a date with time', () => {
-    // AM
-    expect(
-      formatDate({
-        isoDate: '2023-02-22T10:32:47.284Z',
-        format: 'full'
-      })
-    ).toBe('Feb 22, 2023 · 10:32 AM')
-
-    // PM
-    expect(
-      formatDate({
-        isoDate: '2022-10-26T16:16:31.279Z',
-        format: 'full'
-      })
-    ).toBe('Oct 26, 2022 · 4:16 PM')
-  })
-
-  test('Should return a date without year', () => {
-    expect(
-      formatDate({
-        isoDate: '2022-10-14T14:32:00.000Z',
-        format: 'noYear'
-      })
-    ).toBe('Oct 14')
-  })
-
-  test('Should accept a specific timezone override', () => {
-    // Sydney (day after)
-    expect(
-      formatDate({
-        isoDate: '2022-10-26T16:16:31.279Z',
-        timezone: 'Australia/Sydney',
-        format: 'noTime'
-      })
-    ).toBe('Oct 27, 2022')
-
-    // Rome
-    expect(
-      formatDate({
-        isoDate: '2022-10-26T16:16:31.279Z',
-        timezone: 'Europe/Rome',
-        format: 'full'
-      })
-    ).toBe('Oct 26, 2022 · 6:16 PM')
+  afterEach(() => {
+    vi.useRealTimers()
   })
 
   test('Should not break when date format is wrong', () => {
@@ -68,49 +21,163 @@ describe('formatDate', () => {
     expect(formatDate({ isoDate: undefined })).toBe('N/A')
   })
 
-  test('Should accept custom template', () => {
+  test('Should return a nice date string', () => {
+    expect(
+      formatDate({
+        isoDate: '2022-10-14T14:32:00.000Z'
+      })
+    ).toBe('Oct 14, 2022')
+  })
+
+  test('Should return the value without the year when current year', () => {
+    expect(
+      formatDate({
+        isoDate: '2023-10-14T14:32:00.000Z',
+        format: 'date'
+      })
+    ).toBe('Oct 14')
+  })
+
+  test('Should return the value with the year when previous year', () => {
+    expect(
+      formatDate({
+        isoDate: '2022-10-14T14:32:00.000Z',
+        format: 'date'
+      })
+    ).toBe('Oct 14, 2022')
+  })
+
+  test('Should return "Today" when today', () => {
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T14:32:00.000Z',
+        format: 'date'
+      })
+    ).toBe('Today')
+  })
+
+  test('Should return a date with time', () => {
+    // AM
+    expect(
+      formatDate({
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'full'
+      })
+    ).toBe('Feb 22 · 10:32')
+
+    // PM
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        format: 'full'
+      })
+    ).toBe('Oct 26, 2022 · 16:16')
+  })
+
+  test('Should return a date with time and seconds', () => {
+    // AM
+    expect(
+      formatDate({
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'fullWithSeconds'
+      })
+    ).toBe('Feb 22 · 10:32:47')
+
+    // PM
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        format: 'fullWithSeconds'
+      })
+    ).toBe('Oct 26, 2022 · 16:16:31')
+  })
+
+  test('Should return only the time', () => {
+    // AM
+    expect(
+      formatDate({
+        isoDate: '2023-02-22T05:32:47.284Z',
+        format: 'time'
+      })
+    ).toBe('05:32')
+
+    // PM
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        format: 'time'
+      })
+    ).toBe('16:16')
+  })
+
+  test('Should return only the time with seconds', () => {
+    // AM
+    expect(
+      formatDate({
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'timeWithSeconds'
+      })
+    ).toBe('10:32:47')
+
+    // PM
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        format: 'timeWithSeconds'
+      })
+    ).toBe('16:16:31')
+  })
+
+  test('Should accept a specific timezone override', () => {
+    // Sydney (day after)
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        timezone: 'Australia/Sydney',
+        format: 'date'
+      })
+    ).toBe('Oct 27, 2022')
+
+    // Rome
+    expect(
+      formatDate({
+        isoDate: '2022-10-26T16:16:31.279Z',
+        timezone: 'Europe/Rome',
+        format: 'full'
+      })
+    ).toBe('Oct 26, 2022 · 18:16')
+  })
+
+  test('Should return the distance to now', () => {
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T14:30:00.000Z',
+        timezone: 'Australia/Sydney',
+        format: 'distanceToNow'
+      })
+    ).toBe('less than a minute ago')
+
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T14:30:00.000Z',
+        timezone: 'Europe/Rome',
+        format: 'distanceToNow'
+      })
+    ).toBe('less than a minute ago')
+
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T14:23:00.000Z',
+        timezone: 'Europe/Rome',
+        format: 'distanceToNow'
+      })
+    ).toBe('7 minutes ago')
+
     expect(
       formatDate({
         isoDate: '2023-02-27T16:00:00.000Z',
-        timezone: 'Europe/Rome',
-        format: 'custom',
-        customTemplate: `do 'of' LLLL`
+        format: 'distanceToNow'
       })
-    ).toBe('27th of February')
-  })
-})
-
-describe('isCurrentYear', () => {
-  beforeEach(() => {
-    vi.useRealTimers()
-  })
-
-  test('should return TRUE when provided isoDate is current year', () => {
-    vi.useFakeTimers().setSystemTime('2023-12-31')
-    expect(isCurrentYear('2023-01-03T08:35:00.200Z')).toBe(true)
-  })
-
-  test('should return FALSE when provided isoDate is NOT the current year', () => {
-    vi.useFakeTimers().setSystemTime('2023-12-31')
-    expect(isCurrentYear('2022-01-03T08:35:00.200Z')).toBe(false)
-    expect(isCurrentYear('2024-01-03T08:35:00.200Z')).toBe(false)
-  })
-})
-
-describe('isToday', () => {
-  beforeEach(() => {
-    vi.useRealTimers()
-  })
-
-  test('should return TRUE when provided isoDate is today', () => {
-    vi.useFakeTimers().setSystemTime('2023-12-31')
-    expect(isToday('2023-12-31T08:35:00.200Z')).toBe(true)
-  })
-
-  test('should return FALSE when provided isoDate is NOT today', () => {
-    vi.useFakeTimers().setSystemTime('2023-12-31')
-    expect(isToday('2022-01-03T08:35:00.200Z')).toBe(false)
-    expect(isToday('2023-12-30T23:59:00.000Z')).toBe(false)
-    expect(isToday('2024-01-03T08:35:00.200Z')).toBe(false)
+    ).toBe('10 months ago')
   })
 })

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -1,40 +1,37 @@
 import { utcToZonedTime } from 'date-fns-tz'
 import format from 'date-fns/format'
+import isToday from 'date-fns/isToday'
+import isThisYear from 'date-fns/isThisYear'
+import formatDistance from 'date-fns/formatDistance'
 
-type Format = 'full' | 'noTime' | 'noYear'
-type FormatDateOptions =
-  | {
-      /**
-       * JavaScript ISO date string. Example '2022-10-06T11:59:30.371Z'
-       */
-      isoDate?: string
-      /**
-       * Set a specific timezone, when not passed default value is 'UTC'
-       */
-      timezone?: string
-    } & (
-      | {
-          /**
-           * How to format the date:
-           * - full `Feb 28, 2023 · 5:30 PM`
-           * - noTime `Feb 28, 2023`
-           * - noYear `Feb 28`
-           * @default noTime
-           */
-          format?: Format
-        }
-      | {
-          /**
-           * When set as `custom` a `customTemplate` is required
-           */
-          format: 'custom'
-          /**
-           * Custom template to override the default one ('LLL dd, yyyy').
-           * @link https://date-fns.org/v2.29.3/docs/format
-           */
-          customTemplate: string
-        }
-    )
+type Format =
+  | 'date'
+  | 'time'
+  | 'timeWithSeconds'
+  | 'full'
+  | 'fullWithSeconds'
+  | 'distanceToNow'
+interface FormatDateOptions {
+  /**
+   * JavaScript ISO date string. Example '2022-10-06T11:59:30.371Z'
+   */
+  isoDate?: string
+  /**
+   * Set a specific timezone, when not passed default value is 'UTC'
+   */
+  timezone?: string
+  /**
+   * How to format the date:
+   * - `date` – can be `Today` when today, `Feb 28` when current year or `Feb 28, 2022` when previous year
+   * - `time` – `04:34` `18:54`
+   * - `timeWithSeconds` – `04:34:23` `18:54:12`
+   * - `full` – `Feb 28, 2023 · 15:30` the date in this string behaves like the `date` format
+   * - `fullWithSeconds` – `Feb 28, 2023 · 15:30:43` the date in this string behaves like the `date` format
+   * - `distanceToNow` – `about 1 hour ago` `10 months ago` `less than a minute ago`
+   * @default date
+   */
+  format?: Format
+}
 
 /**
  * Format the date as nice string also specifying a custom timezone
@@ -53,10 +50,11 @@ export function formatDate({
   try {
     const date = new Date(isoDate)
     const zonedDate = utcToZonedTime(date, timezone)
-    const formatTemplate =
-      opts.format === 'custom'
-        ? opts.customTemplate
-        : getPresetFormatTemplate(opts.format)
+    const formatTemplate = getPresetFormatTemplate(
+      zonedDate,
+      timezone,
+      opts.format
+    )
 
     return format(zonedDate, formatTemplate)
   } catch {
@@ -64,24 +62,48 @@ export function formatDate({
   }
 }
 
-function getPresetFormatTemplate(format: Format = 'noTime'): string {
+export const timeSeparator = '·'
+
+function getPresetFormatTemplate(
+  zonedDate: Date,
+  timezone: string,
+  format: Format = 'date'
+): string {
   switch (format) {
-    case 'noTime':
-      return 'LLL dd, yyyy' // Feb 28, 2023
-    case 'noYear':
-      return 'LLL dd' // Feb 28
+    case 'date':
+      return isToday(zonedDate)
+        ? "'Today'"
+        : isThisYear(zonedDate)
+        ? 'LLL dd'
+        : 'LLL dd, yyyy'
+    case 'time':
+      return 'kk:mm'
+    case 'timeWithSeconds':
+      return `${getPresetFormatTemplate(zonedDate, timezone, 'time')}:ss`
     case 'full':
-      return 'LLL dd, yyyy · h:mm b' // Feb 28, 2023 · 5:30 PM
+      return `${getPresetFormatTemplate(
+        zonedDate,
+        timezone,
+        'date'
+      )} ${timeSeparator} ${getPresetFormatTemplate(
+        zonedDate,
+        timezone,
+        'time'
+      )}`
+    case 'fullWithSeconds':
+      return `${getPresetFormatTemplate(
+        zonedDate,
+        timezone,
+        'date'
+      )} ${timeSeparator} ${getPresetFormatTemplate(
+        zonedDate,
+        timezone,
+        'timeWithSeconds'
+      )}`
+    case 'distanceToNow':
+      return `'${formatDistance(
+        zonedDate,
+        utcToZonedTime(new Date(), timezone)
+      )} ago'`
   }
-}
-
-export function isCurrentYear(isoDate: string): boolean {
-  return new Date(isoDate).getFullYear() === new Date().getFullYear()
-}
-
-export function isToday(isoDate: string): boolean {
-  return (
-    formatDate({ isoDate, format: 'noTime' }) ===
-    formatDate({ isoDate: new Date().toJSON(), format: 'noTime' })
-  )
 }

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -51,7 +51,7 @@ export { PageError } from '#ui/composite/PageError'
 export { PageLayout } from '#ui/composite/PageLayout'
 export { PageSkeleton } from '#ui/composite/PageSkeleton'
 export { Report } from '#ui/composite/Report'
-export { Timeline } from '#ui/composite/Timeline'
+export { Timeline, type TimelineEvent } from '#ui/composite/Timeline'
 
 // Forms
 export { Input } from '#ui/forms/Input'

--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -1,4 +1,4 @@
-import { formatDate, isCurrentYear, isToday } from '#helpers/date'
+import { formatDate } from '#helpers/date'
 import { Badge } from '#ui/atoms/Badge'
 import { Card } from '#ui/atoms/Card'
 import { Icon } from '#ui/atoms/Icon'
@@ -8,18 +8,18 @@ import groupBy from 'lodash/groupBy'
 import orderBy from 'lodash/orderBy'
 import { Fragment, type ReactNode, useMemo } from 'react'
 
-interface Event {
+export interface TimelineEvent {
   date: string
   message: ReactNode
   note?: string
 }
 
-type EventWithIcon = Event & {
+type EventWithIcon = TimelineEvent & {
   icon: JSX.Element
 }
 
 interface Props {
-  events: Event[]
+  events: TimelineEvent[]
   onChange?: React.ChangeEventHandler<HTMLInputElement>
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>
 }
@@ -32,7 +32,9 @@ export const Timeline = withSkeletonTemplate<Props>(
           return { ...event, icon: getIcon(event, index, arr) }
         }
       )
-      return groupBy(ordered, (val) => getDate(val.date))
+      return groupBy(ordered, (val) =>
+        formatDate({ isoDate: val.date, format: 'date' }).toUpperCase()
+      )
     }, [events])
     return (
       <div data-test-id='timeline'>
@@ -53,7 +55,7 @@ export const Timeline = withSkeletonTemplate<Props>(
                 <Badge
                   data-test-id='timeline-date-group'
                   className='rounded-full bg-gray-100 py-1 px-3 font-bold'
-                  label={date.toUpperCase()}
+                  label={date}
                   variant='secondary'
                 />
               </div>
@@ -92,16 +94,11 @@ export const Timeline = withSkeletonTemplate<Props>(
   }
 )
 
-function getDate(isoDate: string): string {
-  return isToday(isoDate)
-    ? 'TODAY'
-    : formatDate({
-        isoDate,
-        format: isCurrentYear(isoDate) ? 'noYear' : 'noTime'
-      })
-}
-
-function getIcon(event: Event, index: number, events: Event[]): JSX.Element {
+function getIcon(
+  event: TimelineEvent,
+  index: number,
+  events: TimelineEvent[]
+): JSX.Element {
   const isFirst = index === events.length - 1
 
   if (event.note != null) {

--- a/packages/docs/src/stories/composite/Timeline.stories.tsx
+++ b/packages/docs/src/stories/composite/Timeline.stories.tsx
@@ -1,10 +1,10 @@
 import { Text } from '#app-elements/atoms/Text'
 import { Timeline } from '#ui/composite/Timeline'
 
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { set, sub } from 'date-fns'
 
-const setup: ComponentMeta<typeof Timeline> = {
+const setup: Meta<typeof Timeline> = {
   title: 'Composite/Timeline',
   component: Timeline,
   parameters: {
@@ -13,9 +13,7 @@ const setup: ComponentMeta<typeof Timeline> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Timeline> = (args) => (
-  <Timeline {...args} />
-)
+const Template: StoryFn<typeof Timeline> = (args) => <Timeline {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -50,7 +48,7 @@ Default.args = {
         minutes: 6,
         seconds: 27
       }).toJSON(),
-      message: '$250,5 authorized on stripe · 6:27'
+      message: '$250,5 authorized on stripe · 06:27'
     },
     {
       date: set(new Date(), {
@@ -59,7 +57,7 @@ Default.args = {
         minutes: 6,
         seconds: 28
       }).toJSON(),
-      message: 'Approved · 6:28 AM'
+      message: 'Approved · 06:28'
     },
     {
       date: set(new Date(), {
@@ -68,7 +66,7 @@ Default.args = {
         minutes: 6,
         seconds: 29
       }).toJSON(),
-      message: '$250,50 captured on stripe · 6:29'
+      message: '$250,50 captured on stripe · 06:29'
     },
     {
       date: set(new Date(), {
@@ -77,7 +75,7 @@ Default.args = {
         minutes: 6,
         seconds: 20
       }).toJSON(),
-      message: 'Fulfillment in progress · 6:20'
+      message: 'Fulfillment in progress · 06:20'
     },
     {
       date: set(new Date(), {
@@ -88,7 +86,7 @@ Default.args = {
       }).toJSON(),
       message: (
         <span>
-          <Text weight='bold'>S. Jennigs</Text> left a note · 8:35
+          <Text weight='bold'>S. Jennigs</Text> left a note · 08:35
         </span>
       ),
       note: 'Customer would like to receive parcel sooner, please request the customer phone number.'


### PR DESCRIPTION
This contains **breaking changes**.

The `format` attribute has been changed to:
- **`date`** – can be `Today` when today, `Feb 28` when the current year, or `Feb 28, 2022` when the previous year
- **`time`** – `04:34` `18:54`
- **`timeWithSeconds`** – `04:34:23` `18:54:12`
- **`full`** – `Feb 28, 2023 · 15:30` the date in this string behaves like the `date` format
- **`fullWithSeconds`** – `Feb 28, 2023 · 15:30:43` the date in this string behaves like the `date` format
- **`distanceToNow`** – `about 1 hour ago` `10 months ago` `less than a minute ago`

Good to know: 
- `full` format behaves differently.
- `noTime` and `noYear` formats have been removed.
- `custom` format has been removed. If you find a new format that is not present in the list, you'll need to add a new official format.
