### PR TITLE
Update color palette in tailwind config

### DIFF
--- a/packages/app-elements/src/ui/atoms/Text.tsx
+++ b/packages/app-elements/src/ui/atoms/Text.tsx
@@ -37,7 +37,7 @@ function Text({
   const computedClassName = cn(className, {
     // variant
     'text-green': variant === 'success',
-    'text-red': variant === 'danger',
+    'text-red-500': variant === 'danger',
     'text-primary': variant === 'primary',
     'text-gray-500': variant === 'info',
     'text-orange-600': variant === 'warning',

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -35,7 +35,7 @@ module.exports = {
       black: '#101111',
       white: '#fff',
       gray: {
-        50: '#f8f8f8',
+        50: '#F8F8F8',
         100: '#EDEEEE',
         200: '#E6E7E7',
         300: '#DBDCDC',


### PR DESCRIPTION
This adds more shades to Tailwind colors configuration to match our branded color palette.
It is now possible to use classes like `text-red-600` or `bg-orange-300`.
The `DEFAULT` value for each color allows us to keep using the default class names (eg: `text-orange`) without specifying the weight/number.

`<Text>` component has been updated to use `text-red-500` and `text-orange-600` since the defaults are too bright to be used as text color.

 
