### PR TITLE
Fix `ListItem` icon positioning to match design

### DIFF
--- a/packages/app-elements/src/ui/lists/ListItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.tsx
@@ -84,7 +84,13 @@ const ListItem: FC<ListItemProps> = ({
           'items-end': alignIcon === 'bottom'
         })}
       >
-        {icon != null && <div className='flex-shrink-0 mt-[2px]'>{icon}</div>}
+        {icon != null && (
+          <div
+            className={cn('flex-shrink-0', { 'mt-[2px]': alignIcon === 'top' })}
+          >
+            {icon}
+          </div>
+        )}
         <FlexRow alignItems={alignItems}>{children}</FlexRow>
       </div>
     </JsxTag>


### PR DESCRIPTION
## What I did
I edited `ListItem`'s left `Icon`'s classnames to add a top margin of `2px`. At the moment this is the only way to have a 1:1 match of our apps with our Figma design.

`ListItem`'s `Icon` needs to be positioned a top position to avoid wrong behaviors in case of `ListItem`s with long contents. So we cannot center horizontally `ListItem`s content and the only solution here ( to make everybody happy :-] ) is to add a "pixel perfect" style margin or padding only for top direction to avoid any kind of space balance issue.

Actual behavior:
<img width="564" alt="Screenshot 2023-08-02 alle 16 50 41" src="https://github.com/commercelayer/app-elements/assets/105653649/37239ca4-0437-495d-b9ff-53efd777f94a">

Expected behavior:
<img width="569" alt="Screenshot 2023-08-02 alle 16 50 13" src="https://github.com/commercelayer/app-elements/assets/105653649/2cd4be6c-44e7-4d2b-808b-8fafb8188553">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
