### PR TITLE
Allow to open new tab with ctrl or cmd click

### DIFF
--- a/packages/app-elements/src/helpers/appsNavigation.ts
+++ b/packages/app-elements/src/helpers/appsNavigation.ts
@@ -153,6 +153,10 @@ export function navigateToDetail({
     onClick: (
       e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement, MouseEvent>
     ) => {
+      if (e.ctrlKey || e.metaKey) {
+        // allow to open link in a new tab with ctrl+click or cmd+click
+        return
+      }
       e.preventDefault()
       setPersistentItem({ destination: destinationFullUrl })
       if (urlIsForSameApp(destinationFullUrl) && setLocation != null) {


### PR DESCRIPTION
## What I did

When using `navigateToDetail` helpers the onClick handlers is preventing default action, making impossibile to open link in a new tab with `cmd + click` or `ctrl + click`.
This PR fix this behaviour, allowing to completely ignore the `onClick` handler if is triggered by a `cmd + click` action.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
