### PR TITLE
Update "shipment purchased" condition

### DIFF
--- a/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
@@ -75,12 +75,14 @@ function createParcel({
 function createShipment({
   id,
   status,
+  purchaseStartedAt,
   parcels,
   rates,
   selectedRateId
 }: {
   id: string
   status: Shipment['status']
+  purchaseStartedAt?: string | undefined | null
   parcels: Parcel[]
   rates?: Array<Record<string, any>>
   selectedRateId?: 'rate_dhl_1111' | 'rate_fedex_1111'
@@ -91,6 +93,7 @@ function createShipment({
     created_at: '',
     updated_at: '',
     status,
+    purchase_started_at: purchaseStartedAt,
     parcels,
     rates,
     selected_rate_id: selectedRateId
@@ -299,9 +302,17 @@ export const shipmentWithStatusDifferentFromPacking = createShipment({
   parcels: [parcelWithoutTracking1, parcelWithoutTracking2]
 })
 
+export const shipmentHasBeenPurchased = createShipment({
+  id: 'shipment-with-status-not-packing',
+  status: 'packing',
+  purchaseStartedAt: '2023-07-11',
+  parcels: [parcelWithoutTracking1, parcelWithoutTracking2]
+})
+
 export const shipmentWithSingleParcelSingleTracking = createShipment({
   id: 'shipment-with-single-parcel-single-tracking',
   status: 'packing',
+  purchaseStartedAt: '2023-07-11',
   rates,
   selectedRateId: 'rate_dhl_1111',
   parcels: [parcelWithTracking1]
@@ -310,6 +321,7 @@ export const shipmentWithSingleParcelSingleTracking = createShipment({
 export const shipmentWithMultipleParcelsSingleTracking = createShipment({
   id: 'shipment-with-multiple-parcels-single-tracking',
   status: 'packing',
+  purchaseStartedAt: '2023-07-11',
   rates,
   selectedRateId: 'rate_dhl_1111',
   parcels: [parcelWithTracking1, parcelWithoutTracking1]
@@ -318,6 +330,7 @@ export const shipmentWithMultipleParcelsSingleTracking = createShipment({
 export const shipmentWithMultipleParcelsMultipleTrackings = createShipment({
   id: 'shipment-with-multiple-parcels-multiple-trackings',
   status: 'packing',
+  purchaseStartedAt: '2023-07-11',
   rates,
   selectedRateId: 'rate_fedex_1111',
   parcels: [parcelWithTracking1, parcelWithTracking2]
@@ -326,5 +339,6 @@ export const shipmentWithMultipleParcelsMultipleTrackings = createShipment({
 export const shipmentWithoutParcels = createShipment({
   id: 'shipment-without-parcels',
   status: 'picking',
+  purchaseStartedAt: '2023-07-11',
   parcels: []
 })

--- a/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
@@ -10,8 +10,8 @@ import { ListItem, type ListItemProps } from '#ui/lists/ListItem'
 import {
   getParcelTrackingDetail,
   getShipmentRate,
-  hasSingleTracking,
-  hasTracking
+  hasBeenPurchased,
+  hasSingleTracking
 } from '#utils/tracking'
 import {
   type ParcelLineItem as ParcelLineItemResource,
@@ -73,7 +73,7 @@ export const ShipmentParcels = withSkeletonTemplate<{
                 : parcel
             }
             onRemove={
-              hasTracking(shipment) || shipment.status !== 'packing'
+              hasBeenPurchased(shipment) || shipment.status !== 'packing'
                 ? undefined
                 : () => {
                     onRemoveParcel?.(parcel.id)

--- a/packages/app-elements/src/utils/tracking.ts
+++ b/packages/app-elements/src/utils/tracking.ts
@@ -48,13 +48,11 @@ export function hasSingleTracking(shipment: Shipment): boolean {
 }
 
 /**
- * Check whether the `shipment` has tracking information or not.
+ * Check whether the `shipment` has been purchased.
  * @param shipment Shipment
  */
-export function hasTracking(shipment: Shipment): boolean {
-  return (
-    shipment.parcels?.find((parcel) => parcel.tracking_number != null) != null
-  )
+export function hasBeenPurchased(shipment: Shipment): boolean {
+  return shipment.purchase_started_at != null
 }
 
 /**

--- a/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
@@ -1,5 +1,6 @@
 import { ShipmentParcels } from '#ui/resources/ShipmentParcels'
 import {
+  shipmentHasBeenPurchased,
   shipmentWithMultipleParcelsMultipleTrackings,
   shipmentWithMultipleParcelsSingleTracking,
   shipmentWithSingleParcelSingleTracking,
@@ -19,7 +20,7 @@ const setup: Meta = {
 export default setup
 
 /**
- * User can remove and re-create parcels only when there's **not** tracking information and `shipment.status` is equal to `packing`.
+ * User can remove and re-create parcels only when the shipment is not yet purchased (`shipment.purchase_started_at == null`) and `shipment.status` is equal to `packing`.
  */
 export const NoTracking: StoryFn<typeof ShipmentParcels> = (
   args
@@ -32,7 +33,7 @@ NoTracking.args = {
 }
 
 /**
- * Even without tracking information, when the `shipment.status` is different from `packing`, the parcel cannot be removed anymore.
+ * When the `shipment.status` is different from `packing`, the parcel cannot be removed anymore.
  */
 export const StatusDifferentFromPacking: StoryFn<typeof ShipmentParcels> = (
   args
@@ -45,8 +46,19 @@ StatusDifferentFromPacking.args = {
 }
 
 /**
- * As soon as there's tracking information, parcels cannot be removed anymore.
- *
+ * When the `shipment.purchase_started_at` is defined, the parcel cannot be removed anymore.
+ */
+export const ShipmentHasBeenPurchased: StoryFn<typeof ShipmentParcels> = (
+  args
+): JSX.Element => <ShipmentParcels {...args} />
+ShipmentHasBeenPurchased.args = {
+  onRemoveParcel: function (parcelId) {
+    alert(`removed parcel "${parcelId}"`)
+  },
+  shipment: shipmentHasBeenPurchased
+}
+
+/**
  * When there's only one parcel, the tracking information are shown on the carrier section.
  */
 export const SingleParcelSingleTracking: StoryFn<typeof ShipmentParcels> = (


### PR DESCRIPTION
## What I did

The parcels cannot be removed when the shipment has been purchased.
Before this change, we were checking the tracking information field, but since it is updated asynchronously, the UI was misaligned for a few seconds.

When users select a rate, the field `purchased_started_at` is instantly updated. So, checking this field is a better choice.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [X] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [X] Make sure to add/update documentation regarding your changes.
- [X] You are **NOT** deprecating/removing a feature.
