### PR TITLE
The `<A>` element now requires the `href` prop

### DIFF
--- a/packages/app-elements/src/styles/global.css
+++ b/packages/app-elements/src/styles/global.css
@@ -6,6 +6,10 @@ body {
     @apply text-gray-800 antialiased font-medium;
 }
 
+a {
+    @apply text-primary font-bold outline-0 outline-offset-4 outline-primary-light hover:text-primary-light border-primary-light cursor-pointer;
+}
+
 progress.progress {
     @apply w-full h-2;
 }

--- a/packages/app-elements/src/ui/atoms/A.test.tsx
+++ b/packages/app-elements/src/ui/atoms/A.test.tsx
@@ -1,29 +1,17 @@
+import { render } from '@testing-library/react'
 import { A } from './A'
-import { render, type RenderResult } from '@testing-library/react'
-
-interface SetupProps {
-  id: string
-  text: string
-}
-
-type SetupResult = RenderResult & {
-  element: HTMLElement
-}
-
-const setup = ({ id, text }: SetupProps): SetupResult => {
-  const utils = render(<A data-test-id={id}>{text}</A>)
-  const element = utils.getByTestId(id)
-  return {
-    element,
-    ...utils
-  }
-}
 
 describe('Anchor', () => {
   test('Should be rendered', () => {
-    const { element } = setup({ id: 'some-anchor', text: 'My anchor tag' })
-    expect(element).toBeVisible()
-    expect(element.innerHTML).toBe('My anchor tag')
-    expect(element.tagName).toBe('A')
+    const { getByRole } = render(
+      <A href='https://commercelayer.io'>My anchor tag</A>
+    )
+
+    const a = getByRole('link')
+    expect(a).toBeVisible()
+    expect(a.innerHTML).toBe('My anchor tag')
+    expect(a.tagName).toBe('A')
+    expect(a).toBeInstanceOf(HTMLAnchorElement)
+    expect(a.getAttribute('href')).toBe('https://commercelayer.io')
   })
 })

--- a/packages/app-elements/src/ui/atoms/A.tsx
+++ b/packages/app-elements/src/ui/atoms/A.tsx
@@ -1,20 +1,20 @@
-import cn from 'classnames'
+import { type SetRequired } from 'type-fest'
 
-interface Props extends React.AnchorHTMLAttributes<HTMLAnchorElement> {}
+export type Props = SetRequired<
+  React.AnchorHTMLAttributes<HTMLAnchorElement>,
+  'href'
+>
 
-function A({ className, children, ...rest }: Props): JSX.Element {
+/**
+ * This component wraps an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) HTML element.
+ * <blockquote type='info'>All the props are directly sent to the anchor element.</blockquote>
+ */
+export const A: React.FC<Props> = ({ children, href, ...rest }) => {
   return (
-    <a
-      className={cn([
-        className,
-        'text-primary font-bold outline-0 outline-offset-4 outline-primary-light hover:text-primary-light border-primary-light cursor-pointer'
-      ])}
-      {...rest}
-    >
+    <a href={href} {...rest}>
       {children}
     </a>
   )
 }
 
 A.displayName = 'A'
-export { A }

--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
@@ -4,8 +4,8 @@ import { Avatar } from './Avatar'
 import { Badge } from './Badge'
 import { Button } from './Button'
 import { Icon } from './Icon'
-import { SkeletonTemplate } from './SkeletonTemplate'
 import { RadialProgress } from './RadialProgress'
+import { SkeletonTemplate } from './SkeletonTemplate'
 import { Text } from './Text'
 
 describe('SkeletonTemplate', () => {
@@ -25,9 +25,10 @@ describe('SkeletonTemplate', () => {
     const { getByText, getByTestId } = render(
       <SkeletonTemplate isLoading>
         <div>Element #1</div>
-        <A>Element #2</A>
-        <Text>Element #3</Text>
-        <Button data-test-id='button'>Element #4</Button>
+        <A href='https://commercelayer.io'>Element #2</A>
+        <a href='https://commercelayer.io'>Element #3</a>
+        <Text>Element #4</Text>
+        <Button data-test-id='button'>Element #5</Button>
       </SkeletonTemplate>
     )
 
@@ -42,6 +43,9 @@ describe('SkeletonTemplate', () => {
 
     expect(getByText('Element #4')).toHaveClass('animate-pulse', '!bg-gray-50')
     expect(getByText('Element #4').nodeName).toEqual('SPAN')
+
+    expect(getByText('Element #5')).toHaveClass('animate-pulse', '!bg-gray-50')
+    expect(getByText('Element #5').nodeName).toEqual('SPAN')
 
     expect(getByTestId('button')).toHaveClass('animate-pulse', '!bg-gray-50')
   })

--- a/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
@@ -14,6 +14,7 @@ import { useTokenProvider } from '#providers/TokenProvider'
 import { A } from '#ui/atoms/A'
 import { Avatar } from '#ui/atoms/Avatar'
 import { Badge } from '#ui/atoms/Badge'
+import { Button } from '#ui/atoms/Button'
 import { Icon } from '#ui/atoms/Icon'
 import { Legend } from '#ui/atoms/Legend'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
@@ -224,13 +225,14 @@ const Tracking = withSkeletonTemplate<{
         <FlexRow className='mt-4'>
           <Text variant='info'>Tracking</Text>
           <Text weight='semibold'>
-            <A
+            <Button
+              variant='link'
               onClick={() => {
                 openTrackingDetails()
               }}
             >
               {parcel.tracking_number}
-            </A>
+            </Button>
           </Text>
         </FlexRow>
       )}

--- a/packages/docs/.storybook/main.ts
+++ b/packages/docs/.storybook/main.ts
@@ -31,6 +31,22 @@ const storybookConfig: StorybookConfig = {
   docs: {
     autodocs: true,
     docsMode: true
+  },
+  typescript: {
+    // https://storybook.js.org/addons/storybook-addon-react-docgen
+    check: true,
+    reactDocgen: 'react-docgen-typescript',
+    reactDocgenTypescriptOptions: {
+      // propFilter: (prop) => {
+      //   if (prop.parent) {
+      //     return (
+      //       !/@types\/react/.test(prop.parent.fileName)
+      //     )
+      //   }
+
+      //   return true
+      // },
+    }
   }
 }
 

--- a/packages/docs/src/stories/atoms/A.stories.tsx
+++ b/packages/docs/src/stories/atoms/A.stories.tsx
@@ -3,15 +3,34 @@ import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof A> = {
   title: 'Atoms/A',
-  component: A
+  component: A,
+  argTypes: {
+    href: {
+      type: {
+        required: true,
+        name: 'string'
+      },
+      description:
+        'The URL that the hyperlink points to. Links are not restricted to HTTP-based URLs — they can use any URL scheme supported by browsers.'
+    },
+    target: {
+      type: 'string',
+      description:
+        'Where to display the linked URL, as the name for a browsing context (a tab, window, or `<iframe>`).'
+    }
+  }
 }
 export default setup
 
-const Template: StoryFn<typeof A> = (args) => <A {...args}>I am a link</A>
+const Template: StoryFn<typeof A> = (args) => (
+  <>
+    <A {...args}>I am the &lt;A&gt; element</A>
+    <a {...args}>I am an &lt;a&gt; HTML element</a>
+  </>
+)
 
 export const Default = Template.bind({})
 Default.args = {
-  href: 'https://commercelayer.io/',
-  target: '_blank',
-  onClick: () => {}
+  href: 'https://commercelayer.io',
+  target: '_blank'
 }

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -34,6 +34,6 @@ export const Link: StoryFn = (args) => (
   <div>
     <Button variant='link'>I am a button</Button>
     <br />
-    <A onClick={() => {}}>I am a link</A>
+    <A href='https://commercelayer.io'>I am a link</A>
   </div>
 )

--- a/packages/docs/src/stories/atoms/EmptyState.stories.tsx
+++ b/packages/docs/src/stories/atoms/EmptyState.stories.tsx
@@ -29,7 +29,10 @@ WithIcon.args = {
   title: 'No adjustment yet!',
   description: (
     <>
-      Add a adjustment with the API, or use the CLI. <A>View API reference.</A>
+      Add a adjustment with the API, or use the CLI.{' '}
+      <A href='https://docs.commercelayer.io/core/v/api-reference/adjustments/object'>
+        View API reference.
+      </A>
     </>
   ),
   icon: 'stack'

--- a/packages/docs/src/stories/atoms/Hint.stories.tsx
+++ b/packages/docs/src/stories/atoms/Hint.stories.tsx
@@ -19,7 +19,7 @@ export const WithIcon = Template.bind({})
 WithIcon.args = {
   children: (
     <div>
-      Check our <A>documentation</A>.
+      Check our <A href='https://docs.commercelayer.io/core'>documentation</A>.
     </div>
   ),
   icon: 'bulb'

--- a/packages/docs/src/stories/atoms/Legend.stories.tsx
+++ b/packages/docs/src/stories/atoms/Legend.stories.tsx
@@ -1,4 +1,4 @@
-import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { Legend } from '#ui/atoms/Legend'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -22,5 +22,5 @@ export const Small = Template.bind({})
 Small.args = {
   title: 'All SKUs',
   titleSize: 'small',
-  actionButton: <A> New export</A>
+  actionButton: <Button variant='link'> New export</Button>
 }

--- a/packages/docs/src/stories/atoms/PageHeading.stories.tsx
+++ b/packages/docs/src/stories/atoms/PageHeading.stories.tsx
@@ -1,4 +1,4 @@
-import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { PageHeading } from '#ui/atoms/PageHeading'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -12,7 +12,7 @@ const setup: Meta<typeof PageHeading> = {
 export default setup
 
 const Template: StoryFn<typeof PageHeading> = (args) => (
-  <PageHeading {...args} actionButton={<A>Edit</A>} />
+  <PageHeading {...args} actionButton={<Button variant='link'>Edit</Button>} />
 )
 
 export const Default = Template.bind({})

--- a/packages/docs/src/stories/atoms/Stack.stories.tsx
+++ b/packages/docs/src/stories/atoms/Stack.stories.tsx
@@ -1,5 +1,5 @@
-import { A } from '#ui/atoms/A'
 import { Badge } from '#ui/atoms/Badge'
+import { Button } from '#ui/atoms/Button'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Stack } from '#ui/atoms/Stack'
 import { Text } from '#ui/atoms/Text'
@@ -69,7 +69,7 @@ export const Addresses: StoryFn<typeof Stack> = (args) => (
         Wilmington DE 19801 (US)
       </Text>
       <Spacer top='4'>
-        <A>Edit</A>
+        <Button variant='link'>Edit</Button>
       </Spacer>
     </div>
     <div>
@@ -86,7 +86,7 @@ export const Addresses: StoryFn<typeof Stack> = (args) => (
         Wilmington DE 19801 (US)
       </Text>
       <Spacer top='4'>
-        <A>Edit</A>
+        <Button variant='link'>Edit</Button>
       </Spacer>
     </div>
   </Stack>

--- a/packages/docs/src/stories/composite/CardDialog.stories.tsx
+++ b/packages/docs/src/stories/composite/CardDialog.stories.tsx
@@ -1,5 +1,5 @@
-import { A } from '#ui/atoms/A'
 import { Avatar } from '#ui/atoms/Avatar'
+import { Button } from '#ui/atoms/Button'
 import { Icon } from '#ui/atoms/Icon'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
@@ -142,7 +142,7 @@ Carrier.args = {
         border='none'
         gutter='none'
       >
-        <A>In transit</A>
+        <Button variant='link'>In transit</Button>
       </ListDetailsItem>
       <ListDetailsItem
         label='Tracking'
@@ -194,7 +194,7 @@ WithFooter.args = {
   onClose: undefined,
   footer: (
     <div className='text-center'>
-      <A>Hello World!</A>
+      <Button variant='link'>Hello World!</Button>
     </div>
   ),
   children: (
@@ -205,7 +205,7 @@ WithFooter.args = {
         border='none'
         gutter='none'
       >
-        <A>In transit</A>
+        <Button variant='link'>In transit</Button>
       </ListDetailsItem>
       <ListDetailsItem
         label='Tracking'

--- a/packages/docs/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/docs/src/stories/composite/PageLayout.stories.tsx
@@ -1,4 +1,4 @@
-import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { PageLayout } from '#ui/composite/PageLayout'
 
 import { type Meta, type StoryFn } from '@storybook/react'
@@ -30,5 +30,5 @@ WithActionButton.args = {
   description: 'View all resources',
   onGoBack: () => undefined,
   mode: 'live',
-  actionButton: <A>Add new</A>
+  actionButton: <Button variant='link'>Add new</Button>
 }

--- a/packages/docs/src/stories/examples/ListImports.stories.tsx
+++ b/packages/docs/src/stories/examples/ListImports.stories.tsx
@@ -1,4 +1,3 @@
-import { A } from '#ui/atoms/A'
 import { Button } from '#ui/atoms/Button'
 import { Icon } from '#ui/atoms/Icon'
 import { RadialProgress } from '#ui/atoms/RadialProgress'
@@ -32,7 +31,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
       <Spacer bottom='14'>
         <List
           title='Imports'
-          actionButton={<A>New import</A>}
+          actionButton={<Button variant='link'>New import</Button>}
           pagination={{
             recordsPerPage: 20,
             recordCount: 243,

--- a/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderAddresses.stories.tsx
@@ -1,4 +1,4 @@
-import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { Legend } from '#ui/atoms/Legend'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Stack } from '#ui/atoms/Stack'
@@ -32,7 +32,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
           Wilmington DE 19801 (US)
         </Text>
         <Spacer top='4'>
-          <A>Edit</A>
+          <Button variant='link'>Edit</Button>
         </Spacer>
       </div>
       <div>
@@ -49,7 +49,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
           Wilmington DE 19801 (US)
         </Text>
         <Spacer top='4'>
-          <A>Edit</A>
+          <Button variant='link'>Edit</Button>
         </Spacer>
       </div>
     </Stack>

--- a/packages/docs/src/stories/lists/List.stories.tsx
+++ b/packages/docs/src/stories/lists/List.stories.tsx
@@ -1,4 +1,4 @@
-import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { List } from '#ui/lists/List'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -23,7 +23,7 @@ const Template: StoryFn<typeof List> = (args) => (
 export const WithTitle = Template.bind({})
 WithTitle.args = {
   title: 'All items',
-  actionButton: <A>New item</A>
+  actionButton: <Button variant='link'>New item</Button>
 }
 
 export const WithPagination = Template.bind({})

--- a/packages/docs/src/stories/lists/ListDetailsItem.stories.tsx
+++ b/packages/docs/src/stories/lists/ListDetailsItem.stories.tsx
@@ -1,4 +1,5 @@
 import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
 import { ListDetailsItem } from '#ui/lists/ListDetailsItem'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -26,7 +27,11 @@ export const WithLink = Template.bind({})
 WithLink.args = {
   label: 'Name',
   isLoading: false,
-  children: <A>Gray Women Crop Top with Black Logo (M)</A>
+  children: (
+    <A target='_blank' href='https://commercelayer.io'>
+      Gray Women Crop Top with Black Logo (M)
+    </A>
+  )
 }
 
 export const Empty = Template.bind({})
@@ -44,7 +49,7 @@ export const List: StoryFn<typeof ListDetailsItem> = (_args) => (
       border='none'
       gutter='none'
     >
-      <A>In transit</A>
+      <Button variant='link'>In transit</Button>
     </ListDetailsItem>
     <ListDetailsItem
       label='Tracking'


### PR DESCRIPTION
## What I did

`href` is now **required** when using an `<A>` element.

```tsx
// This is wrong
<A>Wrong link</A>

// This is good
<A href="https://commercelayer.io">Commerce Layer</A>
```

If you need a link that behaves like a button, you can use a `<Button>` that renders as a link 😄 

```tsx
// This is good
<Button variant="link" onClick={() => {}}>Click me!</Button>
```

The `<a>` HTML element is now properly styled. If you want a styled link with `Link` from `wouter` you can write:

```tsx
<Link href="/path">
  <a>Link to path</a>
</Link>
```

---

The `<blockquote>` in the documentation should be fixed when we merge PR #313.

<img width="447" alt="Screenshot 2023-08-24 alle 21 50 52" src="https://github.com/commercelayer/app-elements/assets/1681269/c527399d-a65f-48c9-a21c-fcc711ca24fa">

## Checklist

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
