### PR TITLE
Fix forced alignment of `ListItem`s

### DIFF
--- a/packages/app-elements/src/ui/lists/ListItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.tsx
@@ -87,6 +87,9 @@ const ListItem: FC<ListItemProps> = ({
         {icon != null && (
           <div
             className={cn('flex-shrink-0', {
+              // If icon is aligned to top we add a margin to simulate centered alignment
+              // of icon with right content of most common case with one or two rows of text
+              // like in case of ListItem Order
               'my-0.5': alignIcon === 'top',
               'self-center': alignIcon === 'center',
               'self-start': alignIcon === 'top',


### PR DESCRIPTION
## What I did

After having added a 2px margin-top to simulate centered position of listitem's case with big icon and two rows (mostly used for `ListItem Order` case we faced that this fix was not working for list items with small icon and just one line of text on the right.
So I proposed to have always the main flex container of the `ListItem` to be `items-center` and to move positioning of icon directly at icon container level taking advantage of `self-[top|center|end]` classnames. Then the `margin-top: 2px` rule on top position icons has been replaced with `margin: 0.5rem 0` in order to be fine both with big icon and two lines of text and little icon with one line of text.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
