### PR TITLE
Show formatted resource name in RelationshipSelector

### DIFF
--- a/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
+++ b/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
@@ -1,3 +1,4 @@
+import { formatResourceName } from '#helpers/resources'
 import { useOverlayNavigation } from '#hooks/useOverlayNavigation'
 import { useCoreApi } from '#providers/CoreSdkProvider'
 import { Card } from '#ui/atoms/Card'
@@ -128,7 +129,11 @@ function RelationshipSelector({
             }}
           >
             <Text variant='primary' weight='bold'>
-              See all {resource}
+              See all{' '}
+              {formatResourceName({
+                resource,
+                count: 'plural'
+              })}
             </Text>
           </button>
         </Spacer>


### PR DESCRIPTION
## What I did

Before
<img width="325" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/8baa1b24-c93f-4405-aa00-93070f0fa454">

Now
<img width="308" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/1f8e401e-73da-44b6-9e1c-c72c024cb4b3">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
