### PR TITLE
Decrease filters bottom margin in FiltersForm

### DIFF
--- a/packages/app-elements-hook-form/src/filters/components/FiltersForm.tsx
+++ b/packages/app-elements-hook-form/src/filters/components/FiltersForm.tsx
@@ -55,7 +55,7 @@ function FiltersForm({
       {instructions.map((item) => {
         if (isItemOptions(item) && item.hidden !== true) {
           return (
-            <Spacer bottom='14' key={item.label}>
+            <Spacer bottom='10' key={item.label}>
               <FieldItem item={item} />
             </Spacer>
           )
@@ -63,7 +63,7 @@ function FiltersForm({
 
         if (item.type === 'timeRange') {
           return (
-            <Spacer bottom='14' key={item.label}>
+            <Spacer bottom='10' key={item.label}>
               <FieldTimeRange item={item} />
             </Spacer>
           )
@@ -71,7 +71,7 @@ function FiltersForm({
 
         if (item.type === 'currencyRange') {
           return (
-            <Spacer bottom='14' key={item.label}>
+            <Spacer bottom='10' key={item.label}>
               <FieldCurrencyRange item={item} />
             </Spacer>
           )

--- a/packages/app-elements/src/ui/atoms/Spacer.tsx
+++ b/packages/app-elements/src/ui/atoms/Spacer.tsx
@@ -1,5 +1,5 @@
-import { type ReactNode } from 'react'
 import cn from 'classnames'
+import { type ReactNode } from 'react'
 
 export interface SpacingProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
@@ -30,7 +30,7 @@ export interface SpacingProps extends React.HTMLAttributes<HTMLDivElement> {
  * 12: 3rem, 48px
  * 14: 3.5rem, 56px
  */
-export type SpacingValues = '2' | '4' | '6' | '8' | '12' | '14'
+export type SpacingValues = '2' | '4' | '6' | '8' | '10' | '12' | '14'
 
 const marginTopCss: Record<SpacingValues | 'none', string> = {
   none: '',
@@ -38,6 +38,7 @@ const marginTopCss: Record<SpacingValues | 'none', string> = {
   '4': 'mt-4',
   '6': 'mt-6',
   '8': 'mt-8',
+  '10': 'mt-10',
   '12': 'mt-12',
   '14': 'mt-14'
 }
@@ -48,6 +49,7 @@ const marginBottomCss: Record<SpacingValues | 'none', string> = {
   '4': 'mb-4',
   '6': 'mb-6',
   '8': 'mb-8',
+  '10': 'mb-10',
   '12': 'mb-12',
   '14': 'mb-14'
 }
@@ -58,6 +60,7 @@ const marginLeftCss: Record<SpacingValues | 'none', string> = {
   '4': 'ml-4',
   '6': 'ml-6',
   '8': 'ml-8',
+  '10': 'ml-10',
   '12': 'ml-12',
   '14': 'ml-14'
 }
@@ -68,6 +71,7 @@ const marginRightCss: Record<SpacingValues | 'none', string> = {
   '4': 'mr-4',
   '6': 'mr-6',
   '8': 'mr-8',
+  '10': 'mr-10',
   '12': 'mr-12',
   '14': 'mr-14'
 }


### PR DESCRIPTION
## What I did

I reduced from 56px (`pt-14`) to 40px (`pt-10`) filters bottom margin in `FiltersForm` component according to design team reporting.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
