### PR TITLE
Set size variants for `RadialProgress`

### DIFF
--- a/packages/app-elements/src/ui/atoms/RadialProgress.tsx
+++ b/packages/app-elements/src/ui/atoms/RadialProgress.tsx
@@ -8,19 +8,22 @@ interface RadialProgressProps extends SVGAttributes<SVGElement> {
    */
   percentage?: number
   /**
-   * Size in pixels, default is 42
+   * Size variant to match `Icon` dimension.
+   * When missing, default size is 42px, small is 24px
+   * @default 'large'
    */
-  size?: number
+  size?: 'small' | 'large'
 }
 
 function RadialProgress({
   percentage,
   className,
-  size = 42,
+  size = 'large',
   ...rest
 }: RadialProgressProps): JSX.Element {
-  const viewBox = `0 0 ${size * 2} ${size * 2}`
-  const circumference = size * 2 * Math.PI
+  const sizePixels = size === 'small' ? 24 : 42
+  const viewBox = `0 0 ${sizePixels * 2} ${sizePixels * 2}`
+  const circumference = sizePixels * 2 * Math.PI
   const emptyOffset =
     circumference - (parsePercentageRange(percentage) / 100) * circumference
 
@@ -30,17 +33,17 @@ function RadialProgress({
       viewBox={viewBox}
       xmlns='http://www.w3.org/2000/svg'
       className={cn('transform -rotate-90 rounded-full', className)}
-      width={size}
-      height={size}
+      width={sizePixels}
+      height={sizePixels}
       {...rest}
     >
       {percentage == null ? (
         // pending
         <circle
           data-test-id='radial-progress-pending'
-          cx={size}
-          cy={size}
-          r={size}
+          cx={sizePixels}
+          cy={sizePixels}
+          r={sizePixels}
           className='text-gray-500'
           stroke='currentColor'
           strokeWidth='4'
@@ -52,9 +55,9 @@ function RadialProgress({
         <>
           <circle
             data-test-id='radial-progress-base'
-            cx={size}
-            cy={size}
-            r={size}
+            cx={sizePixels}
+            cy={sizePixels}
+            r={sizePixels}
             className='text-gray-100'
             stroke='currentColor'
             strokeWidth='12'
@@ -62,9 +65,9 @@ function RadialProgress({
           />
           <circle
             data-test-id='radial-progress-percentage'
-            cx={size}
-            cy={size}
-            r={size}
+            cx={sizePixels}
+            cy={sizePixels}
+            r={sizePixels}
             className='text-primary transition-all duration-500'
             stroke='currentColor'
             strokeWidth='12'

--- a/packages/docs/src/stories/atoms/RadialProgress.stories.tsx
+++ b/packages/docs/src/stories/atoms/RadialProgress.stories.tsx
@@ -25,3 +25,9 @@ export const Pending = Template.bind({})
 Pending.args = {
   percentage: undefined
 }
+
+export const PendingSmall = Template.bind({})
+PendingSmall.args = {
+  percentage: undefined,
+  size: 'small'
+}


### PR DESCRIPTION
## What I did
Instead of rely on custom `size` as prop, I've defined a variant `small` to match the same sizings of the Icon component.
Internally the component still uses a size in pixels, since it's required to calculate the filled part of the radius.

The only difference is that now instead of passing any custom size in pixel, we can only choose a size variant.
 
<img width="424" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/5581ac4b-7ef8-4cd0-9219-bdb7410f277d">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
