### PR TITLE
Update ts `paths` on docs package

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
   // this ensure ESLint autofix all issue (formatting is done by prettier loaded as eslint rules)
   "editor.codeActionsOnSave": {
     "source.fixAll": true,
+    "source.organizeImports": true
   },
   // be sure vscode always uses TS version in local project
   "typescript.tsdk": "node_modules/typescript/lib",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,7 +13,6 @@
     "pnpm": ">=7"
   },
   "dependencies": {
-    "@commercelayer/app-elements": "workspace:^0.0.28",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/docs/src/stories/atoms/A.stories.tsx
+++ b/packages/docs/src/stories/atoms/A.stories.tsx
@@ -1,15 +1,13 @@
 import { A } from '#ui/atoms/A'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof A> = {
+const setup: Meta<typeof A> = {
   title: 'Atoms/A',
   component: A
 }
 export default setup
 
-const Template: ComponentStory<typeof A> = (args) => (
-  <A {...args}>I am a link</A>
-)
+const Template: StoryFn<typeof A> = (args) => <A {...args}>I am a link</A>
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/atoms/Badge.stories.tsx
+++ b/packages/docs/src/stories/atoms/Badge.stories.tsx
@@ -1,13 +1,13 @@
 import { Badge } from '#ui/atoms/Badge'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Badge> = {
+const setup: Meta<typeof Badge> = {
   title: 'Atoms/Badge',
   component: Badge
 }
 export default setup
 
-const Template: ComponentStory<typeof Badge> = (args) => <Badge {...args} />
+const Template: StoryFn<typeof Badge> = (args) => <Badge {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {

--- a/packages/docs/src/stories/atoms/BlockCode.stories.tsx
+++ b/packages/docs/src/stories/atoms/BlockCode.stories.tsx
@@ -1,15 +1,13 @@
 import { BlockCode } from '#ui/atoms/BlockCode'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof BlockCode> = {
+const setup: Meta<typeof BlockCode> = {
   title: 'Atoms/BlockCode',
   component: BlockCode
 }
 export default setup
 
-const Template: ComponentStory<typeof BlockCode> = (args) => (
-  <BlockCode {...args} />
-)
+const Template: StoryFn<typeof BlockCode> = (args) => <BlockCode {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -1,13 +1,13 @@
 import { Button } from '#ui/atoms/Button'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Button> = {
+const setup: Meta<typeof Button> = {
   title: 'Atoms/Button',
   component: Button
 }
 export default setup
 
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />
+const Template: StoryFn<typeof Button> = (args) => <Button {...args} />
 
 export const Primary = Template.bind({})
 Primary.args = {

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -1,13 +1,13 @@
 import { Card } from '#ui/atoms/Card'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Card> = {
+const setup: Meta<typeof Card> = {
   title: 'Atoms/Card',
   component: Card
 }
 export default setup
 
-const Template: ComponentStory<typeof Card> = (args) => (
+const Template: StoryFn<typeof Card> = (args) => (
   <Card {...args}>
     <p>
       <strong>I am a card</strong>

--- a/packages/docs/src/stories/atoms/Container.stories.tsx
+++ b/packages/docs/src/stories/atoms/Container.stories.tsx
@@ -1,7 +1,7 @@
 import { Container } from '#ui/atoms/Container'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Container> = {
+const setup: Meta<typeof Container> = {
   title: 'Atoms/Container',
   component: Container,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof Container> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Container> = (args) => (
+const Template: StoryFn<typeof Container> = (args) => (
   <Container {...args}>I'm a container</Container>
 )
 

--- a/packages/docs/src/stories/atoms/CopyToClipboard.stories.tsx
+++ b/packages/docs/src/stories/atoms/CopyToClipboard.stories.tsx
@@ -1,7 +1,7 @@
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof CopyToClipboard> = {
+const setup: Meta<typeof CopyToClipboard> = {
   title: 'Atoms/CopyToClipboard',
   component: CopyToClipboard,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof CopyToClipboard> = {
 }
 export default setup
 
-const TemplateDefault: ComponentStory<typeof CopyToClipboard> = (args) => (
+const TemplateDefault: StoryFn<typeof CopyToClipboard> = (args) => (
   <CopyToClipboard {...args} />
 )
 export const Default = TemplateDefault.bind({})
@@ -18,7 +18,7 @@ Default.args = {
   value: 'BEANIEXXFFFFFF000000XXXX'
 }
 
-const TemplateStacked: ComponentStory<typeof CopyToClipboard> = (args) => (
+const TemplateStacked: StoryFn<typeof CopyToClipboard> = (args) => (
   <>
     <CopyToClipboard {...args} />
     <CopyToClipboard value='Soft double-layered customizable beanie. 95% polyester, 5% spandex. Regular fit. Accurately printed, cut, and hand-sewn.' />
@@ -31,7 +31,7 @@ Stacked.args = {
   value: 'BEANIEXXFFFFFF000000XXXX'
 }
 
-const TemplateEmpty: ComponentStory<typeof CopyToClipboard> = (args) => (
+const TemplateEmpty: StoryFn<typeof CopyToClipboard> = (args) => (
   <>
     <CopyToClipboard {...args} />
     <CopyToClipboard {...args} />

--- a/packages/docs/src/stories/atoms/DropdownMenu.stories.tsx
+++ b/packages/docs/src/stories/atoms/DropdownMenu.stories.tsx
@@ -3,15 +3,15 @@ import {
   DropdownMenuDivider,
   DropdownMenuItem
 } from '#ui/atoms/dropdown'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof DropdownMenu> = {
+const setup: Meta<typeof DropdownMenu> = {
   title: 'Atoms/DropdownMenu',
   component: DropdownMenu
 }
 export default setup
 
-const Template: ComponentStory<typeof DropdownMenu> = (args) => (
+const Template: StoryFn<typeof DropdownMenu> = (args) => (
   <DropdownMenu {...args}>
     <DropdownMenuItem label='Edit' />
     <DropdownMenuDivider />

--- a/packages/docs/src/stories/atoms/EmptyState.stories.tsx
+++ b/packages/docs/src/stories/atoms/EmptyState.stories.tsx
@@ -1,9 +1,9 @@
 import { A } from '#ui/atoms/A'
 import { Button } from '#ui/atoms/Button'
 import { EmptyState } from '#ui/atoms/EmptyState'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof EmptyState> = {
+const setup: Meta<typeof EmptyState> = {
   title: 'Atoms/EmptyState',
   component: EmptyState,
   parameters: {
@@ -12,9 +12,7 @@ const setup: ComponentMeta<typeof EmptyState> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof EmptyState> = (args) => (
-  <EmptyState {...args} />
-)
+const Template: StoryFn<typeof EmptyState> = (args) => <EmptyState {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -23,7 +21,7 @@ Default.args = {
   action: <Button variant='primary'>New import</Button>
 }
 
-const TemplateWithIcon: ComponentStory<typeof EmptyState> = (args) => (
+const TemplateWithIcon: StoryFn<typeof EmptyState> = (args) => (
   <EmptyState {...args} />
 )
 export const WithIcon = TemplateWithIcon.bind({})

--- a/packages/docs/src/stories/atoms/Hint.stories.tsx
+++ b/packages/docs/src/stories/atoms/Hint.stories.tsx
@@ -1,14 +1,14 @@
 import { A } from '#ui/atoms/A'
 import { Hint } from '#ui/atoms/Hint'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Hint> = {
+const setup: Meta<typeof Hint> = {
   title: 'Atoms/Hint',
   component: Hint
 }
 export default setup
 
-const Template: ComponentStory<typeof Hint> = (args) => <Hint {...args} />
+const Template: StoryFn<typeof Hint> = (args) => <Hint {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/atoms/Icon.stories.tsx
+++ b/packages/docs/src/stories/atoms/Icon.stories.tsx
@@ -1,7 +1,7 @@
 import { Icon } from '#ui/atoms/Icon'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Icon> = {
+const setup: Meta<typeof Icon> = {
   title: 'Atoms/Icon',
   component: Icon,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof Icon> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Icon> = (args) => <Icon {...args} />
+const Template: StoryFn<typeof Icon> = (args) => <Icon {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -30,11 +30,4 @@ FilterView.args = {
   name: 'eye',
   background: 'teal',
   gap: 'small'
-}
-
-export const CustomSize = Template.bind({})
-CustomSize.args = {
-  name: 'arrowClockwise',
-  background: 'none',
-  size: '5rem'
 }

--- a/packages/docs/src/stories/atoms/Legend.stories.tsx
+++ b/packages/docs/src/stories/atoms/Legend.stories.tsx
@@ -1,8 +1,8 @@
 import { A } from '#ui/atoms/A'
 import { Legend } from '#ui/atoms/Legend'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Legend> = {
+const setup: Meta<typeof Legend> = {
   title: 'Atoms/Legend',
   component: Legend,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof Legend> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Legend> = (args) => <Legend {...args} />
+const Template: StoryFn<typeof Legend> = (args) => <Legend {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/atoms/PageHeading.stories.tsx
+++ b/packages/docs/src/stories/atoms/PageHeading.stories.tsx
@@ -1,8 +1,8 @@
 import { A } from '#ui/atoms/A'
 import { PageHeading } from '#ui/atoms/PageHeading'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof PageHeading> = {
+const setup: Meta<typeof PageHeading> = {
   title: 'Atoms/PageHeading',
   component: PageHeading,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof PageHeading> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof PageHeading> = (args) => (
+const Template: StoryFn<typeof PageHeading> = (args) => (
   <PageHeading {...args} actionButton={<A>Edit</A>} />
 )
 

--- a/packages/docs/src/stories/atoms/Pagination.stories.tsx
+++ b/packages/docs/src/stories/atoms/Pagination.stories.tsx
@@ -1,16 +1,14 @@
 import { Pagination } from '#ui/atoms/Pagination'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof Pagination> = {
+const setup: Meta<typeof Pagination> = {
   title: 'Atoms/Pagination',
   component: Pagination
 }
 export default setup
 
-const Template: ComponentStory<typeof Pagination> = (args) => (
-  <Pagination {...args} />
-)
+const Template: StoryFn<typeof Pagination> = (args) => <Pagination {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
@@ -20,9 +18,7 @@ Default.args = {
   pageCount: 10
 }
 
-const TemplateWithFullPageChange: ComponentStory<typeof Pagination> = (
-  args
-) => {
+const TemplateWithFullPageChange: StoryFn<typeof Pagination> = (args) => {
   const [currentPage, setPage] = useState(1)
   return (
     <Pagination

--- a/packages/docs/src/stories/atoms/RadialProgress.stories.tsx
+++ b/packages/docs/src/stories/atoms/RadialProgress.stories.tsx
@@ -1,7 +1,7 @@
 import { RadialProgress } from '#ui/atoms/RadialProgress'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof RadialProgress> = {
+const setup: Meta<typeof RadialProgress> = {
   title: 'Atoms/RadialProgress',
   component: RadialProgress,
   argTypes: {
@@ -12,7 +12,7 @@ const setup: ComponentMeta<typeof RadialProgress> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof RadialProgress> = (args) => (
+const Template: StoryFn<typeof RadialProgress> = (args) => (
   <RadialProgress {...args} />
 )
 

--- a/packages/docs/src/stories/atoms/Skeleton.stories.tsx
+++ b/packages/docs/src/stories/atoms/Skeleton.stories.tsx
@@ -1,8 +1,8 @@
 import { Skeleton, SkeletonItem } from '#ui/atoms/Skeleton'
 import { Spacer } from '#ui/atoms/Spacer'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Skeleton> = {
+const setup: Meta<typeof Skeleton> = {
   title: 'Atoms/Skeleton',
   component: Skeleton,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof Skeleton> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Skeleton> = (args) => (
+const Template: StoryFn<typeof Skeleton> = (args) => (
   <Skeleton {...args}>
     <Spacer bottom='4'>
       <SkeletonItem type='box' height='2rem' />

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -1,16 +1,16 @@
-import { Avatar } from '#app-elements/atoms/Avatar'
-import { Badge } from '#app-elements/atoms/Badge'
-import { Button } from '#app-elements/atoms/Button'
-import { Icon } from '#app-elements/atoms/Icon'
-import { RadialProgress } from '#app-elements/atoms/RadialProgress'
-import { Text } from '#app-elements/atoms/Text'
-import { ListItem } from '#app-elements/lists/ListItem'
+import { Avatar } from '#ui/atoms/Avatar'
+import { Badge } from '#ui/atoms/Badge'
+import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
+import { RadialProgress } from '#ui/atoms/RadialProgress'
 import {
   SkeletonTemplate,
   withSkeletonTemplate
 } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { Text } from '#ui/atoms/Text'
+import { ListItem } from '#ui/lists/ListItem'
+import { type Meta, type StoryFn } from '@storybook/react'
 import {
   cloneElement,
   createElement,
@@ -19,7 +19,7 @@ import {
   type ReactNode
 } from 'react'
 
-const setup: ComponentMeta<typeof SkeletonTemplate> = {
+const setup: Meta<typeof SkeletonTemplate> = {
   title: 'Atoms/SkeletonTemplate',
   component: SkeletonTemplate,
   parameters: {
@@ -113,10 +113,7 @@ const children = (
   </>
 )
 
-const Template: ComponentStory<typeof SkeletonTemplate> = ({
-  children,
-  ...args
-}) => (
+const Template: StoryFn<typeof SkeletonTemplate> = ({ children, ...args }) => (
   <>
     <div className='flex gap-2 mb-8'>
       <SkeletonTemplate {...args}>

--- a/packages/docs/src/stories/atoms/Spacer.stories.tsx
+++ b/packages/docs/src/stories/atoms/Spacer.stories.tsx
@@ -1,13 +1,13 @@
 import { Spacer } from '#ui/atoms/Spacer'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Spacer> = {
+const setup: Meta<typeof Spacer> = {
   title: 'Atoms/Spacer',
   component: Spacer
 }
 export default setup
 
-const Template: ComponentStory<typeof Spacer> = (args) => <Spacer {...args} />
+const Template: StoryFn<typeof Spacer> = (args) => <Spacer {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/atoms/Stack.stories.tsx
+++ b/packages/docs/src/stories/atoms/Stack.stories.tsx
@@ -1,11 +1,11 @@
-import { A } from '#app-elements/atoms/A'
-import { Badge } from '#app-elements/atoms/Badge'
-import { Spacer } from '#app-elements/atoms/Spacer'
-import { Text } from '#app-elements/atoms/Text'
+import { A } from '#ui/atoms/A'
+import { Badge } from '#ui/atoms/Badge'
+import { Spacer } from '#ui/atoms/Spacer'
 import { Stack } from '#ui/atoms/Stack'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { Text } from '#ui/atoms/Text'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Stack> = {
+const setup: Meta<typeof Stack> = {
   title: 'Atoms/Stack',
   component: Stack,
   parameters: {
@@ -14,7 +14,7 @@ const setup: ComponentMeta<typeof Stack> = {
 }
 export default setup
 
-export const Default: ComponentStory<typeof Stack> = (args) => (
+export const Default: StoryFn<typeof Stack> = (args) => (
   <Stack {...args}>
     <div>Element 1</div>
     <div>Element 2</div>
@@ -23,7 +23,7 @@ export const Default: ComponentStory<typeof Stack> = (args) => (
 )
 Default.args = {}
 
-export const Steps: ComponentStory<typeof Stack> = (args) => (
+export const Steps: StoryFn<typeof Stack> = (args) => (
   <Stack {...args}>
     <div>
       <Spacer bottom='2'>
@@ -53,7 +53,7 @@ export const Steps: ComponentStory<typeof Stack> = (args) => (
 )
 Steps.args = {}
 
-export const Addresses: ComponentStory<typeof Stack> = (args) => (
+export const Addresses: StoryFn<typeof Stack> = (args) => (
   <Stack {...args}>
     <div>
       <Spacer bottom='2'>

--- a/packages/docs/src/stories/atoms/StatusDot.stories.tsx
+++ b/packages/docs/src/stories/atoms/StatusDot.stories.tsx
@@ -1,15 +1,13 @@
 import { StatusDot } from '#ui/atoms/StatusDot'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof StatusDot> = {
+const setup: Meta<typeof StatusDot> = {
   title: 'Atoms/StatusDot',
   component: StatusDot
 }
 export default setup
 
-const Template: ComponentStory<typeof StatusDot> = (args) => (
-  <StatusDot {...args} />
-)
+const Template: StoryFn<typeof StatusDot> = (args) => <StatusDot {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/atoms/Tabs.stories.tsx
+++ b/packages/docs/src/stories/atoms/Tabs.stories.tsx
@@ -1,7 +1,7 @@
 import { Tab, Tabs } from '#ui/atoms/Tabs'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Tabs> = {
+const setup: Meta<typeof Tabs> = {
   title: 'Atoms/Tabs',
   component: Tabs,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof Tabs> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Tabs> = (args) => (
+const Template: StoryFn<typeof Tabs> = (args) => (
   <Tabs {...args}>
     <Tab name='Filters'>
       <div>Content for first tab</div>

--- a/packages/docs/src/stories/atoms/Text.stories.tsx
+++ b/packages/docs/src/stories/atoms/Text.stories.tsx
@@ -1,7 +1,7 @@
 import { Text } from '#ui/atoms/Text'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Text> = {
+const setup: Meta<typeof Text> = {
   title: 'Atoms/Text',
   component: Text,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof Text> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Text> = (args) => <Text {...args} />
+const Template: StoryFn<typeof Text> = (args) => <Text {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/composite/ContextMenu.stories.tsx
+++ b/packages/docs/src/stories/composite/ContextMenu.stories.tsx
@@ -1,14 +1,14 @@
 import { DropdownMenuDivider, DropdownMenuItem } from '#ui/atoms/dropdown'
 import { ContextMenu } from '#ui/composite/ContextMenu'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof ContextMenu> = {
+const setup: Meta<typeof ContextMenu> = {
   title: 'Composite/ContextMenu',
   component: ContextMenu
 }
 export default setup
 
-const Template: ComponentStory<typeof ContextMenu> = (args) => {
+const Template: StoryFn<typeof ContextMenu> = (args) => {
   return <ContextMenu {...args} />
 }
 

--- a/packages/docs/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/docs/src/stories/composite/PageLayout.stories.tsx
@@ -1,9 +1,9 @@
 import { A } from '#ui/atoms/A'
 import { PageLayout } from '#ui/composite/PageLayout'
 
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof PageLayout> = {
+const setup: Meta<typeof PageLayout> = {
   title: 'Composite/PageLayout',
   component: PageLayout,
   parameters: {
@@ -12,7 +12,7 @@ const setup: ComponentMeta<typeof PageLayout> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof PageLayout> = (args) => (
+const Template: StoryFn<typeof PageLayout> = (args) => (
   <PageLayout {...args}>Page content here...</PageLayout>
 )
 

--- a/packages/docs/src/stories/composite/Report.stories.tsx
+++ b/packages/docs/src/stories/composite/Report.stories.tsx
@@ -1,8 +1,8 @@
 import { Report } from '#ui/composite/Report'
 
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Report> = {
+const setup: Meta<typeof Report> = {
   title: 'Composite/Report',
   component: Report,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof Report> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Report> = (args) => <Report {...args} />
+const Template: StoryFn<typeof Report> = (args) => <Report {...args} />
 
 export const Default = Template.bind({})
 Default.args = {

--- a/packages/docs/src/stories/composite/Timeline.stories.tsx
+++ b/packages/docs/src/stories/composite/Timeline.stories.tsx
@@ -1,4 +1,4 @@
-import { Text } from '#app-elements/atoms/Text'
+import { Text } from '#ui/atoms/Text'
 import { Timeline } from '#ui/composite/Timeline'
 
 import { type Meta, type StoryFn } from '@storybook/react'

--- a/packages/docs/src/stories/examples/ListResources.stories.tsx
+++ b/packages/docs/src/stories/examples/ListResources.stories.tsx
@@ -4,7 +4,7 @@ import { Text } from '#ui/atoms/Text'
 import { PageLayout } from '#ui/composite/PageLayout'
 import { List } from '#ui/lists/List'
 import { ListItem } from '#ui/lists/ListItem'
-import { type ComponentStory, type Meta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta = {
   title: 'Examples/List Resources',
@@ -14,7 +14,7 @@ const setup: Meta = {
 }
 export default setup
 
-const Template: ComponentStory<typeof List> = (args) => (
+const Template: StoryFn<typeof List> = (args) => (
   <PageLayout
     title='Resources'
     onGoBack={() => {

--- a/packages/docs/src/stories/examples/ListSkus.stories.tsx
+++ b/packages/docs/src/stories/examples/ListSkus.stories.tsx
@@ -1,10 +1,10 @@
-import { PageLayout } from '#app-elements/composite/PageLayout'
 import { Icon } from '#ui/atoms/Icon'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
+import { PageLayout } from '#ui/composite/PageLayout'
 import { List } from '#ui/lists/List'
 import { ListItem } from '#ui/lists/ListItem'
-import { type ComponentStory, type Meta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta = {
   title: 'Examples/List SKUs',
@@ -14,7 +14,7 @@ const setup: Meta = {
 }
 export default setup
 
-const Template: ComponentStory<typeof List> = (args) => (
+const Template: StoryFn<typeof List> = (args) => (
   <PageLayout
     title='SKUs'
     onGoBack={() => {

--- a/packages/docs/src/stories/examples/ListTasks.stories.tsx
+++ b/packages/docs/src/stories/examples/ListTasks.stories.tsx
@@ -1,13 +1,13 @@
 import { A } from '#ui/atoms/A'
-import { Text } from '#ui/atoms/Text'
 import { Button } from '#ui/atoms/Button'
-import { type ComponentStory, type Meta } from '@storybook/react'
 import { Icon } from '#ui/atoms/Icon'
-import { List } from '#ui/lists/List'
-import { ListItem } from '#ui/lists/ListItem'
-import { PageLayout } from '#ui/composite/PageLayout'
 import { RadialProgress } from '#ui/atoms/RadialProgress'
 import { Spacer } from '#ui/atoms/Spacer'
+import { Text } from '#ui/atoms/Text'
+import { PageLayout } from '#ui/composite/PageLayout'
+import { List } from '#ui/lists/List'
+import { ListItem } from '#ui/lists/ListItem'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
 const setup: Meta = {
@@ -18,7 +18,7 @@ const setup: Meta = {
 }
 export default setup
 
-export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => {
+export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
   const [currentPage, setCurrentPage] = useState(1)
 
   return (

--- a/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
@@ -1,10 +1,10 @@
-import { A } from '#app-elements/atoms/A'
-import { Legend } from '#app-elements/atoms/Legend'
-import { Stack } from '#app-elements/atoms/Stack'
+import { A } from '#ui/atoms/A'
+import { Legend } from '#ui/atoms/Legend'
 import { Spacer } from '#ui/atoms/Spacer'
+import { Stack } from '#ui/atoms/Stack'
 import { Text } from '#ui/atoms/Text'
 import { type ListItem } from '#ui/lists/ListItem'
-import { type ComponentStory, type Meta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta = {
   title: 'Examples/Order Addresses',
@@ -14,7 +14,7 @@ const setup: Meta = {
 }
 export default setup
 
-export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => (
+export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
   <>
     <Legend title='Addresses' border='none' />
     <Stack>

--- a/packages/docs/src/stories/examples/OrderHistory.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderHistory.stories.tsx
@@ -3,7 +3,7 @@ import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
 import { List } from '#ui/lists/List'
 import { ListItem } from '#ui/lists/ListItem'
-import { type ComponentStory, type Meta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta = {
   title: 'Examples/Order History',
@@ -13,7 +13,7 @@ const setup: Meta = {
 }
 export default setup
 
-export const Default: ComponentStory<typeof ListItem> = (args): JSX.Element => (
+export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
   <Spacer bottom='14'>
     <List title='Results · 13,765'>
       <ListItem

--- a/packages/docs/src/stories/forms/Input.stories.tsx
+++ b/packages/docs/src/stories/forms/Input.stories.tsx
@@ -1,8 +1,8 @@
 import { Input } from '#ui/forms/Input'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof Input> = {
+const setup: Meta<typeof Input> = {
   title: 'Forms/Input',
   component: Input,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof Input> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Input> = (args) => {
+const Template: StoryFn<typeof Input> = (args) => {
   return <Input {...args} value={args.value} type={args.type} />
 }
 
@@ -44,7 +44,7 @@ WithError.args = {
   }
 }
 
-const TemplateValidation: ComponentStory<typeof Input> = () => {
+const TemplateValidation: StoryFn<typeof Input> = () => {
   const [value, setValue] = useState('')
 
   return (

--- a/packages/docs/src/stories/forms/InputDate.stories.tsx
+++ b/packages/docs/src/stories/forms/InputDate.stories.tsx
@@ -1,8 +1,8 @@
 import { InputDate } from '#ui/forms/InputDate'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof InputDate> = {
+const setup: Meta<typeof InputDate> = {
   title: 'Forms/InputDate',
   component: InputDate,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof InputDate> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputDate> = (args) => {
+const Template: StoryFn<typeof InputDate> = (args) => {
   const [date, setDate] = useState<Date | null>(null)
   return <InputDate {...args} value={date} onChange={setDate} />
 }

--- a/packages/docs/src/stories/forms/InputDateRange.stories.tsx
+++ b/packages/docs/src/stories/forms/InputDateRange.stories.tsx
@@ -1,8 +1,8 @@
 import { InputDateRange } from '#ui/forms/InputDateRange'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof InputDateRange> = {
+const setup: Meta<typeof InputDateRange> = {
   title: 'Forms/InputDateRange',
   component: InputDateRange,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof InputDateRange> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputDateRange> = (args) => {
+const Template: StoryFn<typeof InputDateRange> = (args) => {
   const [fromDate, setFromDate] = useState<Date | null>(null)
   const [toDate, setToDate] = useState<Date | null>(null)
 

--- a/packages/docs/src/stories/forms/InputFeedback.stories.tsx
+++ b/packages/docs/src/stories/forms/InputFeedback.stories.tsx
@@ -1,13 +1,13 @@
 import { InputFeedback } from '#ui/forms/InputFeedback'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof InputFeedback> = {
+const setup: Meta<typeof InputFeedback> = {
   title: 'Forms/InputFeedback',
   component: InputFeedback
 }
 export default setup
 
-const Template: ComponentStory<typeof InputFeedback> = (args) => (
+const Template: StoryFn<typeof InputFeedback> = (args) => (
   <InputFeedback {...args} />
 )
 

--- a/packages/docs/src/stories/forms/InputFile.stories.tsx
+++ b/packages/docs/src/stories/forms/InputFile.stories.tsx
@@ -1,8 +1,8 @@
 import { InputFile } from '#ui/forms/InputFile'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof InputFile> = {
+const setup: Meta<typeof InputFile> = {
   title: 'Forms/InputFile',
   component: InputFile,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof InputFile> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputFile> = (args) => {
+const Template: StoryFn<typeof InputFile> = (args) => {
   const [file, setFile] = useState<File | null>(null)
 
   return (

--- a/packages/docs/src/stories/forms/InputJson.stories.tsx
+++ b/packages/docs/src/stories/forms/InputJson.stories.tsx
@@ -1,8 +1,8 @@
 import { InputJson } from '#ui/forms/InputJson'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof InputJson> = {
+const setup: Meta<typeof InputJson> = {
   title: 'Forms/InputJson',
   component: InputJson,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof InputJson> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputJson> = (args) => {
+const Template: StoryFn<typeof InputJson> = (args) => {
   const [jsonValue, setJsonValue] = useState<object | null>(null)
   return (
     <>

--- a/packages/docs/src/stories/forms/InputReadonly.stories.tsx
+++ b/packages/docs/src/stories/forms/InputReadonly.stories.tsx
@@ -1,7 +1,7 @@
 import { InputReadonly } from '#ui/forms/InputReadonly'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof InputReadonly> = {
+const setup: Meta<typeof InputReadonly> = {
   title: 'Forms/InputReadonly',
   component: InputReadonly,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof InputReadonly> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputReadonly> = (args) => {
+const Template: StoryFn<typeof InputReadonly> = (args) => {
   return (
     <InputReadonly
       {...args}

--- a/packages/docs/src/stories/forms/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/InputSelect.stories.tsx
@@ -6,7 +6,7 @@ import {
   type SelectValue
 } from '#ui/forms/InputSelect'
 import { Label } from '#ui/forms/Label'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
 const fullList = [
@@ -24,7 +24,7 @@ const fullList = [
   { value: 'sku_options', label: 'Sku Options' }
 ].sort((a, b) => a.label.localeCompare(b.label))
 
-const setup: ComponentMeta<typeof InputSelect> = {
+const setup: Meta<typeof InputSelect> = {
   title: 'Forms/InputSelect',
   component: InputSelect,
   parameters: {
@@ -33,7 +33,7 @@ const setup: ComponentMeta<typeof InputSelect> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputSelect> = (args) => {
+const Template: StoryFn<typeof InputSelect> = (args) => {
   return (
     <>
       <Label gap htmlFor='parent-resource'>
@@ -80,7 +80,7 @@ const fakeSearch = (hint: string): SelectValue[] =>
     item.label.toLowerCase().includes(hint.toLowerCase())
   )
 
-const TemplateError: ComponentStory<typeof InputSelect> = (args) => {
+const TemplateError: StoryFn<typeof InputSelect> = (args) => {
   const [feedback, setFeedback] = useState<InputSelectProps['feedback']>()
   return (
     <InputSelect

--- a/packages/docs/src/stories/forms/InputTextArea.stories.tsx
+++ b/packages/docs/src/stories/forms/InputTextArea.stories.tsx
@@ -1,7 +1,7 @@
 import { InputTextArea } from '#ui/forms/InputTextArea'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof InputTextArea> = {
+const setup: Meta<typeof InputTextArea> = {
   title: 'Forms/InputTextArea',
   component: InputTextArea,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof InputTextArea> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputTextArea> = (args) => {
+const Template: StoryFn<typeof InputTextArea> = (args) => {
   return <InputTextArea {...args} value={args.value} />
 }
 

--- a/packages/docs/src/stories/forms/InputToggleListBox.stories.tsx
+++ b/packages/docs/src/stories/forms/InputToggleListBox.stories.tsx
@@ -1,8 +1,8 @@
 import { InputToggleListBox } from '#ui/forms/InputToggleListBox'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof InputToggleListBox> = {
+const setup: Meta<typeof InputToggleListBox> = {
   title: 'Forms/InputToggleListBox',
   component: InputToggleListBox,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof InputToggleListBox> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof InputToggleListBox> = (args) => {
+const Template: StoryFn<typeof InputToggleListBox> = (args) => {
   const [value, setValue] = useState(args.value ?? 'json')
   return (
     <InputToggleListBox

--- a/packages/docs/src/stories/forms/RadioButtons.stories.tsx
+++ b/packages/docs/src/stories/forms/RadioButtons.stories.tsx
@@ -1,14 +1,14 @@
 import { RadioButtons, type RadioOptionValue } from '#ui/forms/RadioButtons'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
-const setup: ComponentMeta<typeof RadioButtons> = {
+const setup: Meta<typeof RadioButtons> = {
   title: 'Forms/RadioButtons',
   component: RadioButtons
 }
 export default setup
 
-const Template: ComponentStory<typeof RadioButtons> = (args) => {
+const Template: StoryFn<typeof RadioButtons> = (args) => {
   const [value, setValue] = useState<RadioOptionValue>()
 
   return (

--- a/packages/docs/src/stories/forms/ToggleButtons.stories.tsx
+++ b/packages/docs/src/stories/forms/ToggleButtons.stories.tsx
@@ -1,5 +1,5 @@
 import { ToggleButtons, type ToggleButtonOption } from '#ui/forms/ToggleButtons'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
 
 const options: ToggleButtonOption[] = [
@@ -33,13 +33,13 @@ const optionsWithDisabled: ToggleButtonOption[] = options.map((opt, idx) =>
     : opt
 )
 
-const setup: ComponentMeta<typeof ToggleButtons> = {
+const setup: Meta<typeof ToggleButtons> = {
   title: 'Forms/ToggleButtons',
   component: ToggleButtons
 }
 export default setup
 
-const Template: ComponentStory<typeof ToggleButtons> = (args) => {
+const Template: StoryFn<typeof ToggleButtons> = (args) => {
   const [value, setValue] = useState<any>(args.value)
   return <ToggleButtons {...args} value={value} onChange={setValue} />
 }

--- a/packages/docs/src/stories/lists/List.stories.tsx
+++ b/packages/docs/src/stories/lists/List.stories.tsx
@@ -1,8 +1,8 @@
-import { A } from '#app-elements/atoms/A'
+import { A } from '#ui/atoms/A'
 import { List } from '#ui/lists/List'
-import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof List> = {
+const setup: Meta<typeof List> = {
   title: 'Lists/List',
   component: List,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof List> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof List> = (args) => (
+const Template: StoryFn<typeof List> = (args) => (
   <List {...args}>
     <div style={{ padding: '2rem' }}>item #1</div>
     <div style={{ padding: '2rem' }}>item #2</div>

--- a/packages/docs/src/stories/lists/ListDetails.stories.tsx
+++ b/packages/docs/src/stories/lists/ListDetails.stories.tsx
@@ -1,12 +1,12 @@
-import { Avatar } from '#app-elements/atoms/Avatar'
-import { Text } from '#app-elements/atoms/Text'
-import { ListItem } from '#app-elements/lists/ListItem'
+import { Avatar } from '#ui/atoms/Avatar'
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
+import { Text } from '#ui/atoms/Text'
 import { ListDetails } from '#ui/lists/ListDetails'
 import { ListDetailsItem } from '#ui/lists/ListDetailsItem'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { ListItem } from '#ui/lists/ListItem'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof ListDetails> = {
+const setup: Meta<typeof ListDetails> = {
   title: 'Lists/ListDetails',
   component: ListDetails,
   parameters: {
@@ -15,7 +15,7 @@ const setup: ComponentMeta<typeof ListDetails> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof ListDetails> = (args) => (
+const Template: StoryFn<typeof ListDetails> = (args) => (
   <ListDetails {...args}>
     <ListDetailsItem label='ID:'>
       <CopyToClipboard value='WGDMSMNOwJ' />
@@ -41,7 +41,7 @@ Default.args = {
   isLoading: false
 }
 
-export const WithListItem: ComponentStory<typeof ListDetails> = (args) => (
+export const WithListItem: StoryFn<typeof ListDetails> = (args) => (
   <ListDetails {...args}>
     {Array(3).fill(
       <ListItem

--- a/packages/docs/src/stories/lists/ListDetailsItem.stories.tsx
+++ b/packages/docs/src/stories/lists/ListDetailsItem.stories.tsx
@@ -1,7 +1,7 @@
 import { ListDetailsItem } from '#ui/lists/ListDetailsItem'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof ListDetailsItem> = {
+const setup: Meta<typeof ListDetailsItem> = {
   title: 'Lists/ListDetailsItem',
   component: ListDetailsItem,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof ListDetailsItem> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof ListDetailsItem> = (args) => (
+const Template: StoryFn<typeof ListDetailsItem> = (args) => (
   <ListDetailsItem {...args} />
 )
 

--- a/packages/docs/src/stories/lists/ListItem.stories.tsx
+++ b/packages/docs/src/stories/lists/ListItem.stories.tsx
@@ -1,9 +1,9 @@
-import { Text } from '#app-elements/atoms/Text'
-import { ListItem } from '#app-elements/lists/ListItem'
-import { type StoryFn, type Meta } from '@storybook/react'
-import { RadialProgress } from '#app-elements/atoms/RadialProgress'
-import { Icon } from '#app-elements/atoms/Icon'
-import { Avatar } from '#app-elements/atoms/Avatar'
+import { Avatar } from '#ui/atoms/Avatar'
+import { Icon } from '#ui/atoms/Icon'
+import { RadialProgress } from '#ui/atoms/RadialProgress'
+import { Text } from '#ui/atoms/Text'
+import { ListItem } from '#ui/lists/ListItem'
+import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof ListItem> = {
   title: 'Lists/ListItem',

--- a/packages/docs/src/stories/resources/OrderSummary.stories.tsx
+++ b/packages/docs/src/stories/resources/OrderSummary.stories.tsx
@@ -1,7 +1,7 @@
 import { OrderSummary } from '#ui/resources/OrderSummary'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof OrderSummary> = {
+const setup: Meta<typeof OrderSummary> = {
   title: 'Resources/Order Summary',
   component: OrderSummary,
   parameters: {
@@ -10,7 +10,7 @@ const setup: ComponentMeta<typeof OrderSummary> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof OrderSummary> = (args) => {
+const Template: StoryFn<typeof OrderSummary> = (args) => {
   return <OrderSummary {...args} />
 }
 

--- a/packages/docs/src/stories/tables/Table.stories.tsx
+++ b/packages/docs/src/stories/tables/Table.stories.tsx
@@ -1,8 +1,8 @@
 import { Td, Th, Tr } from '#ui/atoms/tables'
 import { Table } from '#ui/tables/Table'
-import { type ComponentMeta, type ComponentStory } from '@storybook/react'
+import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: ComponentMeta<typeof Table> = {
+const setup: Meta<typeof Table> = {
   title: 'Tables/Table',
   component: Table,
   parameters: {
@@ -11,7 +11,7 @@ const setup: ComponentMeta<typeof Table> = {
 }
 export default setup
 
-const Template: ComponentStory<typeof Table> = (args) => {
+const Template: StoryFn<typeof Table> = (args) => {
   const tHead = (
     <Tr>
       <Th>Name</Th>
@@ -41,7 +41,7 @@ const Template: ComponentStory<typeof Table> = (args) => {
 
 export const Default = Template.bind({})
 
-const TemplateWithoutThead: ComponentStory<typeof Table> = (args) => {
+const TemplateWithoutThead: StoryFn<typeof Table> = (args) => {
   const tBody = (
     <>
       <Tr>

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -21,12 +21,25 @@
     "jsx": "react-jsx",
     "baseUrl": "./",
     "paths": {
-      "#app-elements/*": [
-        "../app-elements/src/ui/*"
+      // TODO: we need to keep them in sync with the `app-elements` package.
+      "#providers/*": [
+        "../app-elements/src/providers/*"
       ],
       "#ui/*": [
         "../app-elements/src/ui/*"
-      ]
+      ],
+      "#styles/*": [
+        "../app-elements/src/styles/*"
+      ],
+      "#utils/*": [
+        "../app-elements/src/utils/*"
+      ],
+      "#helpers/*": [
+        "../app-elements/src/helpers/*"
+      ],
+      "#hooks/*": [
+        "../app-elements/src/hooks/*"
+      ],
     }
   },
   "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,9 +188,6 @@ importers:
 
   packages/docs:
     dependencies:
-      '@commercelayer/app-elements':
-        specifier: workspace:^0.0.28
-        version: link:../app-elements
       react:
         specifier: ^18.2.0
         version: 18.2.0


### PR DESCRIPTION
Since `docs` package builds with the `app-elements` sources, we can remove the dependency.
I also updated all the `docs` paths to reflect the same we have on `app-elements`.

The result is that now when we import a component from `app-elements` we have the same DX as we're working on `app-elements` package.

![Screenshot 2023-05-10 alle 15 14 40](https://github.com/commercelayer/app-elements/assets/1681269/1261bda7-afe4-46e1-bb67-fa06f8f1e815)

----

Update deprecated Storybook type:

```diff
- import { type ComponentStory, type ComponentMeta } from '@storybook/react'
+ import { type Meta, type StoryFn } from '@storybook/react'
```