### PR TITLE
Parcels can be removed only when 'shipment.status' is 'packing'

### DIFF
--- a/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
@@ -293,6 +293,12 @@ export const shipmentWithoutTracking = createShipment({
   parcels: [parcelWithoutTracking1, parcelWithoutTracking2]
 })
 
+export const shipmentWithStatusDifferentFromPacking = createShipment({
+  id: 'shipment-with-status-not-packing',
+  status: 'ready_to_ship',
+  parcels: [parcelWithoutTracking1, parcelWithoutTracking2]
+})
+
 export const shipmentWithSingleParcelSingleTracking = createShipment({
   id: 'shipment-with-single-parcel-single-tracking',
   status: 'packing',

--- a/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
@@ -73,7 +73,7 @@ export const ShipmentParcels = withSkeletonTemplate<{
                 : parcel
             }
             onRemove={
-              hasTracking(shipment)
+              hasTracking(shipment) || shipment.status !== 'packing'
                 ? undefined
                 : () => {
                     onRemoveParcel?.(parcel.id)

--- a/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
@@ -3,6 +3,7 @@ import {
   shipmentWithMultipleParcelsMultipleTrackings,
   shipmentWithMultipleParcelsSingleTracking,
   shipmentWithSingleParcelSingleTracking,
+  shipmentWithStatusDifferentFromPacking,
   shipmentWithoutParcels,
   shipmentWithoutTracking
 } from '#ui/resources/ShipmentParcels.mocks'
@@ -17,6 +18,9 @@ const setup: Meta = {
 }
 export default setup
 
+/**
+ * User can remove and re-create parcels only when there's **not** tracking information and `shipment.status` is equal to `packing`.
+ */
 export const NoTracking: StoryFn<typeof ShipmentParcels> = (
   args
 ): JSX.Element => <ShipmentParcels {...args} />
@@ -27,6 +31,24 @@ NoTracking.args = {
   shipment: shipmentWithoutTracking
 }
 
+/**
+ * Even without tracking information, when the `shipment.status` is different from `packing`, the parcel cannot be removed anymore.
+ */
+export const StatusDifferentFromPacking: StoryFn<typeof ShipmentParcels> = (
+  args
+): JSX.Element => <ShipmentParcels {...args} />
+StatusDifferentFromPacking.args = {
+  onRemoveParcel: function (parcelId) {
+    alert(`removed parcel "${parcelId}"`)
+  },
+  shipment: shipmentWithStatusDifferentFromPacking
+}
+
+/**
+ * As soon as there's tracking information, parcels cannot be removed anymore.
+ *
+ * When there's only one parcel, the tracking information are shown on the carrier section.
+ */
 export const SingleParcelSingleTracking: StoryFn<typeof ShipmentParcels> = (
   args
 ): JSX.Element => <ShipmentParcels {...args} />
@@ -37,6 +59,9 @@ SingleParcelSingleTracking.args = {
   shipment: shipmentWithSingleParcelSingleTracking
 }
 
+/**
+ * When there are many parcels, but with only one tracking information (e.g. DHL), this is shown in the carrier section.
+ */
 export const MultipleParcelSingleTracking: StoryFn<typeof ShipmentParcels> = (
   args
 ): JSX.Element => <ShipmentParcels {...args} />
@@ -47,6 +72,9 @@ MultipleParcelSingleTracking.args = {
   shipment: shipmentWithMultipleParcelsSingleTracking
 }
 
+/**
+ * When there are many parcels, and each one has its own tracking information, these are shown on each parcel.
+ */
 export const MultipleParcelsMultipleTrackings: StoryFn<
   typeof ShipmentParcels
 > = (args): JSX.Element => <ShipmentParcels {...args} />
@@ -57,6 +85,9 @@ MultipleParcelsMultipleTrackings.args = {
   shipment: shipmentWithMultipleParcelsMultipleTrackings
 }
 
+/**
+ * When there's no parcel, there's nothing to show.
+ */
 export const NoParcels: StoryFn<typeof ShipmentParcels> = (
   args
 ): JSX.Element => <ShipmentParcels {...args} />


### PR DESCRIPTION
## What I did

Parcels can be removed only when `shipment.status` is equal to `packing`.

Here below an example of a shipment with status equal to `ready_to_ship`:
<img width="582" alt="Screenshot 2023-06-30 alle 15 03 32" src="https://github.com/commercelayer/app-elements/assets/1681269/7a8e6e8f-5b2e-49ea-9a3b-ed99655ebbcf">