### PR TITLE
Perform better checking for validation message error from API

### DIFF
--- a/packages/app-elements-hook-form/src/components/ValidationApiError.tsx
+++ b/packages/app-elements-hook-form/src/components/ValidationApiError.tsx
@@ -1,10 +1,10 @@
-import { useFormContext } from 'react-hook-form'
-import { useEffect } from 'react'
-import { ValidationError } from './ValidationError'
 import {
-  setApiFormErrors,
-  API_ERROR_FIELD_NAME
+  API_ERROR_FIELD_NAME,
+  setApiFormErrors
 } from '#helpers/setApiFormErrors'
+import { useEffect } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { ValidationError } from './ValidationError'
 
 interface ValidationApiErrorProps {
   /**
@@ -15,7 +15,10 @@ interface ValidationApiErrorProps {
   /**
    * Optional map of app field names to API error field names.
    * This is useful when the API returns field names that are different from the app field names.
-   * For example, if the API returns `first_name` instead of `firstName`, you can pass `{ firstName: 'first_name' }`.
+   * For example, if the API returns `first_name` instead of `firstName`, you can pass `{ first_name: 'firstName' }`.
+   *
+   * Format is:
+   * ```{ apiFieldName: appFieldName }```
    */
   fieldMap?: Record<string, string>
 }
@@ -24,11 +27,16 @@ function ValidationApiError({
   apiError,
   fieldMap
 }: ValidationApiErrorProps): JSX.Element {
-  const { setError } = useFormContext()
+  const { setError, getValues } = useFormContext()
 
   useEffect(() => {
     if (apiError != null) {
-      setApiFormErrors({ apiError, setError, fieldMap })
+      setApiFormErrors({
+        apiError,
+        setError,
+        formFields: Object.keys(getValues()),
+        fieldMap
+      })
     }
   }, [apiError, apiError?.errors])
 

--- a/packages/app-elements-hook-form/src/helpers/setApiFormErrors.test.ts
+++ b/packages/app-elements-hook-form/src/helpers/setApiFormErrors.test.ts
@@ -30,7 +30,8 @@ describe('setApiFormErrors', () => {
           }
         ]
       },
-      setError: MockedSetError
+      setError: MockedSetError,
+      formFields: ['first_name', 'phone']
     })
 
     expect(MockedSetError).toHaveBeenCalledWith(
@@ -80,6 +81,7 @@ describe('setApiFormErrors', () => {
         ]
       },
       setError: MockedSetError,
+      formFields: ['myCustomFieldName'],
       fieldMap: {
         first_name: 'myCustomFieldName'
       }
@@ -95,5 +97,54 @@ describe('setApiFormErrors', () => {
         shouldFocus: true
       }
     )
+  })
+
+  test('should treat as `root.apiError` a validation error for a field not found in formFields', () => {
+    const MockedSetError = vi.fn()
+
+    setApiFormErrors({
+      apiError: {
+        errors: [
+          {
+            code: 'VALIDATION_ERROR',
+            title: 'Required field',
+            detail: 'first_name - is required',
+            source: {
+              pointer: '/data/attributes/first_name'
+            }
+          },
+          {
+            code: 'VALIDATION_ERROR',
+            title: 'Required field',
+            detail: 'phone - is required',
+            source: {
+              pointer: '/data/attributes/phone'
+            }
+          }
+        ]
+      },
+      setError: MockedSetError,
+      formFields: ['first_name']
+    })
+
+    // validation error since first_name is in formFields
+    expect(MockedSetError).toHaveBeenCalledWith(
+      'first_name',
+      {
+        type: 'serverValidation',
+        message: 'Required field'
+      },
+      {
+        shouldFocus: true
+      }
+    )
+
+    // generic error since phone is not in formFields
+    expect(MockedSetError).toHaveBeenCalledWith('root.apiError', {
+      type: 'server',
+      message: 'phone - is required'
+    })
+
+    expect(MockedSetError).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/app-elements-hook-form/src/helpers/setApiFormErrors.ts
+++ b/packages/app-elements-hook-form/src/helpers/setApiFormErrors.ts
@@ -83,7 +83,8 @@ export const API_ERROR_FIELD_NAME = 'root.apiError'
 export function setApiFormErrors({
   apiError,
   setError,
-  fieldMap
+  fieldMap,
+  formFields
 }: {
   /**
    * Error response from API
@@ -93,6 +94,10 @@ export function setApiFormErrors({
    * setError function from react-hook-form, it comes from same useForm() context
    */
   setError: UseFormSetError<any>
+  /**
+   * list of from fields
+   */
+  formFields: string[]
   /**
    * Map of field names from API to field names in the form
    */
@@ -108,7 +113,14 @@ export function setApiFormErrors({
           ? fieldMap?.[guessedField] ?? guessedField
           : undefined
 
-      if (item.code === 'VALIDATION_ERROR' && field != null) {
+      // Once we have a field name we check if it's part of the form fields, otherwise we cannot
+      // set the error on it because it won't be visible to the user.
+      // This because API can still return `VALIDATION_ERROR` for a field that is no part of the form.
+      // If we don't perform this check here, the form will not be submitted and the user will not see any errors.
+      // Example: `VALIDATION_ERROR` is returned for field `quantity` but we don't have a field with that name in the form.
+      const isFieldInForm = Boolean(field != null && formFields.includes(field))
+
+      if (item.code === 'VALIDATION_ERROR' && field != null && isFieldInForm) {
         return {
           ...allErrors,
           validation: [


### PR DESCRIPTION
After a form submission, when an error message comes from API, we check if it is a validation error.
Now we also check if the validation error message belongs to an existing form field.
If not it will be set at the `root.apiError` level as all other generic errors.