### PR TITLE
Add support for pending orders in `ListItemOrder`

### DIFF
--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -224,6 +224,33 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
         triggerAttributes: ['_cancel']
       }
 
+    case 'pending:unpaid:unfulfilled':
+      return {
+        status: 'error',
+        label: 'Pending',
+        icon: 'shoppingBag',
+        color: 'white',
+        triggerAttributes: []
+      }
+
+    case 'pending:authorized:unfulfilled':
+      return {
+        status: 'error',
+        label: 'Pending',
+        icon: 'shoppingBag',
+        color: 'white',
+        triggerAttributes: []
+      }
+
+    case 'pending:free:unfulfilled':
+      return {
+        status: 'error',
+        label: 'Pending',
+        icon: 'shoppingBag',
+        color: 'white',
+        triggerAttributes: []
+      }
+
     default:
       return {
         status: 'not_handled',

--- a/packages/app-elements/src/ui/atoms/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon.tsx
@@ -95,6 +95,7 @@ const iconMapping = {
   minus: phosphor.Minus,
   package: phosphor.Package,
   printer: phosphor.Printer,
+  shoppingBag: phosphor.ShoppingBag,
   stack: phosphor.Stack,
   upload: phosphor.Upload,
   user: phosphor.User,

--- a/packages/app-elements/src/ui/resources/ListItemOrder.tsx
+++ b/packages/app-elements/src/ui/resources/ListItemOrder.tsx
@@ -11,6 +11,7 @@ import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/lists/ListItem'
 import type { Order } from '@commercelayer/sdk'
 import isEmpty from 'lodash/isEmpty'
+import { useMemo } from 'react'
 
 interface Props {
   order: Order
@@ -25,6 +26,17 @@ export const ListItemOrder = withSkeletonTemplate<Props>(
     const { user } = useTokenProvider()
     const displayStatus = getOrderDisplayStatus(order)
     const billingAddress = order.billing_address
+
+    const name = useMemo<string>(
+      () =>
+        !isEmpty(billingAddress?.company)
+          ? billingAddress?.company ?? ''
+          : formatDisplayName(
+              billingAddress?.first_name ?? '',
+              billingAddress?.last_name ?? ''
+            ),
+      [billingAddress]
+    )
 
     return (
       <ListItem
@@ -56,13 +68,7 @@ export const ListItemOrder = withSkeletonTemplate<Props>(
               isoDate: order.updated_at,
               timezone: user?.timezone
             })}
-            {' · '}
-            {!isEmpty(billingAddress?.company)
-              ? billingAddress?.company
-              : formatDisplayName(
-                  billingAddress?.first_name ?? '',
-                  billingAddress?.last_name ?? ''
-                )}
+            {!isEmpty(name) ? ` · ${name}` : ''}
             {' · '}
             {displayStatus.task != null ? (
               <Text weight='semibold' size='small' variant='warning'>

--- a/packages/docs/src/stories/resources/OrderListItem.stories.tsx
+++ b/packages/docs/src/stories/resources/OrderListItem.stories.tsx
@@ -10,6 +10,15 @@ const setup: Meta<typeof ListItemOrder> = {
 }
 export default setup
 
+const market = {
+  type: 'markets',
+  id: '',
+  name: 'Europe',
+  created_at: '',
+  updated_at: '',
+  shared_secret: ''
+} as const
+
 const Template: StoryFn<typeof ListItemOrder> = (args) => (
   <ListItemOrder {...args} />
 )
@@ -27,6 +36,7 @@ AwaitingApproval.args = {
     number: 123456,
     payment_status: 'authorized',
     status: 'placed',
+    market,
     billing_address: {
       first_name: 'Bruce',
       last_name: 'Wayne',
@@ -56,6 +66,7 @@ Fulfilled.args = {
     payment_status: 'paid',
     fulfillment_status: 'fulfilled',
     formatted_total_amount: '$272.00',
+    market,
     billing_address: {
       first_name: 'Ringo',
       last_name: 'Starr',
@@ -70,5 +81,22 @@ Fulfilled.args = {
       city: '',
       country_code: ''
     }
+  }
+}
+
+export const Pending = Template.bind({})
+Pending.args = {
+  isLoading: false,
+  order: {
+    type: 'orders',
+    id: '',
+    created_at: '',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    number: 30817130,
+    status: 'pending',
+    payment_status: 'unpaid',
+    fulfillment_status: 'unfulfilled',
+    formatted_total_amount: '$272.00',
+    market
   }
 }


### PR DESCRIPTION
## What I did

- Exposed new `phosphor.ShoppingBag` icon
- add new `combinedStatus` to support `pending` combinations
- made rendering of customer name optional to avoid double dots separator with empty space in the middle (eg: `Jun 10 ·  · Pending`)

<img width="587" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/dd6891e7-c8a1-4d42-b14c-818274f3ca33">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
