### PR TITLE
Hide select dropdown icon when async

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/Async.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/Async.tsx
@@ -52,7 +52,10 @@ export function AsyncSelectComponent({
       onChange={onSelect}
       noOptionsMessage={() => noOptionsMessage}
       loadOptions={loadOptions}
-      components={components}
+      components={{
+        ...components,
+        DropdownIndicator: null
+      }}
       isOptionDisabled={isOptionDisabled}
     />
   )

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -10,9 +10,6 @@ import { type SelectValue } from '.'
 function DropdownIndicator(
   props: DropdownIndicatorProps<SelectValue>
 ): JSX.Element {
-  if (props.isMulti) {
-    return <></>
-  }
   return (
     <components.DropdownIndicator {...props} className='p-0'>
       <button type='button' className='px-2 cursor-pointer'>


### PR DESCRIPTION
## What I did

Update logic to only show select dropdown icon on standard select. The icon will never be visible when using the async version of the component

<img width="597" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/bf65af69-b219-4eeb-ac88-9fbd18e2b7d0">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
