### PR TITLE
Use LineItem id as a uniq key

### DIFF
--- a/packages/app-elements/src/ui/resources/LineItems.tsx
+++ b/packages/app-elements/src/ui/resources/LineItems.tsx
@@ -151,7 +151,7 @@ export const LineItems = withSkeletonTemplate<{
             const isEditable = editable && lineItem.type === 'line_items'
 
             return (
-              <Fragment key={`${lineItem.type}-${code}`}>
+              <Fragment key={lineItem.id}>
                 <tr className='h-0'>
                   <td
                     className={cn('w-0', {

--- a/packages/docs/src/stories/resources/LineItem.stories.tsx
+++ b/packages/docs/src/stories/resources/LineItem.stories.tsx
@@ -72,7 +72,7 @@ export const Default = Template.bind({})
 Default.args = {
   preset: ['custom'],
   isLoading: false,
-  items: [presetLineItems.oneLine],
+  items: [{ ...presetLineItems.oneLine, id: 'nIp9785zse' }],
   footer,
   onChange() {
     alert('Something has changed!')


### PR DESCRIPTION
## What I did

Since is possible to have many `line_items` with the same SKU, I changed the component key to use the `id` from the line item.