### PR TITLE
Prevent rendering of empty `div`s in `<Stack>` when for nullish children

### DIFF
--- a/packages/app-elements/src/ui/atoms/Stack.tsx
+++ b/packages/app-elements/src/ui/atoms/Stack.tsx
@@ -16,7 +16,7 @@ function Stack({ children, ...props }: StackProps): JSX.Element {
   return (
     <div {...props} className='border-t border-b border-gray-100 py-6'>
       <div className='flex'>
-        {Children.map(children, (child) => renderChild(child))}
+        {Children.map(children, (child) => child != null && renderChild(child))}
       </div>
     </div>
   )


### PR DESCRIPTION
## What I did

`Stack` component loops received children and wraps them in a `flex` div.
It was also wrapping `undefined` or `null` child, this PR fixes this behaviour.

Example:
```
<Stack>
  <div>Element 1</div>
  <div>Element 2</div>
  {false && <div>optional element</div>} 
</Stack>
```

Before
<img width="573" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/a4362982-26b5-4c62-ac49-10ec405b57ca">

Now
<img width="621" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/96c10b6a-6c18-4b38-82a1-122c2cd15d1f">



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
