### PR TITLE
Add `Grid` component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -28,6 +28,7 @@ export {
   DropdownMenuItem
 } from '#ui/atoms/dropdown'
 export { EmptyState } from '#ui/atoms/EmptyState'
+export { Grid } from '#ui/atoms/Grid'
 export { Hint } from '#ui/atoms/Hint'
 export { Icon } from '#ui/atoms/Icon'
 export { Legend } from '#ui/atoms/Legend'

--- a/packages/app-elements/src/ui/atoms/Grid.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Grid.test.tsx
@@ -1,0 +1,17 @@
+import { render } from '@testing-library/react'
+import { Grid } from './Grid'
+
+describe('Grid', () => {
+  test('renders', () => {
+    const { container } = render(
+      <Grid columns='2'>
+        <div>item1</div>
+        <div>item2</div>
+        <div>item3</div>
+        <div>item4</div>
+      </Grid>
+    )
+
+    expect(container).toBeVisible()
+  })
+})

--- a/packages/app-elements/src/ui/atoms/Grid.tsx
+++ b/packages/app-elements/src/ui/atoms/Grid.tsx
@@ -1,0 +1,30 @@
+import cn from 'classnames'
+import { type ReactNode } from 'react'
+import React from 'react'
+
+interface GridProps
+  extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  children: ReactNode
+  columns: '1' | '2'
+}
+
+function Grid({
+  children,
+  columns,
+  className,
+  ...rest
+}: GridProps): JSX.Element {
+  return (
+    <div
+      className={cn('grid grid-cols-1 gap-4', className, {
+        'sm:grid-cols-2': columns === '2'
+      })}
+      {...rest}
+    >
+      {children}
+    </div>
+  )
+}
+
+Grid.displayName = 'Grid'
+export { Grid }

--- a/packages/docs/src/stories/atoms/Grid.stories.tsx
+++ b/packages/docs/src/stories/atoms/Grid.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Grid } from '#ui/atoms/Grid'
+
+const meta: Meta<typeof Grid> = {
+  title: 'Atoms/Grid',
+  component: Grid,
+  parameters: {
+    layout: 'padded'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof Grid>
+
+export const Primary: Story = {
+  args: {
+    columns: '2',
+    children: (
+      <>
+        <div>grid item #1</div>
+        <div>grid item #2</div>
+        <div>grid item #3</div>
+        <div>grid item #4</div>
+        <div>grid item #5</div>
+      </>
+    )
+  }
+}


### PR DESCRIPTION
Add new responsive `Grid` component that now supports only 2 columns layout.

Example:
```jsx
<Grid columns='2'>
  <FieldCity />
  <Grid columns='2'>
      <FieldZip />
      <FieldCity />
  </Grid>
</Grid>
```

will render this:
<img width="586" alt="image" src="https://user-images.githubusercontent.com/30926550/235883988-fd7d6389-1c26-4084-9aa3-092abb0efb7a.png">

that will stack on small screen:
<img width="359" alt="image" src="https://user-images.githubusercontent.com/30926550/235884115-476e0c84-8c8e-435f-82ed-1d1a9074bb78.png">

