### PR TITLE
Set unique key in `useCoreApi`

### DIFF
--- a/packages/app-elements/src/providers/CoreSdkProvider/useCoreApi.tsx
+++ b/packages/app-elements/src/providers/CoreSdkProvider/useCoreApi.tsx
@@ -1,5 +1,6 @@
 import type { CommerceLayerClient } from '@commercelayer/sdk'
 import { type ResourceTypeLock } from '@commercelayer/sdk/lib/cjs/api'
+import { useCallback } from 'react'
 import useSWR, {
   type Fetcher,
   type SWRConfiguration,
@@ -29,13 +30,20 @@ export function useCoreApi<
 ): SWRResponse<Output, any, SWROptions> {
   const { sdkClient } = useCoreSdkProvider()
 
-  const fetcher = async (args: Args): Promise<Output> => {
-    // @ts-expect-error I don't know how to fix it :(
-    return sdkClient[resource][action](...args)
-  }
+  const fetcher = useCallback(
+    async ([resource, action, args]: [
+      resource: Resource,
+      action: Action,
+      args: Args
+    ]): Promise<Output> => {
+      // @ts-expect-error I don't know how to fix it :(
+      return sdkClient[resource][action](...args)
+    },
+    [sdkClient]
+  )
 
   return useSWR(
-    args != null ? (args.length > 0 ? args : [{}]) : null,
+    args !== null ? [resource, action, args] : null,
     fetcher,
     config
   )


### PR DESCRIPTION
## What we did

Since first `useSwr` argument is also used as key to cache fetched data, this PR fix it with an unique value.
Now key contains not only the query arguments, but also resource and action.

Also, the `fetcher` method has been memoized within an `useCallback`

## How to test

```
  const { data: addresses } = useCoreApi('addresses', 'list', [])
  const { data: skus } = useCoreApi('skus', 'list', [])
```
The above code now triggers two different api requests also if the third params is the same (`[]`)

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
