### PR TITLE
Update `Timeline` component

### DIFF
--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -14,7 +14,10 @@ export interface TimelineEvent {
   note?: string
 }
 
+type Position = 'first' | 'other'
+
 type EventWithIcon = TimelineEvent & {
+  position: Position
   icon: JSX.Element
 }
 
@@ -29,7 +32,13 @@ export const Timeline = withSkeletonTemplate<Props>(
     const groupedEvents = useMemo(() => {
       const ordered: EventWithIcon[] = orderBy(events, 'date', 'desc').map(
         (event, index, arr) => {
-          return { ...event, icon: getIcon(event, index, arr) }
+          const position: Position =
+            index === events.length - 1 ? 'first' : 'other'
+          return {
+            ...event,
+            position,
+            icon: getIcon(event, position)
+          }
         }
       )
       return groupBy(ordered, (val) =>
@@ -62,7 +71,13 @@ export const Timeline = withSkeletonTemplate<Props>(
               {eventsByDate.map((event) => (
                 <Fragment key={event.date}>
                   <div className='flex gap-2 mt-6 items-center'>
-                    <div className='relative -left-[13px] self-start'>
+                    <div
+                      className={`relative -left-[13px] ${
+                        event.position === 'first'
+                          ? 'self-stretch bg-white'
+                          : 'self-start'
+                      }`}
+                    >
                       <div
                         data-test-id='timeline-event-icon'
                         className='bg-white py-1'
@@ -97,18 +112,12 @@ export const Timeline = withSkeletonTemplate<Props>(
   }
 )
 
-function getIcon(
-  event: TimelineEvent,
-  index: number,
-  events: TimelineEvent[]
-): JSX.Element {
-  const isFirst = index === events.length - 1
-
+function getIcon(event: TimelineEvent, position: Position): JSX.Element {
   if (event.note != null) {
     return <Icon name='chatCircle' background='black' gap='small' />
   }
 
-  return isFirst ? (
+  return position === 'first' ? (
     <Icon name='flag' background='black' gap='small' />
   ) : (
     <Icon

--- a/packages/docs/src/stories/composite/Timeline.stories.tsx
+++ b/packages/docs/src/stories/composite/Timeline.stories.tsx
@@ -31,15 +31,45 @@ Default.args = {
           month: 11,
           date: 29,
           minutes: 23,
-          seconds: 12
+          seconds: 10
         }),
         { years: 1 }
       ).toJSON(),
       message: (
         <span>
-          <Text weight='bold'>M. Jordan</Text> placed this order · 23:12
+          Text in two lines.
+          <br />I should not see the border on my left · 23:10
         </span>
       )
+    },
+    {
+      date: sub(
+        set(new Date(), {
+          month: 11,
+          date: 29,
+          minutes: 23,
+          seconds: 11
+        }),
+        { years: 1 }
+      ).toJSON(),
+      message: (
+        <span>
+          Text in two lines.
+          <br />I should see the border on my left · 23:11
+        </span>
+      )
+    },
+    {
+      date: sub(
+        set(new Date(), {
+          month: 11,
+          date: 29,
+          minutes: 23,
+          seconds: 12
+        }),
+        { years: 1 }
+      ).toJSON(),
+      message: `Placed · 23:12`
     },
     {
       date: set(new Date(), {
@@ -96,7 +126,7 @@ Default.args = {
         month: 0,
         date: 3,
         minutes: 8,
-        seconds: 35
+        seconds: 36
       }).toJSON(),
       message: (
         <span>


### PR DESCRIPTION
Few small changes to the `Timeline` component:

1. Set full width to the timeline note when the note contains a short text.
2. Remove the border left from the first event.

<img width="500" alt="Screenshot 2023-05-03 alle 11 46 32" src="https://user-images.githubusercontent.com/1681269/235883926-45b7ad9d-2cde-48ff-bbae-c46c3db0e8ec.png">