### PR TITLE
Improve `emptyState` prop in `<ResourceList>

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceList/index.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/index.test.tsx
@@ -41,9 +41,7 @@ const setup = ({
       title='All orders'
       Item={Item}
       query={query}
-      emptyState={{
-        title: 'No orders found'
-      }}
+      emptyState={<div>No orders found</div>}
       sdkClient={CommerceLayer({
         accessToken: 'abc123',
         organization: 'demo-store'

--- a/packages/app-elements/src/ui/resources/ResourceList/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/index.tsx
@@ -1,6 +1,6 @@
 import { useIsChanged } from '#hooks/useIsChanged'
 import { Button } from '#ui/atoms/Button'
-import { EmptyState, type EmptyStateProps } from '#ui/atoms/EmptyState'
+import { EmptyState } from '#ui/atoms/EmptyState'
 import { Legend, type LegendProps } from '#ui/atoms/Legend'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
@@ -10,18 +10,15 @@ import {
   type CommerceLayerClient,
   type QueryParamsList
 } from '@commercelayer/sdk'
+import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
 import { useCallback, useEffect, useReducer, type FC } from 'react'
 import { VisibilityTrigger } from './VisibilityTrigger'
-import {
-  infiniteFetcher,
-  type ListableResource,
-  type Resource
-} from './infiniteFetcher'
+import { infiniteFetcher, type Resource } from './infiniteFetcher'
 import { initialState, reducer } from './reducer'
 
 const LegendWithSkeleton = withSkeletonTemplate(Legend)
 
-export interface ResourceListProps<TResource extends ListableResource>
+export interface ResourceListProps<TResource extends ListableResourceType>
   extends Pick<LegendProps, 'title' | 'actionButton'> {
   type: TResource
   query?: Omit<QueryParamsList, 'pageNumber'>
@@ -30,11 +27,11 @@ export interface ResourceListProps<TResource extends ListableResource>
     isLoading?: boolean
     delayMs?: number
   }>
-  emptyState: EmptyStateProps
+  emptyState: JSX.Element
   sdkClient?: CommerceLayerClient
 }
 
-function ResourceList<TResource extends ListableResource>({
+function ResourceList<TResource extends ListableResourceType>({
   type,
   query,
   title,
@@ -103,7 +100,7 @@ function ResourceList<TResource extends ListableResource>({
 
   const isEmptyList = data != null && data.list.length === 0
   if (isEmptyList) {
-    return <EmptyState {...emptyState} />
+    return <>{emptyState}</>
   }
 
   const isFirstLoading = isLoading && data == null

--- a/packages/app-elements/src/ui/resources/ResourceList/infiniteFetcher.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/infiniteFetcher.ts
@@ -1,28 +1,12 @@
 import type { CommerceLayerClient, QueryParamsList } from '@commercelayer/sdk'
+import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
 import uniqBy from 'lodash/uniqBy'
 
-export type ListableResource = Exclude<
-  keyof CommerceLayerClient,
-  | 'addRawResponseReader'
-  | 'addRawResponseReader'
-  | 'addRequestInterceptor'
-  | 'addResponseInterceptor'
-  | 'application'
-  | 'config'
-  | 'currentOrganization'
-  | 'isApiError'
-  | 'openApiSchemaVersion'
-  | 'organization'
-  | 'removeInterceptor'
-  | 'removeRawResponseReader'
-  | 'resources'
->
-
-type ListResource<TResource extends ListableResource> = Awaited<
+type ListResource<TResource extends ListableResourceType> = Awaited<
   ReturnType<CommerceLayerClient[TResource]['list']>
 >
 
-export type Resource<TResource extends ListableResource> =
+export type Resource<TResource extends ListableResourceType> =
   ListResource<TResource>[number]
 
 export interface FetcherResponse<TResource> {
@@ -35,7 +19,7 @@ export interface FetcherResponse<TResource> {
   }
 }
 
-export async function infiniteFetcher<TResource extends ListableResource>({
+export async function infiniteFetcher<TResource extends ListableResourceType>({
   sdkClient,
   query,
   currentData,

--- a/packages/app-elements/src/ui/resources/ResourceList/reducer.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/reducer.ts
@@ -1,10 +1,7 @@
-import {
-  type FetcherResponse,
-  type Resource,
-  type ListableResource
-} from './infiniteFetcher'
+import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
+import { type FetcherResponse, type Resource } from './infiniteFetcher'
 
-interface ResourceListInternalState<TResource extends ListableResource> {
+interface ResourceListInternalState<TResource extends ListableResourceType> {
   isLoading: boolean
   error?: {
     message: string
@@ -16,7 +13,7 @@ export const initialState: ResourceListInternalState<any> = {
   isLoading: true
 }
 
-type Action<TResource extends ListableResource> =
+type Action<TResource extends ListableResourceType> =
   | {
       type: 'prepare'
     }
@@ -32,7 +29,7 @@ type Action<TResource extends ListableResource> =
       payload: string
     }
 
-export const reducer = <TResource extends ListableResource>(
+export const reducer = <TResource extends ListableResourceType>(
   state: ResourceListInternalState<TResource>,
   action: Action<TResource>
 ): ResourceListInternalState<TResource> => {


### PR DESCRIPTION
Before `emptyState` prop was an object with keys `title`, `description` and `icon`.

Now it's a standalone `JSX.Element`, so the consumer app has more control around it
