### PR TITLE
Add `click` action to full clickable area of `RelationshipSelector` checkboxes

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox.tsx
@@ -38,6 +38,9 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
                 'cursor-pointer': rest.disabled !== true
               }
             )}
+            onClick={(e) => {
+              e.stopPropagation()
+            }}
           >
             <input
               type='checkbox'

--- a/packages/app-elements/src/ui/resources/RelationshipSelector/Checkbox.tsx
+++ b/packages/app-elements/src/ui/resources/RelationshipSelector/Checkbox.tsx
@@ -4,6 +4,7 @@ import { Text } from '#ui/atoms/Text'
 import { InputCheckbox, type InputCheckboxProps } from '#ui/forms/InputCheckbox'
 import { type CommerceLayerClient } from '@commercelayer/sdk'
 import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
+import { useRef } from 'react'
 
 export interface CheckboxItem {
   value: string
@@ -24,9 +25,19 @@ export function Checkbox({
   onChange
 }: CheckboxProps): JSX.Element {
   const isLoading = item.value === '' // is mock
+  const checkbox = useRef<HTMLInputElement>(null)
+
   return (
     <SkeletonTemplate isLoading={isLoading} delayMs={0}>
-      <div className='rounded p-3 hover:bg-gray-50 mb-[1px] last:mb-0'>
+      <div
+        className='rounded p-3 hover:bg-gray-50 mb-[1px] last:mb-0 cursor-pointer'
+        onClick={(e) => {
+          if (checkbox.current != null) {
+            checkbox.current.click()
+            checkbox.current.focus()
+          }
+        }}
+      >
         <InputCheckbox
           onChange={onChange}
           checked={checked}
@@ -35,6 +46,7 @@ export function Checkbox({
               <AvatarLetter text={item.label} />
             ) : undefined
           }
+          ref={checkbox}
         >
           <Text weight='semibold'>{item.label}</Text>
         </InputCheckbox>


### PR DESCRIPTION
## What I did

- I add an onClick action to checkbox wrapper of `RelationshipSelector` checkboxes in order to trigger checkbox click on wrapper click.
- I modified also `InputCheckbox` to set the event.stopPropagation() on its onClick event to avoid propagated clicks.


https://github.com/commercelayer/app-elements/assets/105653649/93bba6c3-5e39-46e4-92f9-3686bdafcc1c

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
