### PR TITLE
Add `<Progress>` component

### DIFF
--- a/packages/app-elements/src/styles/global.css
+++ b/packages/app-elements/src/styles/global.css
@@ -3,5 +3,26 @@
 @tailwind utilities;
 
 body {
-  @apply text-gray-800 antialiased font-medium;
+    @apply text-gray-800 antialiased font-medium;
+}
+
+progress.progress {
+    @apply w-full h-2;
+}
+
+progress.progress,
+progress.progress::-webkit-progress-bar {
+    @apply rounded bg-gray-100 overflow-hidden;
+}
+
+progress.progress::-moz-progress-bar {
+    @apply rounded bg-gray-100 overflow-hidden;
+}
+
+progress.progress::-webkit-progress-value {
+    @apply rounded bg-primary;
+}
+
+progress.progress[value]::-moz-progress-bar {
+    @apply rounded bg-primary;
 }

--- a/packages/app-elements/src/ui/atoms/Progress.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Progress.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react'
+import { Progress } from './Progress'
+
+describe('Progress', () => {
+  test('Should be rendered with indeterminate state', () => {
+    const { container } = render(<Progress>Indeterminate</Progress>)
+    expect(container).toContainHTML(
+      '<progress class="progress" max="1">Indeterminate</progress>'
+    )
+  })
+
+  test('Should be rendered with defined max attribute', () => {
+    const { container } = render(<Progress max={20}>Indeterminate</Progress>)
+    expect(container).toContainHTML(
+      '<progress class="progress" max="20">Indeterminate</progress>'
+    )
+  })
+
+  test('Should be rendered with defined value attribute', () => {
+    const { container } = render(
+      <Progress max={20} value={12}>
+        20%
+      </Progress>
+    )
+    expect(container).toContainHTML(
+      '<progress class="progress" max="20" value="12">20%</progress>'
+    )
+  })
+})

--- a/packages/app-elements/src/ui/atoms/Progress.tsx
+++ b/packages/app-elements/src/ui/atoms/Progress.tsx
@@ -1,0 +1,28 @@
+interface ProgressProps {
+  /**
+   * This attribute describes how much work the task indicated by the `progress` element requires.
+   * The `max` attribute, if present, must have a value greater than `0` and be a valid floating point number.
+   * @default 1
+   */
+  max?: number
+  /**
+   * This attribute specifies how much of the task that has been completed.
+   * It must be a valid floating point number between `0` and `max`.
+   * If there is no `value` attribute, the progress bar is indeterminate;
+   * this indicates that an activity is ongoing with no indication of how long it is expected to take.
+   */
+  value?: number
+
+  children: React.ReactNode
+}
+
+function Progress({ max = 1, value, children }: ProgressProps): JSX.Element {
+  return (
+    <progress className='progress' max={max} value={value}>
+      {children}
+    </progress>
+  )
+}
+
+Progress.displayName = 'Progress'
+export { Progress }

--- a/packages/docs/src/stories/atoms/Progress.stories.tsx
+++ b/packages/docs/src/stories/atoms/Progress.stories.tsx
@@ -1,0 +1,24 @@
+import { Progress } from '#ui/atoms/Progress'
+import { type Meta, type StoryFn } from '@storybook/react'
+
+const setup: Meta<typeof Progress> = {
+  title: 'Atoms/Progress',
+  component: Progress,
+  parameters: {
+    layout: 'padded'
+  }
+}
+export default setup
+
+export const Default: StoryFn<typeof Progress> = (args) => (
+  <Progress {...args}>40%</Progress>
+)
+Default.args = {
+  max: 100,
+  value: 40
+}
+
+export const Indeterminate: StoryFn<typeof Progress> = (args) => (
+  <Progress {...args}>Loading...</Progress>
+)
+Indeterminate.args = {}


### PR DESCRIPTION
Add `<Progress>` component:

<img width="573" alt="Screenshot 2023-06-14 alle 23 45 43" src="https://github.com/commercelayer/app-elements/assets/1681269/5fe744d7-5d40-4d85-9ad9-6e9fefb05611">

This component simply wraps 1 to 1 with the [`<progress>` HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress).