### PR TITLE
Fix `Icon`s centered positioning by moving to flexbox classnames

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon.tsx
@@ -41,8 +41,8 @@ function Icon({
   return (
     <div
       className={cn([
-        'inline-block',
-        'align-middle',
+        'flex',
+        'items-center',
         'w-fit',
         // padding
         { 'p-[10px]': gap === 'large' },


### PR DESCRIPTION
## What I did
I edited `Icon` component to replace `inline-block` and `align-middle` classnames with their counterparts based on `flexbox`: `flex` and `items-center` in order to fix a wrong positioning of icons in some places along apps elements.

Here you can see an example of wrong positioning:
<img width="571" alt="Screenshot 2023-08-02 alle 16 32 50" src="https://github.com/commercelayer/app-elements/assets/105653649/21285195-5e02-48a4-95d4-4c5d9e1fa4a3">

and here you can see the expected behavior fixed by this update:
<img width="560" alt="Screenshot 2023-08-02 alle 16 33 57" src="https://github.com/commercelayer/app-elements/assets/105653649/d847771c-6b31-4986-b5b8-56fca77bcb4c">

In our case it seems to be recommended to use `flexbox` because we mostly rely on it for creating our boxes / container and positioned hierarchies of elements.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
