### PR TITLE
Add missing generic definition in `useFilters` > `FilteredList`

### DIFF
--- a/packages/app-elements-hook-form/src/filters/useFilters.tsx
+++ b/packages/app-elements-hook-form/src/filters/useFilters.tsx
@@ -57,10 +57,10 @@ interface UseFiltersHook {
   /**
    * Filtered ResourceList component based on current active filters
    */
-  FilteredList: (
+  FilteredList: <TResource extends ListableResourceType>(
     props: Pick<
-      ResourceListProps<ListableResourceType>,
-      'Item' | 'query' | 'type' | 'emptyState'
+      ResourceListProps<TResource>,
+      'Item' | 'type' | 'query' | 'emptyState'
     >
   ) => JSX.Element
   /**


### PR DESCRIPTION
## What I did

`FilteredList` componente returned from `useFilters` hook was not properly defined as Generic function

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
