### PR TITLE
Reset `ResourceList` on query change

### DIFF
--- a/packages/app-elements/src/hooks/useIsChanged.test.tsx
+++ b/packages/app-elements/src/hooks/useIsChanged.test.tsx
@@ -1,0 +1,65 @@
+import { renderHook, act } from '@testing-library/react'
+import { useIsChanged } from './useIsChanged'
+
+describe('useIsChanged', () => {
+  test('Should detect changes of value', () => {
+    let value: Record<string, string> = { foo: 'bar' }
+    const { result, rerender } = renderHook(() =>
+      useIsChanged({
+        value
+      })
+    )
+
+    // changing value
+    act(() => {
+      value = { foo: 'baz' }
+      rerender()
+    })
+    expect(result.current).toBe(true)
+
+    // re-rendering with the same value
+    act(() => {
+      value = { foo: 'baz' }
+      rerender()
+    })
+    expect(result.current).toBe(false)
+  })
+
+  test('Should trigger onChange callback every time value is changed', () => {
+    const mockedConsoleLog = vi.spyOn(console, 'log')
+    let value: Record<string, string> = { foo: 'bar' }
+
+    const { result, rerender } = renderHook(() =>
+      useIsChanged({
+        value,
+        onChange: () => {
+          console.log('value is changed')
+        }
+      })
+    )
+
+    // changing value
+    act(() => {
+      value = { foo: 'baz' }
+      rerender()
+    })
+    expect(result.current).toBe(true)
+    expect(mockedConsoleLog).toBeCalledTimes(1)
+
+    // re-rendering with the same value
+    act(() => {
+      value = { foo: 'baz' }
+      rerender()
+    })
+    expect(result.current).toBe(false)
+    expect(mockedConsoleLog).toBeCalledTimes(1)
+
+    // changing value again
+    act(() => {
+      value = { foo: 'baz', bar: 'foo' }
+      rerender()
+    })
+    expect(result.current).toBe(true)
+    expect(mockedConsoleLog).toBeCalledTimes(2)
+  })
+})

--- a/packages/app-elements/src/hooks/useIsChanged.ts
+++ b/packages/app-elements/src/hooks/useIsChanged.ts
@@ -1,0 +1,29 @@
+import isEqual from 'lodash/isEqual'
+import { useEffect, useRef } from 'react'
+
+/**
+ * This hook is used to detect when a value has changed during new rendering.
+ * It is useful to trigger an action when a value has changed.
+ * @param value - the value to watch
+ * @param onChange - the action to trigger when the value has changed
+ * @returns - a boolean that is true when the value has changed
+ */
+export function useIsChanged<T>({
+  value,
+  onChange
+}: {
+  value: T
+  onChange?: () => void
+}): boolean {
+  const previousValue = useRef<T>(value)
+  const isValueChanged = !isEqual(value, previousValue.current)
+
+  useEffect(() => {
+    previousValue.current = value
+    if (isValueChanged && onChange != null) {
+      onChange()
+    }
+  }, [isValueChanged])
+
+  return isValueChanged
+}

--- a/packages/app-elements/src/ui/resources/ResourceList/reducer.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/reducer.ts
@@ -21,6 +21,9 @@ type Action<TResource extends ListableResource> =
       type: 'prepare'
     }
   | {
+      type: 'reset'
+    }
+  | {
       type: 'loaded'
       payload: FetcherResponse<Resource<TResource>>
     }
@@ -55,7 +58,12 @@ export const reducer = <TResource extends ListableResource>(
           message: action.payload
         }
       }
-    default:
-      return state
+    case 'reset':
+      return {
+        ...state,
+        error: undefined,
+        isLoading: true,
+        data: undefined
+      }
   }
 }


### PR DESCRIPTION
`<ResourceList>` now reacts when the `query` prop changes and it will reset the internal state.

This is required because every time we pass a different query, the previous infinite list is not valid anymore and we need to return to the initial loading UI state waiting for a new list of resources.

Example:
```jsx
const [query, setQuery] = useState({
  filters: {},
  sort: {
    updated_at: 'desc'
  }
})
return <ResourceList type='skus' query={query} />

```
If later we update the `query` object with a different filter or a different sort option, the list will be refreshed.
