### PR TITLE
Fix mobile visualization of `ListItemOrder`

### DIFF
--- a/packages/app-elements/src/ui/resources/ListItemOrder.tsx
+++ b/packages/app-elements/src/ui/resources/ListItemOrder.tsx
@@ -53,6 +53,7 @@ export const ListItemOrder = withSkeletonTemplate<Props>(
             />
           )
         }
+        alignItems='top'
         data-test-id='ListItemOrder'
         onClick={onClick}
         {...rest}
@@ -85,7 +86,13 @@ export const ListItemOrder = withSkeletonTemplate<Props>(
           </Text>
         </div>
         <div>
-          <Text tag='div' weight='semibold' data-test-id='ListItemOrder-total'>
+          <Text
+            tag='div'
+            weight='semibold'
+            data-test-id='ListItemOrder-total'
+            className='break-keep'
+            wrap='nowrap'
+          >
             {order.formatted_total_amount}
           </Text>
           <Text
@@ -94,6 +101,7 @@ export const ListItemOrder = withSkeletonTemplate<Props>(
             size='small'
             variant='info'
             data-test-id='ListItemOrder-payment'
+            wrap='nowrap'
           >
             {getOrderPaymentStatusName(order.payment_status)}
           </Text>


### PR DESCRIPTION
## What I did

I noticed that in case of `ListItemOrder`s showing orders with total amount of more then `99.xx` the price breaks in two lines so I forced price and order status `Text` wrappers to avoid wrap behavior. I also set the items alignment to top to have always the content slot of the `ListItemOrder` aligned to top same as its icon.

### Actual behavior

<img width="371" alt="Screenshot 2023-08-16 alle 16 31 47" src="https://github.com/commercelayer/app-elements/assets/105653649/ca0babb5-7bc7-4564-a7bd-6ecaf38d8861">

### Wanted behavior

<img width="374" alt="Screenshot 2023-08-16 alle 16 33 56" src="https://github.com/commercelayer/app-elements/assets/105653649/3540c274-0cea-4c6d-bda3-16fdea5771f2">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
