### PR TITLE
Set default CSS font weight

### DIFF
--- a/packages/app-elements/src/styles/global.css
+++ b/packages/app-elements/src/styles/global.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply text-gray-800 antialiased;
+  @apply text-gray-800 antialiased font-medium;
 }


### PR DESCRIPTION
`font-medium` (font-weight: 500) is now the default rule and is directly applied to the body tag