### PR TITLE
Set un-checked `<ToggleButtons>` value as null

### DIFF
--- a/packages/app-elements/src/ui/forms/ToggleButtons.tsx
+++ b/packages/app-elements/src/ui/forms/ToggleButtons.tsx
@@ -60,7 +60,7 @@ interface BaseProps
 interface SingleValueProps {
   mode: 'single'
   value?: ToggleButtonValue
-  onChange: (value?: ToggleButtonValue) => void
+  onChange: (value: ToggleButtonValue | null) => void
 }
 interface MultiValuesProps {
   mode: 'multi'
@@ -113,7 +113,7 @@ function ToggleButtons({
                 onChange(newValues)
               } else {
                 // when is single value mode, we need also to handle the un-check action
-                onChange(isChecked ? undefined : opt.value)
+                onChange(isChecked ? null : opt.value)
               }
             }
             return (


### PR DESCRIPTION
### What does this PR do?
When un-checked, ToggleButton is now set as `null` since library like `react-hook-form` doesn't support `undefined` as onChange value