### PR TITLE
Add `author` to `TimelineEvent` and fix `message` text color

### DIFF
--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -3,13 +3,15 @@ import { Badge } from '#ui/atoms/Badge'
 import { Card } from '#ui/atoms/Card'
 import { Icon } from '#ui/atoms/Icon'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import { Text } from '#ui/atoms/Text'
 import { Input } from '#ui/forms/Input'
 import groupBy from 'lodash/groupBy'
 import orderBy from 'lodash/orderBy'
-import { Fragment, type ReactNode, useMemo } from 'react'
+import { Fragment, useMemo, type ReactNode } from 'react'
 
 export interface TimelineEvent {
   date: string
+  author?: string
   message: ReactNode
   note?: string
 }
@@ -91,12 +93,21 @@ export const Timeline = withSkeletonTemplate<Props>(
                       </div>
                     </div>
                     <div data-test-id='timeline-event-message'>
-                      {event.message} {timeSeparator}{' '}
-                      {formatDate({
-                        format: 'time',
-                        isoDate: event.date,
-                        timezone
-                      })}
+                      <>
+                        {event.author != null && (
+                          <Text weight='bold' className='text-black'>
+                            {event.author}{' '}
+                          </Text>
+                        )}
+                        <Text variant='info'>
+                          {event.message} {timeSeparator}{' '}
+                          {formatDate({
+                            format: 'time',
+                            isoDate: event.date,
+                            timezone
+                          })}
+                        </Text>
+                      </>
                     </div>
                   </div>
                   {event.note != null && (
@@ -106,7 +117,7 @@ export const Timeline = withSkeletonTemplate<Props>(
                       </div>
                       <Card
                         data-test-id='timeline-event-note'
-                        className='w-full'
+                        className='w-full mt-1'
                       >
                         {event.note}
                       </Card>

--- a/packages/docs/src/stories/composite/Timeline.stories.tsx
+++ b/packages/docs/src/stories/composite/Timeline.stories.tsx
@@ -123,11 +123,8 @@ Default.args = {
         minutes: 8,
         seconds: 35
       }).toJSON(),
-      message: (
-        <span>
-          <Text weight='bold'>S. Jennigs</Text> left a note
-        </span>
-      ),
+      author: 'S. Jennigs',
+      message: 'left a note',
       note: 'Customer would like to receive parcel sooner, please request the customer phone number.'
     },
     {
@@ -138,11 +135,8 @@ Default.args = {
         minutes: 8,
         seconds: 36
       }).toJSON(),
-      message: (
-        <span>
-          <Text weight='bold'>S. Jennigs</Text> left a note
-        </span>
-      ),
+      author: 'S. Jennigs',
+      message: 'left a note',
       note: 'Short text.'
     },
     {


### PR DESCRIPTION
### What does this PR do?
- Add optional `author` prop to `TimelineEvent`. Once the `author` is filled it will be shown inside a `Text` component set to have weight `bold` and color `black`. Documentation stories have been updated to set the `author` using this new pattern.
- TimelineEvent `message` has been wrapped into a `Text` component with variant `info` to have the `gray-500` color defined by design.