### PR TITLE
Add `type='button'` attribute to button tags

### DIFF
--- a/packages/app-elements/src/ui/atoms/ButtonFilter.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonFilter.tsx
@@ -26,6 +26,7 @@ function ButtonFilter({
       {...rest}
     >
       <button
+        type='button'
         data-test-id='ButtonFilter-main'
         onClick={onClick}
         className={cn('font-bold', 'flex items-center', 'pl-4 py-[10px]', {
@@ -46,6 +47,7 @@ function ButtonFilter({
       </button>
       {onRemoveRequest != null ? (
         <button
+          type='button'
           data-test-id='ButtonFilter-remove'
           className='pl-1 pr-4'
           onClick={onRemoveRequest}

--- a/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
+++ b/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
@@ -1,6 +1,6 @@
+import { Check, Copy } from '@phosphor-icons/react'
 import cn from 'classnames'
 import isEmpty from 'lodash/isEmpty'
-import { Check, Copy } from '@phosphor-icons/react'
 import { useCallback, useEffect, useState } from 'react'
 import invariant from 'ts-invariant'
 
@@ -81,6 +81,7 @@ function CopyToClipboard({
       {showValue && <p className='overflow-x-auto py-2'>{value}</p>}
       <div className='pt-2'>
         <button
+          type='button'
           onClick={() => {
             void handleCopy(value)
           }}

--- a/packages/app-elements/src/ui/atoms/Overlay.tsx
+++ b/packages/app-elements/src/ui/atoms/Overlay.tsx
@@ -90,7 +90,7 @@ const Overlay: React.FC<OverlayProps> = ({
               data-test-id='overlay-buttonContainer'
             >
               {/* eslint-disable-next-line react/jsx-handler-names */}
-              <Button onClick={button.onClick} className='w-full'>
+              <Button type='button' onClick={button.onClick} className='w-full'>
                 {button.label}
               </Button>
             </Container>

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -1,6 +1,6 @@
+import { ArrowLeft } from '@phosphor-icons/react'
 import cn from 'classnames'
 import { type ReactNode } from 'react'
-import { ArrowLeft } from '@phosphor-icons/react'
 import { Badge, type BadgeVariant } from './Badge'
 
 export interface PageHeadingProps {
@@ -60,7 +60,7 @@ function PageHeading({
       {(onGoBack != null || actionButton != null) && (
         <div className={cn('mb-4 flex items-center justify-between')}>
           {onGoBack != null ? (
-            <button onClick={onGoBack}>
+            <button type='button' onClick={onGoBack}>
               <ArrowLeft className='text-2.5xl' />
             </button>
           ) : null}


### PR DESCRIPTION
When some components are mounted inside a `<form>` html tag, the fact they render a `<button>` makes the browser to think that it will be used to submit the form.

This PR fixes this behaviour by specifying the `type="button"` on generic components.
