### PR TITLE
Update `useCoreApi` types to accepts all actions

### DIFF
--- a/packages/app-elements-hook-form/package.json
+++ b/packages/app-elements-hook-form/package.json
@@ -41,7 +41,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.43.9",
-    "typescript": "^5.0.3",
+    "typescript": "^5.1.3",
     "vite": "^4.2.1",
     "vite-plugin-dts": "^2.2.0",
     "vitest": "^0.29.8"

--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -64,7 +64,7 @@
     "polished": "^4.2.2",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.1",
-    "typescript": "^5.0.3",
+    "typescript": "^5.1.3",
     "vite": "^4.2.1",
     "vite-plugin-dts": "^2.2.0",
     "vitest": "^0.29.8",

--- a/packages/app-elements/src/providers/CoreSdkProvider/useCoreApi.tsx
+++ b/packages/app-elements/src/providers/CoreSdkProvider/useCoreApi.tsx
@@ -1,29 +1,37 @@
 import type { CommerceLayerClient } from '@commercelayer/sdk'
-import type { ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
+import { type ResourceTypeLock } from '@commercelayer/sdk/lib/cjs/api'
 import useSWR, {
   type Fetcher,
   type SWRConfiguration,
   type SWRResponse
 } from 'swr'
+import { type ConditionalKeys } from 'type-fest'
 import { useCoreSdkProvider } from '.'
 
+type GenericMethod = (...args: any) => Promise<any>
+
+type ForceToBeMethod<Method> = Method extends GenericMethod
+  ? Method
+  : GenericMethod
+
 export function useCoreApi<
-  Resource extends ListableResourceType,
-  Action extends 'list' | 'retrieve',
-  Method extends CommerceLayerClient[Resource][Action],
+  Resource extends ResourceTypeLock,
+  Action extends ConditionalKeys<CommerceLayerClient[Resource], GenericMethod>,
+  Method extends ForceToBeMethod<CommerceLayerClient[Resource][Action]>,
+  Args extends Parameters<Method>,
   Output extends Awaited<ReturnType<Method>>,
   SWROptions extends SWRConfiguration<Output, any, Fetcher<Output>>
 >(
   resource: Resource,
   action: Action,
-  args: Parameters<Method>,
+  args: Args,
   config?: SWROptions
 ): SWRResponse<Output, any, SWROptions> {
   const { sdkClient } = useCoreSdkProvider()
 
-  const fetcher = async (args: Parameters<Method>): Promise<Output> => {
+  const fetcher = async (args: Args): Promise<Output> => {
     // @ts-expect-error I don't know how to fix it :(
-    return await sdkClient[resource][action](...args)
+    return sdkClient[resource][action](...args)
   }
 
   return useSWR(args.length > 0 ? args : [{}], fetcher, config)

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -52,7 +52,7 @@
     "eslint-plugin-storybook": "^0.6.11",
     "msw": "^1.2.1",
     "storybook": "^7.0.2",
-    "typescript": "^5.0.3",
+    "typescript": "^5.1.3",
     "vite": "^4.2.1",
     "vite-tsconfig-paths": "^4.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
     devDependencies:
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.0.0
-        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.0.3)
+        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.1.3)
       '@phosphor-icons/react':
         specifier: v2.0.9
         version: 2.0.9(react-dom@18.2.0)(react@18.2.0)
@@ -106,7 +106,7 @@ importers:
         version: 21.1.1
       msw:
         specifier: ^1.2.1
-        version: 1.2.1(typescript@5.0.3)
+        version: 1.2.1(typescript@5.1.3)
       polished:
         specifier: ^4.2.2
         version: 4.2.2
@@ -117,8 +117,8 @@ importers:
         specifier: ^3.3.1
         version: 3.3.1(postcss@8.4.21)
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.1.3
+        version: 5.1.3
       vite:
         specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
@@ -139,7 +139,7 @@ importers:
         version: link:../app-elements
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.0.0
-        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.0.3)
+        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.1.3)
       '@testing-library/jest-dom':
         specifier: ^5.16.5
         version: 5.16.5
@@ -183,8 +183,8 @@ importers:
         specifier: ^7.43.9
         version: 7.43.9(react@18.2.0)
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.1.3
+        version: 5.1.3
       vite:
         specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
@@ -212,7 +212,7 @@ importers:
         version: 7.21.4(@babel/core@7.21.4)
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.0.0
-        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.0.3)
+        version: 1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.1.3)
       '@mdx-js/react':
         specifier: ^2.3.0
         version: 2.3.0(react@18.2.0)
@@ -272,10 +272,10 @@ importers:
         version: 7.0.2
       '@storybook/react':
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.3)
+        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
       '@storybook/react-vite':
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.3)(vite@4.2.1)
+        version: 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.2.1)
       '@storybook/testing-library':
         specifier: ^0.1.0
         version: 0.1.0
@@ -302,22 +302,22 @@ importers:
         version: 8.37.0
       eslint-plugin-storybook:
         specifier: ^0.6.11
-        version: 0.6.11(eslint@8.37.0)(typescript@5.0.3)
+        version: 0.6.11(eslint@8.37.0)(typescript@5.1.3)
       msw:
         specifier: ^1.2.1
-        version: 1.2.1(typescript@5.0.3)
+        version: 1.2.1(typescript@5.1.3)
       storybook:
         specifier: ^7.0.2
         version: 7.0.2
       typescript:
-        specifier: ^5.0.3
-        version: 5.0.3
+        specifier: ^5.1.3
+        version: 5.1.3
       vite:
         specifier: ^4.2.1
         version: 4.2.1(@types/node@18.15.11)
       vite-tsconfig-paths:
         specifier: ^4.0.8
-        version: 4.0.8(typescript@5.0.3)(vite@4.2.1)
+        version: 4.0.8(typescript@5.1.3)(vite@4.2.1)
 
 packages:
 
@@ -1626,44 +1626,44 @@ packages:
     dev: true
     optional: true
 
-  /@commercelayer/eslint-config-ts-react@1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.0.3):
+  /@commercelayer/eslint-config-ts-react@1.0.0(eslint@8.37.0)(react@18.2.0)(typescript@5.1.3):
     resolution: {integrity: sha512-Lbb0Uk4MEJ//aGome9r6T/PddGeaZE07+5GJN4vb2C4YkDXA4cPWgyF5q29Y/JRW+1GwasOxoIkNu3/lnB9Sgw==}
     peerDependencies:
       eslint: '>=8.0'
       react: '>= 17.0'
       typescript: '>=4.0'
     dependencies:
-      '@commercelayer/eslint-config-ts': 1.0.0(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@commercelayer/eslint-config-ts': 1.0.0(eslint@8.37.0)(typescript@5.1.3)
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       eslint: 8.37.0
       eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.32.2)(eslint@8.37.0)
       eslint-plugin-react: 7.32.2(eslint@8.37.0)
       react: 18.2.0
-      typescript: 5.0.3
+      typescript: 5.1.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /@commercelayer/eslint-config-ts@1.0.0(eslint@8.37.0)(typescript@5.0.3):
+  /@commercelayer/eslint-config-ts@1.0.0(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-GDtApwxg+/xPjyen4Uu6q4iyRVwjxrvD5PW7TUnd04fB9BYXySCOzbUoxnvAGvKQbcWXLhsjcJXmTAFDCWYAMw==}
     peerDependencies:
       eslint: '>=8.0'
       typescript: '>=5.0'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       eslint: 8.37.0
       eslint-config-prettier: 8.8.0(eslint@8.37.0)
-      eslint-config-standard-with-typescript: 34.0.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.37.0)(typescript@5.0.3)
+      eslint-config-standard-with-typescript: 34.0.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.37.0)(typescript@5.1.3)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)
       eslint-plugin-n: 15.7.0(eslint@8.37.0)
       eslint-plugin-prettier: 4.2.1(eslint-config-prettier@8.8.0)(eslint@8.37.0)(prettier@2.8.7)
       eslint-plugin-promise: 6.1.1(eslint@8.37.0)
       prettier: 2.8.7
-      typescript: 5.0.3
+      typescript: 5.1.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -2130,7 +2130,7 @@ packages:
       chalk: 4.1.2
     dev: true
 
-  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.0.3)(vite@4.2.1):
+  /@joshwooding/vite-plugin-react-docgen-typescript@0.2.1(typescript@5.1.3)(vite@4.2.1):
     resolution: {integrity: sha512-ou4ZJSXMMWHqGS4g8uNRbC5TiTWxAgQZiVucoUrOCWuPrTbkpJbmVyIi9jU72SBry7gQtuMEDp4YR8EEXAg7VQ==}
     peerDependencies:
       typescript: '>= 4.3.x'
@@ -2142,8 +2142,8 @@ packages:
       glob: 7.2.3
       glob-promise: 4.2.2(glob@7.2.3)
       magic-string: 0.27.0
-      react-docgen-typescript: 2.2.2(typescript@5.0.3)
-      typescript: 5.0.3
+      react-docgen-typescript: 2.2.2(typescript@5.1.3)
+      typescript: 5.1.3
       vite: 4.2.1(@types/node@18.15.11)
     dev: true
 
@@ -3379,7 +3379,7 @@ packages:
       - supports-color
     dev: true
 
-  /@storybook/builder-vite@7.0.2(typescript@5.0.3)(vite@4.2.1):
+  /@storybook/builder-vite@7.0.2(typescript@5.1.3)(vite@4.2.1):
     resolution: {integrity: sha512-G6CD2Gf2zwzRslvNvqgz4FeADVEA9XA4Mw6+NM6Twc+Wy/Ah482dvHS9ApSgirtGyBKjOfdHn1xQT4Z+kzbJnw==}
     peerDependencies:
       '@preact/preset-vite': '*'
@@ -3417,7 +3417,7 @@ packages:
       remark-external-links: 8.0.0
       remark-slug: 6.1.0
       rollup: 3.20.2
-      typescript: 5.0.3
+      typescript: 5.1.3
       vite: 4.2.1(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color
@@ -3792,7 +3792,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: true
 
-  /@storybook/react-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.3)(vite@4.2.1):
+  /@storybook/react-vite@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)(vite@4.2.1):
     resolution: {integrity: sha512-1bDrmGo6imxBzZKJJ+SEHPuDn474JY3Yatm0cPaNVtlYhbnbiTPa3PxhI4U3233l4Qsc6DXNLKvi++j/knXDCw==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -3800,10 +3800,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
       vite: ^3.0.0 || ^4.0.0
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.0.3)(vite@4.2.1)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.2.1(typescript@5.1.3)(vite@4.2.1)
       '@rollup/pluginutils': 4.2.1
-      '@storybook/builder-vite': 7.0.2(typescript@5.0.3)(vite@4.2.1)
-      '@storybook/react': 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.3)
+      '@storybook/builder-vite': 7.0.2(typescript@5.1.3)(vite@4.2.1)
+      '@storybook/react': 7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3)
       '@vitejs/plugin-react': 3.1.0(vite@4.2.1)
       ast-types: 0.14.2
       magic-string: 0.27.0
@@ -3819,7 +3819,7 @@ packages:
       - vite-plugin-glimmerx
     dev: true
 
-  /@storybook/react@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.0.3):
+  /@storybook/react@7.0.2(react-dom@18.2.0)(react@18.2.0)(typescript@5.1.3):
     resolution: {integrity: sha512-2P7Oju1XKWMyn75dO0vjL4gthzBL/lLiCBRyAHKXZJ1H2eNdWjXkOOtH1HxnbRcXjWSU4tW96dqKY8m0iR9zAA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -3852,7 +3852,7 @@ packages:
       react-element-to-jsx-string: 15.0.0(react-dom@18.2.0)(react@18.2.0)
       ts-dedent: 2.2.0
       type-fest: 2.19.0
-      typescript: 5.0.3
+      typescript: 5.1.3
       util-deprecate: 1.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4351,7 +4351,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/eslint-plugin@5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-1MeobQkQ9tztuleT3v72XmY0XuKXVXusAhryoLuU5YZ+mXoYKZP9SQ7Flulh1NX4DTjpGTc2b/eMu4u7M7dhnQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4363,23 +4363,23 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.57.1
-      '@typescript-eslint/type-utils': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/type-utils': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.37.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.4
       natural-compare-lite: 1.4.0
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser@5.57.1(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/parser@5.57.1(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-hlA0BLeVSA/wBPKdPGxoVr9Pp6GutGoY380FEhbVi0Ph4WNe8kLvqIRx76RSQt1lynZKfrXKs0/XeEk4zZycuA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4391,10 +4391,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.37.0
-      typescript: 5.0.3
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4407,7 +4407,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.57.1
     dev: true
 
-  /@typescript-eslint/type-utils@5.57.1(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/type-utils@5.57.1(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-/RIPQyx60Pt6ga86hKXesXkJ2WOS4UemFrmmq/7eOyiYjYv/MUSHPlkhU6k9T9W1ytnTJueqASW+wOmW4KrViw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4417,12 +4417,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
-      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       debug: 4.3.4
       eslint: 8.37.0
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4432,7 +4432,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree@5.57.1(typescript@5.0.3):
+  /@typescript-eslint/typescript-estree@5.57.1(typescript@5.1.3):
     resolution: {integrity: sha512-A2MZqD8gNT0qHKbk2wRspg7cHbCDCk2tcqt6ScCFLr5Ru8cn+TCfM786DjPhqwseiS+PrYwcXht5ztpEQ6TFTw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4447,13 +4447,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.8
-      tsutils: 3.21.0(typescript@5.0.3)
-      typescript: 5.0.3
+      tsutils: 3.21.0(typescript@5.1.3)
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils@5.57.1(eslint@8.37.0)(typescript@5.0.3):
+  /@typescript-eslint/utils@5.57.1(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-kN6vzzf9NkEtawECqze6v99LtmDiUJCVpvieTFA1uL7/jDghiJGubGZ5csicYHU1Xoqb3oH/R5cN5df6W41Nfg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4464,7 +4464,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.57.1
       '@typescript-eslint/types': 5.57.1
-      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.0.3)
+      '@typescript-eslint/typescript-estree': 5.57.1(typescript@5.1.3)
       eslint: 8.37.0
       eslint-scope: 5.1.1
       semver: 7.3.8
@@ -6719,7 +6719,7 @@ packages:
       eslint-plugin-react: 7.32.2(eslint@8.37.0)
     dev: true
 
-  /eslint-config-standard-with-typescript@34.0.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.37.0)(typescript@5.0.3):
+  /eslint-config-standard-with-typescript@34.0.1(@typescript-eslint/eslint-plugin@5.57.1)(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-J7WvZeLtd0Vr9F+v4dZbqJCLD16cbIy4U+alJMq4MiXdpipdBM3U5NkXaGUjePc4sb1ZE01U9g6VuTBpHHz1fg==}
     peerDependencies:
       '@typescript-eslint/eslint-plugin': ^5.43.0
@@ -6729,14 +6729,14 @@ packages:
       eslint-plugin-promise: ^6.0.0
       typescript: '*'
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.0.3)
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/eslint-plugin': 5.57.1(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       eslint: 8.37.0
       eslint-config-standard: 17.0.0(eslint-plugin-import@2.27.5)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.37.0)
       eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.1)(eslint@8.37.0)
       eslint-plugin-n: 15.7.0(eslint@8.37.0)
       eslint-plugin-promise: 6.1.1(eslint@8.37.0)
-      typescript: 5.0.3
+      typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6786,7 +6786,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       debug: 3.2.7
       eslint: 8.37.0
       eslint-import-resolver-node: 0.3.7
@@ -6815,7 +6815,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/parser': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
@@ -6905,14 +6905,14 @@ packages:
       string.prototype.matchall: 4.0.8
     dev: true
 
-  /eslint-plugin-storybook@0.6.11(eslint@8.37.0)(typescript@5.0.3):
+  /eslint-plugin-storybook@0.6.11(eslint@8.37.0)(typescript@5.1.3):
     resolution: {integrity: sha512-lIVmCqQgA0bhcuS1yWYBFrnPHBKPEQI+LHPDtlN81UE1/17onCqgwUW7Nyt7gS2OHjCAiOR4npjTGEoe0hssKw==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.0.3)
+      '@typescript-eslint/utils': 5.57.1(eslint@8.37.0)(typescript@5.1.3)
       eslint: 8.37.0
       requireindex: 1.2.0
       ts-dedent: 2.2.0
@@ -9721,7 +9721,7 @@ packages:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
     dev: true
 
-  /msw@1.2.1(typescript@5.0.3):
+  /msw@1.2.1(typescript@5.1.3):
     resolution: {integrity: sha512-bF7qWJQSmKn6bwGYVPXOxhexTCGD5oJSZg8yt8IBClxvo3Dx/1W0zqE1nX9BSWmzRsCKWfeGWcB/vpqV6aclpw==}
     engines: {node: '>=14'}
     hasBin: true
@@ -9750,7 +9750,7 @@ packages:
       path-to-regexp: 6.2.1
       strict-event-emitter: 0.4.6
       type-fest: 2.19.0
-      typescript: 5.0.3
+      typescript: 5.1.3
       yargs: 17.7.1
     transitivePeerDependencies:
       - encoding
@@ -11182,12 +11182,12 @@ packages:
       react-popper: 2.3.0(@popperjs/core@2.11.7)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
-  /react-docgen-typescript@2.2.2(typescript@5.0.3):
+  /react-docgen-typescript@2.2.2(typescript@5.1.3):
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 5.0.3
+      typescript: 5.1.3
     dev: true
 
   /react-docgen@6.0.0-alpha.3:
@@ -12669,7 +12669,7 @@ packages:
       code-block-writer: 11.0.3
     dev: true
 
-  /tsconfck@2.1.1(typescript@5.0.3):
+  /tsconfck@2.1.1(typescript@5.1.3):
     resolution: {integrity: sha512-ZPCkJBKASZBmBUNqGHmRhdhM8pJYDdOXp4nRgj/O0JwUwsMq50lCDRQP/M5GBNAA0elPrq4gAeu4dkaVCuKWww==}
     engines: {node: ^14.13.1 || ^16 || >=18}
     hasBin: true
@@ -12679,7 +12679,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 5.0.3
+      typescript: 5.1.3
     dev: true
 
   /tsconfig-paths@3.14.2:
@@ -12707,14 +12707,14 @@ packages:
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
-  /tsutils@3.21.0(typescript@5.0.3):
+  /tsutils@3.21.0(typescript@5.1.3):
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 5.0.3
+      typescript: 5.1.3
     dev: true
 
   /tuf-js@1.1.2:
@@ -12835,9 +12835,9 @@ packages:
     hasBin: true
     dev: true
 
-  /typescript@5.0.3:
-    resolution: {integrity: sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==}
-    engines: {node: '>=12.20'}
+  /typescript@5.1.3:
+    resolution: {integrity: sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==}
+    engines: {node: '>=14.17'}
     hasBin: true
     dev: true
 
@@ -13190,7 +13190,7 @@ packages:
       - supports-color
     dev: true
 
-  /vite-tsconfig-paths@4.0.8(typescript@5.0.3)(vite@4.2.1):
+  /vite-tsconfig-paths@4.0.8(typescript@5.1.3)(vite@4.2.1):
     resolution: {integrity: sha512-p04zH+Ey+NT78571x0pdX7nVRIJSlmKVvYryFglSWOK3Hc72eDL0+JJfbyQiugaIBApJkaEqbBQvqpsFZOSVGg==}
     peerDependencies:
       vite: '*'
@@ -13200,7 +13200,7 @@ packages:
     dependencies:
       debug: 4.3.4
       globrex: 0.1.2
-      tsconfck: 2.1.1(typescript@5.0.3)
+      tsconfck: 2.1.1(typescript@5.1.3)
       vite: 4.2.1(@types/node@18.15.11)
     transitivePeerDependencies:
       - supports-color


### PR DESCRIPTION
Now you can use `useCoreApi` with all resources and actions:

```ts
// get organization
useCoreApi('organization', 'retrieve', [])

// get customer orders
useCoreApi('customers', 'orders', ['customer_id'])
```

And you can also do CRUD operations on resources:

```ts
useCoreApi('line_items', 'create', [
  {
    order: {
      id: 'order-1',
      type: 'orders'
    },
    quantity: 1
  }
])
```

Everything with autocompletion:

<img width="918" alt="Screenshot 2023-06-07 alle 17 13 18" src="https://github.com/commercelayer/app-elements/assets/1681269/2a8b075c-9010-446d-be7b-4992e92d1157">

<img width="1059" alt="Screenshot 2023-06-07 alle 17 13 45" src="https://github.com/commercelayer/app-elements/assets/1681269/c950d71f-5e15-4ee9-8575-b6d9c8f53c90">
