### PR TITLE
Refactor `Tag` to be `button` and add `onTagClick` prop to `ResourceTags`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tag.tsx
+++ b/packages/app-elements/src/ui/atoms/Tag.tsx
@@ -1,7 +1,6 @@
 import { type FlexRowProps } from '#ui/internals/FlexRow'
 import { enforceAllowedTags, removeTagProp } from '#utils/htmltags'
 import cn from 'classnames'
-import isEmpty from 'lodash/isEmpty'
 import { useMemo, type FC } from 'react'
 
 type Props = Pick<FlexRowProps, 'children'> & {
@@ -24,8 +23,9 @@ export type TagProps = Props &
         /**
          * HTML tag to render
          */
-        tag: 'a'
-      } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'>)
+        tag: 'button'
+        buttonStyle: 'anchor' | 'button'
+      } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>)
   )
 
 const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
@@ -33,27 +33,29 @@ const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
     () =>
       enforceAllowedTags({
         tag: rest.tag,
-        allowedTags: ['a', 'div'],
+        allowedTags: ['button', 'div'],
         defaultTag: 'div'
       }),
     [rest.tag]
   )
-  const hasHover =
-    rest.onClick != null || (rest.tag === 'a' && !isEmpty(rest.href))
+  const hasHover = rest.onClick != null && rest.tag === 'button'
 
   return (
     <JsxTag
       className={cn([
         className,
         'flex gap-1 items-center select-none',
-        'text-black text-sm font-semibold',
+        'text-black text-sm',
         'px-4 py-1',
         'rounded border border-solid border-gray-200',
         {
-          'cursor-pointer hover:bg-gray-50 text-primary outline-primary-light':
-            hasHover
+          'cursor-pointer hover:bg-gray-50  outline-primary-light': hasHover,
+          'font-semibold': !hasHover,
+          'text-primary font-bold':
+            rest.tag === 'button' && rest.buttonStyle === 'anchor'
         }
       ])}
+      type={rest.tag === 'button' && 'button'}
       // we don't want `tag` prop to be present as attribute on html tag
       // still we need to be part of `rest` to discriminate the union type
       {...(removeTagProp(rest) as any)}

--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -40,7 +40,8 @@ export const ResourceTags = withSkeletonTemplate<{
   resourceType: TaggableResource
   resourceId: string
   overlay: TagsOverlay
-}>(({ resourceType, resourceId, overlay }) => {
+  onTagClick?: (tagId: string) => void
+}>(({ resourceType, resourceId, overlay, onTagClick }) => {
   const [showOverlay, setShowOverlay] = useState(false)
   const [selectedTagsLimitReached, setSelectedTagsLimitReached] =
     useState(false)
@@ -97,15 +98,31 @@ export const ResourceTags = withSkeletonTemplate<{
   return (
     <div>
       <div className='flex flex-wrap gap-2'>
-        {resourceTags.map((tag, idx) => (
-          <TagUi tag='div' key={idx}>
-            {tag.name}
-          </TagUi>
-        ))}
+        {resourceTags.map((tag, idx) => {
+          if (onTagClick != null) {
+            return (
+              <TagUi
+                tag='button'
+                buttonStyle='button'
+                key={idx}
+                onClick={() => {
+                  onTagClick(tag.id)
+                }}
+              >
+                {tag.name}
+              </TagUi>
+            )
+          }
+          return (
+            <TagUi tag='div' key={idx}>
+              {tag.name}
+            </TagUi>
+          )
+        })}
         <TagUi
-          tag='a'
+          tag='button'
+          buttonStyle='anchor'
           icon={<TagIcon weight='bold' />}
-          href='#'
           onClick={(e) => {
             e.preventDefault()
             setShowOverlay(true)

--- a/packages/docs/src/stories/resources/ResourceTags.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceTags.stories.tsx
@@ -28,5 +28,8 @@ Default.args = {
   resourceId: 'NMWYhbGorj',
   overlay: {
     title: 'hello@commercelayer.io'
+  },
+  onTagClick: (tagId) => {
+    console.log('onTagClick - tadId: ', tagId)
   }
 }


### PR DESCRIPTION
## What I did

- I modified `Tag` component in order to generate a tag of kind `button` instead of `a` to manage all kind of clickable `Tag`s and added a new prop called `buttonStyle` to manage the UI styling of clickable `Tag`s. Permitted styles are of kind `anchor` (text primary and weight bold) or `button` (text black and weight semibold).
- I modified `ResourceTags` component to add a new `onTagClick?: (tagId: string) => void` prop in order to let the apps to define the expected behavior to happen at `Tag` being able to access internally shared `tag` id. This new prop is used internally as `onClick` callback for each `Tag`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
