### PR TITLE
Prevent `ListItem` to be styled as global `<a>` css

### DIFF
--- a/packages/app-elements/src/ui/lists/ListItem.tsx
+++ b/packages/app-elements/src/ui/lists/ListItem.tsx
@@ -70,6 +70,7 @@ const ListItem: FC<ListItemProps> = ({
     <JsxTag
       className={cn(
         'flex gap-4 border-gray-100',
+        'text-gray-800 hover:text-gray-800 font-normal', // keep default text color also when used as `<a>` tag
         {
           'py-4': padding !== 'none' && padding !== 'x',
           'px-4': padding !== 'none' && padding !== 'y',


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

This PR fix a bug  on `ListItem` introduced by https://github.com/commercelayer/app-elements/pull/314

The new global style for the `a` tag was wrongly applied to `ListItem` when rendered as `<a>`:
<img width="590" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/3c7de90c-6feb-42e3-915d-477da05aadc5">

How it looks now:
<img width="581" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/f32a8c6e-b88c-47af-8df1-57c9befc815b">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
