### PR TITLE
Add `ValidationApiError` component in hook-form package

### DIFF
--- a/packages/app-elements-hook-form/src/components/Form.test.tsx
+++ b/packages/app-elements-hook-form/src/components/Form.test.tsx
@@ -8,6 +8,7 @@ import { InputDateRange } from './InputDateRange'
 import { InputCheckbox } from './InputCheckbox'
 import { InputSelect } from './InputSelect'
 import { ToggleButtons } from './ToggleButtons'
+import { ValidationApiError } from './ValidationApiError'
 
 type SetupResult = RenderResult & {
   element: HTMLElement
@@ -45,6 +46,7 @@ function FullFormScreen({ id }: { id: string }): JSX.Element {
           ]}
           mode='multi'
         />
+        <ValidationApiError apiError={{}} />
       </Form>
     </div>
   )

--- a/packages/app-elements-hook-form/src/components/ValidationApiError.tsx
+++ b/packages/app-elements-hook-form/src/components/ValidationApiError.tsx
@@ -1,0 +1,39 @@
+import { useFormContext } from 'react-hook-form'
+import { useEffect } from 'react'
+import { ValidationError } from './ValidationError'
+import {
+  setApiFormErrors,
+  API_ERROR_FIELD_NAME
+} from '#helpers/setApiFormErrors'
+
+interface ValidationApiErrorProps {
+  /**
+   * An error object returned from a failed API request.
+   * We expect an object that contain an `errors` property with the Core Api error items shape.
+   */
+  apiError: any
+  /**
+   * Optional map of app field names to API error field names.
+   * This is useful when the API returns field names that are different from the app field names.
+   * For example, if the API returns `first_name` instead of `firstName`, you can pass `{ firstName: 'first_name' }`.
+   */
+  fieldMap?: Record<string, string>
+}
+
+function ValidationApiError({
+  apiError,
+  fieldMap
+}: ValidationApiErrorProps): JSX.Element {
+  const { setError } = useFormContext()
+
+  useEffect(() => {
+    if (apiError != null) {
+      setApiFormErrors({ apiError, setError, fieldMap })
+    }
+  }, [apiError, apiError?.errors])
+
+  return <ValidationError name={API_ERROR_FIELD_NAME} />
+}
+
+ValidationApiError.displayName = 'ValidationApiError'
+export { ValidationApiError }

--- a/packages/app-elements-hook-form/src/helpers/setApiFormErrors.test.ts
+++ b/packages/app-elements-hook-form/src/helpers/setApiFormErrors.test.ts
@@ -1,0 +1,99 @@
+import { setApiFormErrors } from './setApiFormErrors'
+
+describe('setApiFormErrors', () => {
+  test('should set errors', () => {
+    const MockedSetError = vi.fn()
+
+    setApiFormErrors({
+      apiError: {
+        errors: [
+          {
+            code: 'VALIDATION_ERROR',
+            title: 'Required field',
+            detail: 'first_name - is required',
+            source: {
+              pointer: '/data/attributes/first_name'
+            }
+          },
+          {
+            code: 'VALIDATION_ERROR',
+            title: 'Required field',
+            detail: 'phone - is required',
+            source: {
+              pointer: '/data/attributes/phone'
+            }
+          },
+          {
+            title: 'Bad request',
+            code: 'UNKNOWN_ERROR',
+            detail: 'Too many params'
+          }
+        ]
+      },
+      setError: MockedSetError
+    })
+
+    expect(MockedSetError).toHaveBeenCalledWith(
+      'first_name',
+      {
+        type: 'serverValidation',
+        message: 'Required field'
+      },
+      {
+        shouldFocus: true
+      }
+    )
+
+    expect(MockedSetError).toHaveBeenCalledWith(
+      'phone',
+      {
+        type: 'serverValidation',
+        message: 'Required field'
+      },
+      {
+        shouldFocus: false
+      }
+    )
+
+    expect(MockedSetError).toHaveBeenCalledWith('root.apiError', {
+      type: 'server',
+      message: 'Too many params'
+    })
+
+    expect(MockedSetError).toHaveBeenCalledTimes(3)
+  })
+
+  test('should accept a map object', () => {
+    const MockedSetError = vi.fn()
+
+    setApiFormErrors({
+      apiError: {
+        errors: [
+          {
+            code: 'VALIDATION_ERROR',
+            title: 'Required field',
+            detail: 'first_name - is required',
+            source: {
+              pointer: '/data/attributes/first_name'
+            }
+          }
+        ]
+      },
+      setError: MockedSetError,
+      fieldMap: {
+        first_name: 'myCustomFieldName'
+      }
+    })
+
+    expect(MockedSetError).toHaveBeenCalledWith(
+      'myCustomFieldName',
+      {
+        type: 'serverValidation',
+        message: 'Required field'
+      },
+      {
+        shouldFocus: true
+      }
+    )
+  })
+})

--- a/packages/app-elements-hook-form/src/helpers/setApiFormErrors.ts
+++ b/packages/app-elements-hook-form/src/helpers/setApiFormErrors.ts
@@ -1,0 +1,154 @@
+import { type UseFormSetError } from 'react-hook-form'
+
+interface ApiError {
+  /**
+   * Error message without attribute key
+   * Example: "must be less than or equal to 10"
+   */
+  title: string
+  /**
+   * Computed error message that also includes attribute key
+   * Example: "quantity - must be less than or equal to 10"
+   */
+  detail: string
+  /**
+   * error code
+   * Example: "VALIDATION_ERROR"
+   */
+  code?: string
+  /**
+   * HTTP status code
+   * Example: "422"
+   */
+  status?: string
+  /**
+   * Points where the error occurred
+   * Only when  code: 'VALIDATION_ERROR'
+   * Example: {"pointer": "/data/attributes/quantity"}
+   */
+  source?: {
+    pointer: string
+  }
+  meta?: unknown
+}
+
+interface ApiErrorResponse {
+  errors: ApiError[]
+}
+
+const genericError: ApiErrorResponse = {
+  errors: [
+    {
+      title: 'Generic error',
+      detail: 'Could not process your request'
+    }
+  ]
+}
+
+function isApiError(error: any): error is ApiErrorResponse {
+  try {
+    const hasErrorsArray =
+      'errors' in error &&
+      Array.isArray(error.errors) &&
+      error.errors.length > 0
+    const errorsHaveApiErrorShape = (error as ApiErrorResponse).errors.every(
+      (err) => 'title' in err && 'detail' in err && 'code' in err
+    )
+    return hasErrorsArray && errorsHaveApiErrorShape
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Guesses the field name from the error source pointer (if available).
+ * Example: "/data/attributes/quantity" -> "quantity"
+ * Otherwise, guesses the field name from the error detail.
+ * Example: "quantity - must be less than or equal to 10" -> "quantity"
+ */
+function guessField(item: ApiError): string | undefined {
+  if (item.source?.pointer != null && item.source?.pointer !== '') {
+    const field = item.source?.pointer.split('/').at(-1)
+    return field
+  }
+
+  if (item.detail != null && item.detail !== '') {
+    const field = item.detail.split(' - ').at(0)
+    return field
+  }
+}
+
+export const API_ERROR_FIELD_NAME = 'root.apiError'
+
+export function setApiFormErrors({
+  apiError,
+  setError,
+  fieldMap
+}: {
+  /**
+   * Error response from API
+   */
+  apiError: any
+  /**
+   * setError function from react-hook-form, it comes from same useForm() context
+   */
+  setError: UseFormSetError<any>
+  /**
+   * Map of field names from API to field names in the form
+   */
+  fieldMap?: Record<string, string>
+}): void {
+  const { errors } = isApiError(apiError) ? apiError : genericError
+
+  const errorByTypes = errors.reduce(
+    (allErrors, item) => {
+      const guessedField = guessField(item)
+      const field =
+        guessedField != null
+          ? fieldMap?.[guessedField] ?? guessedField
+          : undefined
+
+      if (item.code === 'VALIDATION_ERROR' && field != null) {
+        return {
+          ...allErrors,
+          validation: [
+            ...allErrors.validation,
+            {
+              field,
+              message: item.title
+            }
+          ]
+        }
+      }
+
+      return {
+        ...allErrors,
+        others: [...allErrors.others, item.detail]
+      }
+    },
+    {
+      validation: [] as Array<{ field: string; message: string }>,
+      others: [] as string[]
+    }
+  )
+
+  errorByTypes.validation.forEach((error, idx) => {
+    setError(
+      error.field,
+      {
+        type: 'serverValidation',
+        message: error.message
+      },
+      {
+        shouldFocus: idx === 0
+      }
+    )
+  })
+
+  if (errorByTypes.others.length > 0) {
+    setError(API_ERROR_FIELD_NAME, {
+      type: 'server',
+      message: errorByTypes.others.join('. ')
+    })
+  }
+}

--- a/packages/app-elements-hook-form/src/main.ts
+++ b/packages/app-elements-hook-form/src/main.ts
@@ -1,4 +1,5 @@
 export { Form } from '#components/Form'
+export { ValidationApiError } from '#components/ValidationApiError'
 export { ValidationError } from '#components/ValidationError'
 
 export { Input } from '#components/Input'

--- a/packages/app-elements-hook-form/tsconfig.json
+++ b/packages/app-elements-hook-form/tsconfig.json
@@ -27,6 +27,9 @@
     "paths": {
       "#components/*": [
         "src/components/*"
+      ],
+      "#helpers/*": [
+        "src/helpers/*"
       ]
     }
   },

--- a/packages/app-elements-hook-form/vite.config.ts
+++ b/packages/app-elements-hook-form/vite.config.ts
@@ -43,7 +43,8 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '#components': resolve(__dirname, './src/components')
+      '#components': resolve(__dirname, './src/components'),
+      '#helpers': resolve(__dirname, './src/helpers')
     }
   },
   test: {


### PR DESCRIPTION
This component is intended to be used inside a `react-hook-form` context

Example:
```
// For simplicity we assume all the form submission logic to be contained in a custom hook
// but his could be a generic "onSubmitHander()" and a manual  "const [ error,setError] = useState()"
const { submit, apiError } = usePostToServer()  

<Form>
  <ValidationApiError apiError={apiError} />
  <Button type='submit'>Save</Button>
</Form>
```

When `apiError` is set, the object will be iterated and:
- for matched form field names, it will set the error message for that specific registered field 
- error messages for not matched field names will be rendered when the component is mounted

It is also possible to configure a custom field mapping in case the fields name in the app don't match the server response:
```
<ValidationApiError apiError={errors} fieldMap={{ first_name: 'myCustomFieldName' }} />
```
