### PR TITLE
Add break option to Text

### DIFF
--- a/packages/app-elements/src/ui/atoms/Text.tsx
+++ b/packages/app-elements/src/ui/atoms/Text.tsx
@@ -11,7 +11,7 @@ export type TextVariant =
 export type TextSize = 'small' | 'regular' | 'large' | 'inherit'
 export type TextWeight = 'regular' | 'medium' | 'semibold' | 'bold' | 'inherit'
 export type TextAlignment = 'center' | 'left' | 'right' | 'inherit'
-export type TextWrap = 'normal' | 'nowrap' | 'inherit'
+export type TextWrap = 'normal' | 'nowrap' | 'break' | 'inherit'
 
 export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   children?: ReactNode
@@ -56,6 +56,7 @@ function Text({
     'text-center': align === 'center',
     // wrap
     'whitespace-nowrap': wrap === 'nowrap',
+    'break-all': wrap === 'break',
     'whitespace-normal': wrap === 'normal'
   })
   return tag === 'span' ? (

--- a/packages/app-elements/src/ui/resources/OrderSummary.tsx
+++ b/packages/app-elements/src/ui/resources/OrderSummary.tsx
@@ -80,7 +80,7 @@ const OrderSummary = withSkeletonTemplate<{
                   })}
                 >
                   <td className='px-4 pb-6' valign='top'>
-                    <Text tag='div' weight='bold'>
+                    <Text tag='div' weight='bold' wrap='break'>
                       {lineItem.name}
                     </Text>
                     <Spacer top='2' bottom='2'>

--- a/packages/docs/src/stories/resources/OrderSummary.stories.tsx
+++ b/packages/docs/src/stories/resources/OrderSummary.stories.tsx
@@ -107,7 +107,7 @@ Default.args = {
         sku_code: 'HOODIEUL000000FFFFFFLXXX',
         image_url:
           'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/HOODIEUL000000FFFFFFLXXX_FLAT.png',
-        name: 'Black Unisex Lightweight Hoodie with White Logo',
+        name: 'BlackUnisexLightweightHoodieWithWhiteLogo_Cotton_Fabric_long_name',
         quantity: 10,
         formatted_total_amount: '1090.00€',
         formatted_unit_amount: '109.00€',


### PR DESCRIPTION
Add new `break` option to `wrap` prop in Text component


### Before
<img width="600" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/d322953a-d19a-4949-8024-5d07f95d02a8">

### Now with `<Text wrap='break'>`
<img width="600" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/fdab47f7-fa1f-4f5c-af90-dc9de4791c9e">

