### PR TITLE
Disable `Input` browser autofill ui and behavior based on `autoComplete` prop value

### DIFF
--- a/packages/app-elements/src/ui/forms/Input.tsx
+++ b/packages/app-elements/src/ui/forms/Input.tsx
@@ -33,11 +33,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       >
         <input
           {...rest}
+          data-lpignore={rest.autoComplete === 'off' && 'true'}
+          data-1p-ignore={rest.autoComplete === 'off' && true}
+          data-form-type={rest.autoComplete === 'off' && 'other'}
           id={rest.id ?? rest.name}
           className={cn(
             className,
-            'block w-full px-4 py-2.5 font-medium !bg-white !shadow-[0_0_0_1000px_white_inset]',
+            'block w-full px-4 py-2.5 font-medium',
             'rounded outline-0',
+            rest.autoComplete === 'off' &&
+              '!bg-white !shadow-[0_0_0_1000px_white_inset]',
             getFeedbackStyle(feedback)
           )}
           type={type}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified the `Input` atom component to avoid browser or any of its plugins to influence the field autocompletion and autofill UI background if `autoComplete` prop is set to `off`. 

In that case these classNames `!bg-white !shadow-[0_0_0_1000px_white_inset]` are added to `input` in order to force `background-color` and `box-shadow` CSS properties to be always `white` and these props too:
- data-lpignore='true'
- data-1p-ignore=true
- data-form-type='other'

Here you can see an example of default Chrome's autofill behavior:

<img width="425" alt="Chrome autofill email" src="https://github.com/commercelayer/app-elements/assets/105653649/565680d8-2e6c-4af2-9d0d-9defd244b5d9">

## How to test

Let's create an `Input` atom of type `email` and see if in any way the browser or any of its plugins will try to autofill any value.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
