### PR TITLE
Remove border on `RadialProgress` inner icon

### DIFF
--- a/packages/app-elements/src/ui/atoms/RadialProgress.tsx
+++ b/packages/app-elements/src/ui/atoms/RadialProgress.tsx
@@ -88,7 +88,6 @@ function RadialProgress({
       {icon != null && (
         <Icon
           name={icon}
-          background='white'
           className='absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2'
           data-test-id='radial-progress-icon'
         />


### PR DESCRIPTION
## What I did

Before the `icon` in `RadialProgress` component was rendering with a gray border, due to the `background='white'` prop set on the icon component
<img width="125" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/4b4ba07d-d2d7-4a2a-8318-7b0363520726">

This PR fix this by rending the icon without any background prop
<img width="90" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/18d56621-e412-46e0-b680-3a3804f93954">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
