### PR TITLE
Validate currentMode in TokenProvider

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -177,7 +177,8 @@ export function TokenProvider({
           accessToken,
           kind,
           domain,
-          isProduction: !devMode
+          isProduction: !devMode,
+          currentMode: getCurrentMode({ accessToken })
         })
 
         if (!tokenInfo.isValidToken) {

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
@@ -32,7 +32,8 @@ describe('isValidTokenForCurrentApp', () => {
       accessToken: token,
       kind: 'integration',
       domain: 'commercelayer.io',
-      isProduction: false
+      isProduction: false,
+      currentMode: 'test'
     })
 
     expect(tokenInfo.isValidToken).toBe(true)

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.ts
@@ -49,16 +49,25 @@ export async function isValidTokenForCurrentApp({
   accessToken,
   kind,
   domain,
-  isProduction
+  isProduction,
+  currentMode
 }: {
   accessToken: string
   kind: TokenProviderTokenApplicationKind
   domain: string
   isProduction: boolean
+  currentMode: Mode
 }): Promise<ValidToken | InvalidToken> {
   const jwtInfo = getInfoFromJwt(accessToken)
 
   if (jwtInfo.slug == null) {
+    return {
+      isValidToken: false
+    }
+  }
+
+  // this means we are trying to use a token for a different mode (live|test) the app is running on
+  if (jwtInfo.mode !== currentMode) {
     return {
       isValidToken: false
     }


### PR DESCRIPTION
## What I did

There is a case where we open (via cross link) an app with `?mode` param in url, but we already have a token for a different `mode` stored in our sessionStorage.

This PR add a validation to check this and return ad invalid token if mode is different.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
