### PR TITLE
Set priority to get mode from url, then from access token

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/getAccessTokenFromUrl.ts
+++ b/packages/app-elements/src/providers/TokenProvider/getAccessTokenFromUrl.ts
@@ -22,16 +22,18 @@ export const getCurrentMode = ({
   accessToken?: string | null
 }): Mode => {
   const defaultMode = 'live'
+  const modeParam = new URLSearchParams(window.location.search).get('mode')
 
-  if (accessToken == null) {
-    const modeParam = new URLSearchParams(window.location.search).get('mode')
-    return modeParam === 'test' || modeParam === 'live'
-      ? modeParam
-      : defaultMode
+  if (modeParam === 'test' || modeParam === 'live') {
+    return modeParam
   }
 
-  const { mode } = getInfoFromJwt(accessToken)
-  return mode ?? defaultMode
+  if (accessToken != null) {
+    const { mode } = getInfoFromJwt(accessToken)
+    return mode ?? defaultMode
+  }
+
+  return defaultMode
 }
 
 export const removeAuthParamsFromUrl = (): void => {


### PR DESCRIPTION
## What I did

Instead of checking first the mode from stored accessToken and then from url param, I swap the order so url param has always priority

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
