### PR TITLE
Handle validation error on `<InputDate>`

### DIFF
--- a/packages/app-elements-hook-form/src/components/InputDate.tsx
+++ b/packages/app-elements-hook-form/src/components/InputDate.tsx
@@ -1,6 +1,5 @@
 import { InputDate as InputDateUi } from '@commercelayer/app-elements'
 import { type InputDateProps } from '@commercelayer/app-elements/dist/ui/forms/InputDate/InputDateComponent'
-
 import { Controller, useFormContext } from 'react-hook-form'
 import { useValidationFeedback } from '#components/useValidationFeedback'
 
@@ -20,7 +19,16 @@ function InputDate({ name, ...props }: Props): JSX.Element {
       name={name}
       control={control}
       render={({ field }) => (
-        <InputDateUi {...props} {...field} feedback={feedback} />
+        <InputDateUi
+          {...props}
+          {...field}
+          feedback={feedback}
+          ref={(ref) => {
+            field.ref({
+              focus: ref?.setFocus
+            })
+          }}
+        />
       )}
     />
   )

--- a/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.tsx
@@ -51,6 +51,12 @@ export interface InputDateProps extends InputWrapperBaseProps {
    * enables a button to clear the selected date
    */
   isClearable?: boolean
+  /**
+   * prevent the date picker calendar from opening on focus,
+   * this is useful when showing validation error message and
+   * to avoid the calendar to open on top of the error message
+   */
+  preventOpenOnFocus?: boolean
 }
 
 const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
@@ -68,6 +74,7 @@ const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
       isClearable,
       hint,
       feedback,
+      preventOpenOnFocus,
       ...rest
     },
     ref
@@ -78,6 +85,7 @@ const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
         {...rest}
         className={wrapperClassName}
         hint={hint}
+        feedback={feedback}
         label={label}
       >
         <div className='relative'>
@@ -98,6 +106,7 @@ const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
               getFeedbackStyle(feedback),
               inputClassName
             )}
+            preventOpenOnFocus={preventOpenOnFocus}
           />
           <div className='absolute top-0 bottom-0 right-4 flex items-center pointer-events-none touch-none'>
             <CalendarBlank />


### PR DESCRIPTION
This fixes the following on `InputDate`: 
- it was not displaying the validation error message (`feedback` prop)
- when used with `react-hook-form` it was triggering an error since the `domElement.focus` method does not exist on the original DatePicker component. Now we properly map the `focus` action to `setFocus` method available from `react-datepicker` 
- we now expose `preventOpenOnFocus` prop to avoid that date-picker overlap the validation error message (react-hook-form automatically set focus on the first field with error)