### PR TITLE
Remove flag icon from the Timeline

### DIFF
--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -40,7 +40,7 @@ export const Timeline = withSkeletonTemplate<Props>(
           return {
             ...event,
             position,
-            icon: getIcon(event, position)
+            icon: getIcon(event)
           }
         }
       )
@@ -133,14 +133,12 @@ export const Timeline = withSkeletonTemplate<Props>(
   }
 )
 
-function getIcon(event: TimelineEvent, position: Position): JSX.Element {
+function getIcon(event: TimelineEvent): JSX.Element {
   if (event.note != null) {
     return <Icon name='chatCircle' background='black' gap='small' />
   }
 
-  return position === 'first' ? (
-    <Icon name='flag' background='black' gap='small' />
-  ) : (
+  return (
     <Icon
       name='check'
       background='gray'


### PR DESCRIPTION
Removed timeline flag as per Figma discussion.

<img width="633" alt="Screenshot 2023-06-14 alle 08 50 30" src="https://github.com/commercelayer/app-elements/assets/1681269/956e2425-93b3-4b78-834d-2e3d53ab6dc9">
