### PR TITLE
Remove unwanted padding top in `Overlay`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Overlay.tsx
+++ b/packages/app-elements/src/ui/atoms/Overlay.tsx
@@ -77,7 +77,7 @@ const Overlay: React.FC<OverlayProps> = ({
       data-test-id='overlay'
       {...rest}
     >
-      <Container className={cn('pt-5')} minHeight={false}>
+      <Container minHeight={false}>
         <div ref={overlayContent}>{children}</div>
 
         {hasButton && (

--- a/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
+++ b/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
@@ -142,17 +142,19 @@ function RelationshipSelector({
           }
         }}
       >
-        <FullList
-          defaultValues={values}
-          fieldForLabel={fieldForLabel}
-          fieldForValue={fieldForValue}
-          onChange={setValues}
-          resource={resource}
-          searchBy={searchBy}
-          sortBy={sortBy}
-          title={title}
-          totalCount={totalCount}
-        />
+        <div className='pt-5'>
+          <FullList
+            defaultValues={values}
+            fieldForLabel={fieldForLabel}
+            fieldForValue={fieldForValue}
+            onChange={setValues}
+            resource={resource}
+            searchBy={searchBy}
+            sortBy={sortBy}
+            title={title}
+            totalCount={totalCount}
+          />
+        </div>
       </Overlay>
     </div>
   )


### PR DESCRIPTION
## What I did

- I removed from main `Overlay` container the `pt-5` classname because it is not necessary and it was added only to manage a standard case of `Overlay` without any internal layout. Due to the fact that in most of cases we do use a layout (`PageLayout`) in currently created `Overlay`s it is better to delegate the padding/margin setup to each usage of `Overlay` while setting its content.
- To maintain backward compatibility of existing `Overlay`s managed internally in `app-elements` I added the `pt-5` classname to `RelationshipSelector`'s first `Overlay` child. Actually this one is the only `app-elements` component using an `Overlay` without a `PageLayout`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
