### PR TITLE
Break text with `overflow-wrap: anywhere` as default for the `Text` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Text.tsx
+++ b/packages/app-elements/src/ui/atoms/Text.tsx
@@ -11,7 +11,7 @@ export type TextVariant =
 export type TextSize = 'small' | 'regular' | 'large' | 'inherit'
 export type TextWeight = 'regular' | 'medium' | 'semibold' | 'bold' | 'inherit'
 export type TextAlignment = 'center' | 'left' | 'right' | 'inherit'
-export type TextWrap = 'normal' | 'nowrap' | 'break' | 'inherit'
+export type TextWrap = 'normal' | 'nowrap' | 'inherit'
 
 export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   children?: ReactNode
@@ -56,8 +56,8 @@ function Text({
     'text-center': align === 'center',
     // wrap
     'whitespace-nowrap': wrap === 'nowrap',
-    'break-all': wrap === 'break',
-    'whitespace-normal': wrap === 'normal'
+    'whitespace-normal': wrap === 'normal',
+    '[overflow-wrap:anywhere]': true
   })
   return tag === 'span' ? (
     <span {...rest} className={computedClassName}>

--- a/packages/app-elements/src/ui/resources/OrderSummary.tsx
+++ b/packages/app-elements/src/ui/resources/OrderSummary.tsx
@@ -80,7 +80,7 @@ const OrderSummary = withSkeletonTemplate<{
                   })}
                 >
                   <td className='px-4 pb-6' valign='top'>
-                    <Text tag='div' weight='bold' wrap='break'>
+                    <Text tag='div' weight='bold'>
                       {lineItem.name}
                     </Text>
                     <Spacer top='2' bottom='2'>
@@ -110,7 +110,7 @@ const OrderSummary = withSkeletonTemplate<{
                     </Text>
                   </td>
                   <td valign='top' align='right'>
-                    <Text weight='bold' tag='div'>
+                    <Text weight='bold' tag='div' wrap='nowrap'>
                       {lineItem.formatted_total_amount}
                     </Text>
                   </td>


### PR DESCRIPTION
Removed `break` option from `Text` since it was using `break-all` that inserts line breaks between two characters of the same word.
Use [`overflow-wrap: everywhere;`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap) instead as a default for the `Text` component.