### PR TITLE
Update Filters instructions to use `defaultOptions` instead of `restrictToOptions`

### DIFF
--- a/packages/app-elements-hook-form/src/filters/components/FieldItem.tsx
+++ b/packages/app-elements-hook-form/src/filters/components/FieldItem.tsx
@@ -36,7 +36,9 @@ export function FieldItem({ item }: FieldProps): JSX.Element | null {
           }
           name={item.sdk.predicate}
           mode={item.render.props.mode}
-          options={item.render.props.options}
+          options={item.render.props.options.filter(
+            (opt) => opt.isHidden !== true
+          )}
         />
       )
 

--- a/packages/app-elements-hook-form/src/filters/methods/adaptFormValuesToSdk.test.ts
+++ b/packages/app-elements-hook-form/src/filters/methods/adaptFormValuesToSdk.test.ts
@@ -204,14 +204,12 @@ describe('extractEnforcedValues', () => {
     })
   })
   test('should return empty object if no enforced values', () => {
-    const instructionsWithoutRestrictToOptions = instructions.filter(
+    const instructionsWithoutDefaultOptions = instructions.filter(
       (item) =>
-        !(
-          'restrictToOptions' in item.sdk && item.sdk.restrictToOptions === true
-        )
+        !('defaultOptions' in item.sdk && item.sdk.defaultOptions != null)
     )
     expect(
-      extractEnforcedValues(instructionsWithoutRestrictToOptions)
+      extractEnforcedValues(instructionsWithoutDefaultOptions)
     ).toStrictEqual({})
   })
 })

--- a/packages/app-elements-hook-form/src/filters/methods/adaptFormValuesToSdk.ts
+++ b/packages/app-elements-hook-form/src/filters/methods/adaptFormValuesToSdk.ts
@@ -131,23 +131,25 @@ export function adaptFormValuesToSdk<
 export function extractEnforcedValues(
   instructions: FiltersInstructions
 ): QueryFilter {
-  return instructions
+  const instructionsWithDefaultOptions = instructions
     .filter(isItemOptions)
-    .filter((item) => item.sdk.restrictToOptions === true)
-    .reduce<QueryFilter>((acc, item) => {
-      if (
-        !('options' in item.render.props) ||
-        ('options' in item.render.props && item.render.props.options == null)
-      ) {
-        return acc
-      }
-      return {
-        ...acc,
-        [item.sdk.predicate]: item.render.props.options
-          .map((option) => option.value)
-          .join(',')
-      }
-    }, {})
+    .filter(
+      (item) =>
+        item.sdk.defaultOptions != null && item.sdk.defaultOptions.length > 0
+    )
+  return instructionsWithDefaultOptions.reduce<QueryFilter>((acc, item) => {
+    if (
+      item.sdk.defaultOptions == null ||
+      item.sdk.defaultOptions.length === 0
+    ) {
+      return acc
+    }
+
+    return {
+      ...acc,
+      [item.sdk.predicate]: item.sdk.defaultOptions.join(',')
+    }
+  }, {})
 }
 
 /**

--- a/packages/app-elements-hook-form/src/filters/methods/mockedInstructions.ts
+++ b/packages/app-elements-hook-form/src/filters/methods/mockedInstructions.ts
@@ -24,13 +24,14 @@ export const instructions: FiltersInstructions = [
     type: 'options',
     sdk: {
       predicate: 'status_in',
-      restrictToOptions: true
+      defaultOptions: ['placed', 'approved', 'cancelled']
     },
     render: {
       component: 'toggleButtons',
       props: {
         mode: 'multi',
         options: [
+          { value: 'pending', label: 'Pending' },
           { value: 'placed', label: 'Places' },
           { value: 'approved', label: 'Approved' },
           { value: 'cancelled', label: 'Cancelled' }

--- a/packages/app-elements-hook-form/src/filters/methods/types.ts
+++ b/packages/app-elements-hook-form/src/filters/methods/types.ts
@@ -59,11 +59,11 @@ export interface BaseFilterItem {
      */
     predicate: string
     /**
-     * Restrict the sdk query to the options provides when this filter is not selected.
-     * Example, you have no `status_in` selected in UI, but if this option is `true`, the query will always contain
-     * a `status_in` predicate with all the possible filtrable statuses
+     * Set the default options to use in the query when this filter is not selected.
+     * Example, you have no `status_in` selected in UI, but if this option is `['placed', 'approved']`, the query will always contain
+     * a `status_in` predicate with `placed` and `approved` statuses. This helps to avoid getting status we never want to see (eg: 'draft')
      */
-    restrictToOptions?: boolean
+    defaultOptions?: string[]
     /**
      * Custom function to transform the form value to the SDK value
      */
@@ -84,7 +84,11 @@ export type FilterItemOptions = BaseFilterItem & {
          */
         props: {
           mode: 'multi' | 'single'
-          options: Array<{ label: string; value: string }>
+          /**
+           * an option can be hidden from the UI but still be used in the query
+           * Example: we wont show the button to filter `pending` status in the UI, but we still want to accept it for a predefined list)
+           */
+          options: Array<{ label: string; value: string; isHidden?: boolean }>
         }
       }
     | {


### PR DESCRIPTION
## What I did
We realized that logic applied to the `restrictToOptions` property does not work with our use cases.
This is because we don't want to restrict the allowed values to the options, but instead we want to handle a default options list when that filter item is not set.

Example: 
We want to be able to filter for following order statuses: `pending, placed, approved, cancelled`.
But our default list (when no filters are applied) needs to only show `placed, approved, cancelled`.
At the same time we still want to have `pending` as accepted value because we have a dedicated pending orders list.

This still covers the behaviour `restrictToOptions` had, it's just more flexible with a small price to pay (write same values inside the instructions)
```diff
sdk: {
  predicate: 'status_in',
- restrictToOptions: true,
+ defaultOptions: ['placed', 'approved', 'cancelled']
},
render: {
  component: 'toggleButtons',
  props: {
    mode: 'multi',
    options: [
+      { value: 'pending', label: 'Pending' },
      { value: 'placed', label: 'Places' },
      { value: 'approved', label: 'Approved' },
      { value: 'cancelled', label: 'Cancelled' }
    ]
  }
}
```


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
