### PR TITLE
Avoid useless api requests in `ResourceTags`

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -59,13 +59,6 @@ export const ResourceTags = withSkeletonTemplate<{
         ]
   )
 
-  const { data: organizationTags } = useCoreApi('tags', 'list', [
-    {
-      fields: ['id', 'name'],
-      sort: ['updated_at'],
-      pageSize: 10
-    }
-  ])
   const { sdkClient } = useCoreSdkProvider()
 
   const tagsToSelectOptions = useCallback(
@@ -93,7 +86,7 @@ export const ResourceTags = withSkeletonTemplate<{
     tagsToSelectOptions(resourceTags ?? [])
   )
 
-  if (resourceTags == null || organizationTags == null) return <></>
+  if (resourceTags == null) return <></>
 
   return (
     <div>
@@ -189,9 +182,12 @@ export const ResourceTags = withSkeletonTemplate<{
               isClearable={false}
               isOptionDisabled={() => selectedTags.length >= 10}
               loadAsyncValues={async (hint) => {
-                return await sdkClient.tags
-                  .list(makeTagQuery(hint))
-                  .then(tagsToSelectOptions)
+                if (hint.length > 0) {
+                  return await sdkClient.tags
+                    .list(makeTagQuery(hint))
+                    .then(tagsToSelectOptions)
+                }
+                return []
               }}
               initialValues={[]}
               defaultValue={tagsToSelectOptions(resourceTags)}


### PR DESCRIPTION
## What I did

- I removed no more used api request to gather all organization tags previously used to fill the default status of the select.
- I added a check in the tags search `InputSelect` `loadAsyncValues` prop in order to avoid the search if `hint` is empty.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
