### PR TITLE
Add `fullWidth` prop to `<Button>`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Button.tsx
+++ b/packages/app-elements/src/ui/atoms/Button.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from 'react'
 import cn from 'classnames'
+import { type ReactNode } from 'react'
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /**
@@ -14,6 +14,10 @@ interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
    * Set button size
    */
   size?: ButtonSize
+  /**
+   * Set button width to 100%
+   */
+  fullWidth?: boolean
 }
 
 export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'link'
@@ -39,6 +43,7 @@ function Button({
   size = 'regular',
   variant = 'primary',
   disabled,
+  fullWidth,
   ...rest
 }: Props): JSX.Element {
   return (
@@ -46,7 +51,10 @@ function Button({
       className={cn([
         className,
         'text-sm rounded text-center font-bold transition-opacity duration-500 focus:outline-none',
-        { 'opacity-50 pointer-events-none touch-none': disabled },
+        {
+          'opacity-50 pointer-events-none touch-none': disabled,
+          'w-full': fullWidth === true
+        },
         sizeCss[size],
         variantCss[variant]
       ])}


### PR DESCRIPTION
In different places we need to use a full width button.


```jsx
<Button fullWidth>Apply</Button>
```

<img width="328" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/7fbf0aba-9a2f-4633-bcf3-5581d4778827">


<img width="400" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/f86b35cc-4b2b-4b60-8fcd-e88dbc46635e">


<img width="671" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/0c08de2c-6f52-4246-b65d-1467779c9320">
