### PR TITLE
Optional icons in `RelationshipSelector` checkboxes

### DIFF
--- a/packages/app-elements/src/ui/resources/RelationshipSelector/Checkbox.tsx
+++ b/packages/app-elements/src/ui/resources/RelationshipSelector/Checkbox.tsx
@@ -13,10 +13,12 @@ export interface CheckboxItem {
 interface CheckboxProps
   extends Pick<InputCheckboxProps, 'checked' | 'onChange'> {
   item: CheckboxItem
+  showIcon?: boolean
 }
 
 export function Checkbox({
   item,
+  showIcon,
   checked,
   onChange
 }: CheckboxProps): JSX.Element {
@@ -26,7 +28,11 @@ export function Checkbox({
       <InputCheckbox
         onChange={onChange}
         checked={checked}
-        icon={<AvatarLetter text={item.label} />}
+        icon={
+          showIcon != null && showIcon ? (
+            <AvatarLetter text={item.label} />
+          ) : undefined
+        }
       >
         <Text weight='semibold'>{item.label}</Text>
       </InputCheckbox>

--- a/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
+++ b/packages/app-elements/src/ui/resources/RelationshipSelector/index.tsx
@@ -33,9 +33,13 @@ export interface RelationshipSelectorProps
    * Hide the component when there is only one item.
    */
   hideWhenSingleItem?: boolean
+  /**
+   * Show icon in checkbox selectors
+   */
+  showCheckboxIcon?: boolean
 }
 
-function RelationshipSelector({
+export function RelationshipSelector({
   defaultValues,
   fieldForLabel,
   fieldForValue,
@@ -46,6 +50,7 @@ function RelationshipSelector({
   sortBy,
   filters = {},
   hideWhenSingleItem,
+  showCheckboxIcon = true,
   title
 }: RelationshipSelectorProps): JSX.Element {
   const { Overlay, close, open } = useOverlayNavigation({
@@ -114,6 +119,7 @@ function RelationshipSelector({
                 onChange={() => {
                   toggleValue(item.value)
                 }}
+                showIcon={showCheckboxIcon}
               />
             </Spacer>
           )
@@ -271,4 +277,3 @@ function useList({
 }
 
 RelationshipSelector.displayName = 'RelationshipSelector'
-export { RelationshipSelector }


### PR DESCRIPTION
## What I did

I modified `RelationshipSelector` component and its internal `Checkbox` component in order to add respectively:
- a `showCheckboxIcon` optional boolean prop (default: `true`) to `RelationshipSelector`
- a `showIcon` optional boolean prop to `Checkbox`

This changes would let users of `RelationshipSelector` to define whether to show or not the `AvatarLetter` icon next to each checkbox.
The new prop `showCheckboxIcon` will be also available while configuring this kind of selector inside `Filters` `instructions`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
