### PR TITLE
Add SkeletonTemplate inside `Legend` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Legend.tsx
+++ b/packages/app-elements/src/ui/atoms/Legend.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode } from 'react'
+import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import cn from 'classnames'
+import { type ReactNode } from 'react'
 
 export interface LegendProps {
   /**
@@ -24,42 +25,43 @@ export interface LegendProps {
   className?: string
 }
 
-// TODO: Do we want to manage headings? (h2, h3, hx)
-
-function Legend({
-  title,
-  titleSize = 'normal',
-  actionButton,
-  className,
-  border,
-  ...rest
-}: LegendProps): JSX.Element {
-  return (
-    <div
-      className={cn(
-        'border-b pb-4 flex justify-between items-center',
-        {
-          // border
-          'border-gray-100': border == null,
-          'border-transparent': border === 'none'
-        },
-        className
-      )}
-      {...rest}
-    >
-      <h2
-        className={cn({
-          // titleSize
-          'text-gray-500 font-medium': titleSize === 'small',
-          'text-lg font-semibold': titleSize === 'normal'
-        })}
+export const Legend = withSkeletonTemplate<LegendProps>(
+  ({
+    title,
+    titleSize = 'normal',
+    actionButton,
+    className,
+    border,
+    isLoading,
+    delayMs,
+    ...rest
+  }) => {
+    return (
+      <div
+        className={cn(
+          'border-b pb-4 flex justify-between items-center',
+          {
+            // border
+            'border-gray-100': border == null,
+            'border-transparent': border === 'none'
+          },
+          className
+        )}
+        {...rest}
       >
-        {title}
-      </h2>
-      <div>{actionButton}</div>
-    </div>
-  )
-}
+        <h2
+          className={cn({
+            // titleSize
+            'text-gray-500 font-medium': titleSize === 'small',
+            'text-lg font-semibold': titleSize === 'normal'
+          })}
+        >
+          {title}
+        </h2>
+        <div>{actionButton}</div>
+      </div>
+    )
+  }
+)
 
 Legend.displayName = 'Legend'
-export { Legend }

--- a/packages/app-elements/src/ui/resources/ResourceList/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/index.tsx
@@ -2,10 +2,7 @@ import { useIsChanged } from '#hooks/useIsChanged'
 import { Button } from '#ui/atoms/Button'
 import { EmptyState } from '#ui/atoms/EmptyState'
 import { Legend, type LegendProps } from '#ui/atoms/Legend'
-import {
-  withSkeletonTemplate,
-  type SkeletonTemplateProps
-} from '#ui/atoms/SkeletonTemplate'
+import { type SkeletonTemplateProps } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { InputFeedback } from '#ui/forms/InputFeedback'
 import {
@@ -19,8 +16,6 @@ import { VisibilityTrigger } from './VisibilityTrigger'
 import { infiniteFetcher, type Resource } from './infiniteFetcher'
 import { initialState, reducer } from './reducer'
 import { computeTitleWithTotalCount } from './utils'
-
-const LegendWithSkeleton = withSkeletonTemplate(Legend)
 
 export interface ResourceListItemProps<TResource extends ListableResourceType>
   extends SkeletonTemplateProps<{
@@ -139,7 +134,7 @@ function ResourceList<TResource extends ListableResourceType>({
   return (
     <div data-test-id='resource-list'>
       {title != null || actionButton != null ? (
-        <LegendWithSkeleton
+        <Legend
           isLoading={isFirstLoading}
           title={computeTitleWithTotalCount({
             title,


### PR DESCRIPTION
## What I did
I've integrated `SkeletonTemplate` inside `Legend`.

In this way we can prevent `isLoading` and `delayMs` props to be spread in the `Legend` main `<div>` and solve the following warnings:
```
Warning: React does not recognize the `isLoading` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `isloading` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Warning: React does not recognize the `delayMs` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `delayms` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
