### PR TITLE
Show tracking on parcel card when is single shipment and no carrier and rates are available

### DIFF
--- a/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.mocks.tsx
@@ -389,6 +389,20 @@ export const shipmentWithSingleParcelSingleTracking = createShipment({
   parcels: [parcelWithTracking1]
 })
 
+export const shipmentWithSingleParcelSingleTrackingNoCarrier = createShipment({
+  id: 'shipment-with-single-parcel-single-tracking',
+  status: 'packing',
+  purchaseStartedAt: '2023-07-11',
+  selectedRateId: 'rate_dhl_1111',
+  parcels: [
+    {
+      ...parcelWithTracking1,
+      tracking_details: [],
+      tracking_status: 'delivered'
+    }
+  ]
+})
+
 export const shipmentWithMultipleParcelsSingleTracking = createShipment({
   id: 'shipment-with-multiple-parcels-single-tracking',
   status: 'packing',

--- a/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ShipmentParcels.tsx
@@ -52,12 +52,14 @@ export const ShipmentParcels = withSkeletonTemplate<{
 }>(({ shipment, onRemoveParcel }) => {
   const singleTracking = hasSingleTracking(shipment)
   const rate = getShipmentRate(shipment)
+  const hasCarrier = rate != null
+
   return (
     <div
       data-test-id={`shipment-parcels-${shipment.id}`}
       className='flex flex-col gap-2'
     >
-      <Carrier shipment={shipment} />
+      {hasCarrier && <Carrier shipment={shipment} />}
       {shipment.parcels?.map((parcel) => {
         if (!hasPackage(parcel)) {
           return null
@@ -69,7 +71,7 @@ export const ShipmentParcels = withSkeletonTemplate<{
             rate={rate}
             showEstimatedDelivery={!singleTracking}
             parcel={
-              singleTracking
+              singleTracking && hasCarrier
                 ? {
                     ...parcel,
                     tracking_details: undefined,
@@ -215,24 +217,33 @@ const Tracking = withSkeletonTemplate<{
   return (
     <>
       <TrackingDetailsOverlay />
-      {trackingDetails?.status != null && (
+      {trackingDetails?.status != null ? (
         <FlexRow className='mt-4'>
           <Text variant='info'>Status</Text>
           <Text weight='semibold'>{trackingDetails.status}</Text>
         </FlexRow>
-      )}
+      ) : parcel.tracking_status != null ? (
+        <FlexRow className='mt-4'>
+          <Text variant='info'>Status</Text>
+          <Text weight='semibold'>{parcel.tracking_status}</Text>
+        </FlexRow>
+      ) : null}
       {parcel.tracking_number != null && (
         <FlexRow className='mt-4'>
           <Text variant='info'>Tracking</Text>
           <Text weight='semibold'>
-            <Button
-              variant='link'
-              onClick={() => {
-                openTrackingDetails()
-              }}
-            >
-              {parcel.tracking_number}
-            </Button>
+            {trackingDetails != null ? (
+              <Button
+                variant='link'
+                onClick={() => {
+                  openTrackingDetails()
+                }}
+              >
+                {parcel.tracking_number}
+              </Button>
+            ) : (
+              parcel.tracking_number
+            )}
           </Text>
         </FlexRow>
       )}

--- a/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ShipmentParcels.stories.tsx
@@ -4,6 +4,7 @@ import {
   shipmentWithMultipleParcelsMultipleTrackings,
   shipmentWithMultipleParcelsSingleTracking,
   shipmentWithSingleParcelSingleTracking,
+  shipmentWithSingleParcelSingleTrackingNoCarrier,
   shipmentWithStatusDifferentFromPacking,
   shipmentWithoutParcels,
   shipmentWithoutTracking,
@@ -70,6 +71,19 @@ SingleParcelSingleTracking.args = {
     alert(`removed parcel "${parcelId}"`)
   },
   shipment: shipmentWithSingleParcelSingleTracking
+}
+
+/**
+ * When there's only one parcel, but carrier information is missing. We show tracking information in the parcel box.
+ */
+export const SingleParcelSingleTrackingWithoutCarrier: StoryFn<
+  typeof ShipmentParcels
+> = (args): JSX.Element => <ShipmentParcels {...args} />
+SingleParcelSingleTrackingWithoutCarrier.args = {
+  onRemoveParcel: function (parcelId) {
+    alert(`removed parcel "${parcelId}"`)
+  },
+  shipment: shipmentWithSingleParcelSingleTrackingNoCarrier
 }
 
 /**


### PR DESCRIPTION
## What I did
Now tracking number for single shipment is shown in the carriere section.
This is not always correct since we need to also support the showing of the tracking number and status (when available) even if there is no carrier section to be displayed.

So this PR cover the above case and show a non-clickable tracking number in the parcel box when there is no carrier details.

View story -> https://64ecae0cf69bcc0008475a1e--commercelayer-app-elements.netlify.app/?path=/docs/resources-shipment-parcels--docs#single-parcel-single-tracking-without-carrier

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
