### PR TITLE
Enhance order actions behaviour

### DIFF
--- a/packages/app-elements/src/ui/resources/OrderSummary.test.tsx
+++ b/packages/app-elements/src/ui/resources/OrderSummary.test.tsx
@@ -245,22 +245,74 @@ describe('OrderSummary', () => {
             onClick: () => {
               console.log('approved!')
             }
+          },
+          {
+            label: 'Cancel',
+            variant: 'secondary',
+            onClick: () => {
+              console.log('cancelled!')
+            }
           }
         ]}
       />
     )
 
-    expect(getByTestId('order-summary-footer-actions')).toBeInTheDocument()
+    const actionContainer = getByTestId('order-summary-footer-actions')
+    expect(actionContainer).toBeInTheDocument()
+
+    expect(actionContainer.children[0]).toHaveClass('basis-1/2 flex gap-3')
+    expect(actionContainer.children[1]).toHaveClass(
+      'basis-1/2 flex gap-3 justify-end'
+    )
 
     const archiveButton = getByText('Archive')
     const approveButton = getByText('Approve')
+    const cancelButton = getByText('Cancel')
 
     expect(archiveButton).toBeInTheDocument()
+    expect(approveButton).not.toHaveClass('w-full')
     expect(archiveButton.tagName).toEqual('BUTTON')
     await act(() => fireEvent.click(archiveButton))
     expect(mockedConsoleLog).not.toHaveBeenCalled()
 
     expect(approveButton).toBeInTheDocument()
+    expect(approveButton).not.toHaveClass('w-full')
+    expect(approveButton.tagName).toEqual('BUTTON')
+    await act(() => fireEvent.click(approveButton))
+    expect(mockedConsoleLog).toHaveBeenCalledWith('approved!')
+
+    expect(cancelButton).toBeInTheDocument()
+    expect(approveButton).not.toHaveClass('w-full')
+    expect(cancelButton.tagName).toEqual('BUTTON')
+    await act(() => fireEvent.click(cancelButton))
+    expect(mockedConsoleLog).toHaveBeenCalledWith('cancelled!')
+  })
+
+  it('should render a full-width button when there is only one primary action', async () => {
+    const mockedConsoleLog = vi.spyOn(console, 'log')
+    const { getByText, getByTestId } = render(
+      <OrderSummary
+        order={order}
+        footerActions={[
+          {
+            label: 'Approve',
+            onClick: () => {
+              console.log('approved!')
+            }
+          }
+        ]}
+      />
+    )
+
+    const actionContainer = getByTestId('order-summary-footer-actions')
+    expect(actionContainer).toBeInTheDocument()
+
+    expect(actionContainer.children[0]).not.toHaveClass('basis-1/2 flex gap-3')
+
+    const approveButton = getByText('Approve')
+
+    expect(approveButton).toBeInTheDocument()
+    expect(approveButton).toHaveClass('w-full')
     expect(approveButton.tagName).toEqual('BUTTON')
     await act(() => fireEvent.click(approveButton))
     expect(mockedConsoleLog).toHaveBeenCalledWith('approved!')

--- a/packages/docs/src/stories/resources/OrderSummary.stories.tsx
+++ b/packages/docs/src/stories/resources/OrderSummary.stories.tsx
@@ -27,13 +27,6 @@ Default.args = {
   isLoading: false,
   footerActions: [
     {
-      label: 'Archive',
-      disabled: true,
-      onClick: () => {
-        alert('Approved!')
-      }
-    },
-    {
       label: 'Approve',
       onClick: () => {
         alert('Approved!')
@@ -41,6 +34,7 @@ Default.args = {
     },
     {
       label: 'Cancel',
+      variant: 'secondary',
       onClick: () => {
         alert('Cancelled!')
       }
@@ -122,6 +116,20 @@ Default.args = {
       }
     ]
   }
+}
+
+export const OneAction = Template.bind({})
+OneAction.args = {
+  isLoading: false,
+  footerActions: [
+    {
+      label: 'Approve',
+      onClick: () => {
+        alert('Approved!')
+      }
+    }
+  ],
+  order: Default.args.order
 }
 
 export const NoActions = Template.bind({})


### PR DESCRIPTION
New UX
- Cancel - always small and gray on the left.
- All the others - small black on the right (when cancel is present).
- When there's only the primary button, it'll be full-width.

<img src="https://user-images.githubusercontent.com/1681269/235620551-7c85436f-2a61-4ac5-ad19-c11600bf397e.png" width="350" />

<img src="https://user-images.githubusercontent.com/1681269/235620737-dc15968f-9eb6-4d86-aabb-7c7607fb176a.png" width="350" />

