### PR TITLE
Remove `InputSelect` indicator if `isMulti`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -10,6 +10,9 @@ import { type SelectValue } from '.'
 function DropdownIndicator(
   props: DropdownIndicatorProps<SelectValue>
 ): JSX.Element {
+  if (props.isMulti) {
+    return <></>
+  }
   return (
     <components.DropdownIndicator {...props} className='p-0'>
       <button type='button' className='px-2 cursor-pointer'>


### PR DESCRIPTION
## What I did

I modified `InputSelect` override of `DropdownIndicator` to return empty if `InputSelect` is set to be multi

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
