### PR TITLE
`displayName` and `fullName` should compute to undefined instead of empty string

### DIFF
--- a/packages/app-elements/src/helpers/name.test.ts
+++ b/packages/app-elements/src/helpers/name.test.ts
@@ -1,6 +1,10 @@
 import { computeFullname, formatDisplayName } from './name'
 
 describe('formatDisplayName', () => {
+  test('should return undefined if both first and last name are undefined', () => {
+    expect(formatDisplayName(undefined, undefined)).toBe(undefined)
+  })
+
   test('should return empty string if both first and last name are empty', () => {
     expect(formatDisplayName('', '')).toBe('')
   })
@@ -35,6 +39,6 @@ describe('computeFullname', () => {
   test('should allow undefined values', () => {
     expect(computeFullname(undefined, 'Reed')).toBe('Reed')
     expect(computeFullname('John')).toBe('John')
-    expect(computeFullname()).toBe('')
+    expect(computeFullname()).toBe(undefined)
   })
 })

--- a/packages/app-elements/src/helpers/name.ts
+++ b/packages/app-elements/src/helpers/name.ts
@@ -7,7 +7,11 @@ import isEmpty from 'lodash/isEmpty'
 export function formatDisplayName(
   firstName?: string,
   lastName?: string
-): string {
+): string | undefined {
+  if (firstName == null && lastName == null) {
+    return firstName
+  }
+
   if (isEmpty(firstName) && isEmpty(lastName)) {
     return ''
   }
@@ -30,6 +34,13 @@ export function formatDisplayName(
 /**
  *
  */
-export function computeFullname(firstName?: string, lastName?: string): string {
+export function computeFullname(
+  firstName?: string,
+  lastName?: string
+): string | undefined {
+  if (firstName == null && lastName == null) {
+    return firstName
+  }
+
   return `${firstName ?? ''} ${lastName ?? ''}`.trim()
 }


### PR DESCRIPTION
This is to avoid inconsistency with the other user fields:

<img width="181" alt="Screenshot 2023-05-04 alle 14 32 41" src="https://user-images.githubusercontent.com/1681269/236205139-25793040-6116-45b1-9edc-129ff9d83e1a.png">
