### PR TITLE
Add `teal` and `teal-solid` badges and show all the available variants in the doc

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -50,7 +50,7 @@ export {
 export { A } from '#ui/atoms/A'
 export { Avatar } from '#ui/atoms/Avatar'
 export { AvatarLetter } from '#ui/atoms/AvatarLetter'
-export { Badge } from '#ui/atoms/Badge'
+export { Badge, badgeVariants } from '#ui/atoms/Badge'
 export { BlockCode } from '#ui/atoms/BlockCode'
 export { Button } from '#ui/atoms/Button'
 export { ButtonFilter } from '#ui/atoms/ButtonFilter'

--- a/packages/app-elements/src/ui/atoms/Badge.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge.tsx
@@ -2,16 +2,18 @@ import cn from 'classnames'
 import React from 'react'
 
 export type BadgeVariant =
-  | 'primary'
-  | 'secondary'
-  | 'warning'
-  | 'danger'
-  | 'success'
-  | 'primary-solid'
-  | 'secondary-solid'
-  | 'warning-solid'
   | 'danger-solid'
+  | 'danger'
+  | 'primary-solid'
+  | 'primary'
+  | 'secondary-solid'
+  | 'secondary'
   | 'success-solid'
+  | 'success'
+  | 'teal-solid'
+  | 'teal'
+  | 'warning-solid'
+  | 'warning'
 
 interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   variant: BadgeVariant
@@ -19,17 +21,23 @@ interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
 }
 
 const variantCss: Record<BadgeVariant, string> = {
-  primary: 'text-primary bg-primary/10',
-  secondary: 'text-gray-500 bg-gray-500/10',
-  warning: 'text-orange bg-orange/10',
-  danger: 'text-red bg-red/10',
-  success: 'text-green bg-green/10',
+  'danger-solid': 'text-white bg-red',
   'primary-solid': 'text-white bg-primary',
   'secondary-solid': 'text-white bg-gray-500',
+  'success-solid': 'text-white bg-green',
+  'teal-solid': 'text-white bg-teal',
   'warning-solid': 'text-white bg-orange',
-  'danger-solid': 'text-white bg-red',
-  'success-solid': 'text-white bg-green'
+  danger: 'text-red bg-red/10',
+  primary: 'text-primary bg-primary/10',
+  secondary: 'text-gray-500 bg-gray-500/10',
+  success: 'text-green bg-green/10',
+  teal: 'text-teal-800 bg-teal-800/10',
+  warning: 'text-orange bg-orange/10'
 }
+
+export const badgeVariants = Object.keys(variantCss) as Array<
+  keyof typeof variantCss
+>
 
 function Badge({ variant, label, className, ...rest }: Props): JSX.Element {
   return (

--- a/packages/docs/src/stories/atoms/Badge.stories.tsx
+++ b/packages/docs/src/stories/atoms/Badge.stories.tsx
@@ -1,4 +1,5 @@
-import { Badge } from '#ui/atoms/Badge'
+import { Badge, badgeVariants } from '#ui/atoms/Badge'
+import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Badge> = {
@@ -9,19 +10,46 @@ export default setup
 
 const Template: StoryFn<typeof Badge> = (args) => <Badge {...args} />
 
-export const Primary = Template.bind({})
-Primary.args = {
+export const Default = Template.bind({})
+Default.args = {
   variant: 'success',
   label: 'completed'
 }
 
-export const Warning = Template.bind({})
-Warning.args = {
+/** These are all the possible values for the `variant` prop. */
+export const AvailableVariants: StoryFn = () => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+      gridAutoFlow: 'row',
+      gap: '1rem'
+    }}
+  >
+    {badgeVariants.sort().map((name) => (
+      <div key={name} className='flex flex-row gap-2 items-center align-middle'>
+        <Badge key={name} variant={name} label={name} />
+        <CopyToClipboard showValue={false} value={name} />
+      </div>
+    ))}
+  </div>
+)
+AvailableVariants.parameters = {
+  docs: {
+    source: {
+      code: null
+    }
+  }
+}
+
+export const Simple = Template.bind({})
+Simple.args = {
   variant: 'warning',
   label: 'TEST DATA'
 }
-export const WarningSolid = Template.bind({})
-WarningSolid.args = {
+
+export const Solid = Template.bind({})
+Solid.args = {
   variant: 'warning-solid',
   label: 'TEST DATA'
 }

--- a/packages/docs/src/stories/atoms/Icon.stories.tsx
+++ b/packages/docs/src/stories/atoms/Icon.stories.tsx
@@ -1,5 +1,5 @@
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
-import { Icon, iconNames } from '#ui/atoms/Icon'
+import { Icon, iconNames, type IconProps } from '#ui/atoms/Icon'
 import { Text } from '#ui/atoms/Text'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -19,7 +19,8 @@ Default.args = {
   name: 'check'
 }
 
-export const AvailableIcons: StoryFn = () => (
+/** These are all the possible values for the `name` prop. */
+export const AvailableNames: StoryFn = () => (
   <div
     style={{
       display: 'grid',
@@ -39,7 +40,59 @@ export const AvailableIcons: StoryFn = () => (
     ))}
   </div>
 )
-AvailableIcons.parameters = {
+AvailableNames.parameters = {
+  docs: {
+    source: {
+      code: null
+    }
+  }
+}
+
+/** These are all the possible values for the `background` prop. */
+export const AvailableBackgrounds: StoryFn = () => {
+  const backgrounds = [
+    undefined,
+    ...(
+      Object.keys({
+        black: null,
+        gray: null,
+        green: null,
+        none: null,
+        orange: null,
+        red: null,
+        teal: null,
+        white: null
+      } satisfies Record<NonNullable<IconProps['background']>, null>) as Array<
+        NonNullable<IconProps['background']>
+      >
+    ).sort()
+  ]
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+        gridAutoFlow: 'row',
+        gap: '1rem'
+      }}
+    >
+      {backgrounds.map((name) => (
+        <div
+          key={name}
+          className='flex flex-row gap-2 items-center align-middle'
+        >
+          <Icon key={name} name='check' background={name} gap='small' />
+          <Text size='small' variant='info'>
+            {name}
+          </Text>
+          <CopyToClipboard showValue={false} value={name} />
+        </div>
+      ))}
+    </div>
+  )
+}
+AvailableBackgrounds.parameters = {
   docs: {
     source: {
       code: null


### PR DESCRIPTION
## What I did

Add `teal` and `teal-solid` badges and show all the available variants in the doc.
<img width="671" alt="Screenshot 2023-08-16 alle 11 52 40" src="https://github.com/commercelayer/app-elements/assets/1681269/b7679534-1409-40db-a840-7b6aa4443e7b">

I also added all the available `background`s to the `<Icon>` doc.
<img width="660" alt="Screenshot 2023-08-16 alle 11 53 08" src="https://github.com/commercelayer/app-elements/assets/1681269/e2d9aecf-05b1-4a26-aa78-6dfb02ebf9c9">
