### PR TITLE
Remove capitalize forced case on `InputFeedback`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputFeedback.tsx
+++ b/packages/app-elements/src/ui/forms/InputFeedback.tsx
@@ -41,7 +41,7 @@ function InputFeedback({
       {...rest}
     >
       {icons[variant]}
-      <div className='text-sm font-bold capitalize'>{message}</div>
+      <div className='text-sm font-bold'>{message}</div>
     </div>
   )
 }


### PR DESCRIPTION
## What I did
We don't need the text inside `InputFeedback` to be capitalized (means have every word in title case).

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
