### PR TITLE
Autofocus `SearchBar` filter when a value is already present

### DIFF
--- a/packages/app-elements-hook-form/src/filters/components/FiltersSearchBar.tsx
+++ b/packages/app-elements-hook-form/src/filters/components/FiltersSearchBar.tsx
@@ -74,6 +74,7 @@ function FiltersSearchBar({
       initialValue={safeInitialValue}
       onClear={updateTextFilter}
       onSearch={updateTextFilter}
+      autoFocus={safeInitialValue?.length > 0}
     />
   )
 }

--- a/packages/app-elements/src/ui/composite/SearchBar.tsx
+++ b/packages/app-elements/src/ui/composite/SearchBar.tsx
@@ -2,7 +2,7 @@ import { Icon } from '#ui/atoms/Icon'
 import cn from 'classnames'
 import debounce from 'lodash/debounce'
 import isEmpty from 'lodash/isEmpty'
-import { useCallback, useEffect, useState } from 'react'
+import { forwardRef, useCallback, useEffect, useState } from 'react'
 
 interface SearchBarProps {
   /**
@@ -31,81 +31,97 @@ interface SearchBarProps {
    * Placeholder text for the input element
    */
   placeholder?: string
+  /**
+   * Enable auto focus on the input element
+   */
+  autoFocus?: boolean
 }
 
-function SearchBar({
-  initialValue = '',
-  onSearch,
-  onClear,
-  debounceMs = 500,
-  className,
-  placeholder,
-  ...rest
-}: SearchBarProps): JSX.Element {
-  const [searchValue, setSearchValue] = useState('')
-
-  const debouncedOnSearch = useCallback(debounce(onSearch, debounceMs), [
-    onSearch
-  ])
-
-  useEffect(() => {
-    setSearchValue(initialValue)
-  }, [initialValue])
-
-  useEffect(
-    function unmountDebounce() {
-      return () => {
-        debouncedOnSearch?.cancel()
-      }
+/**
+ * This component renders a search bar with a clear button with debounced `onSearch` callback.
+ * <blockquote type='info'>In this way the `onSearch` callback will be triggered only when the user stops typing
+ * for the specified value of `debounceMs` (default 500ms).</blockquote>
+ */
+export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
+  (
+    {
+      initialValue = '',
+      onSearch,
+      onClear,
+      debounceMs = 500,
+      className,
+      placeholder,
+      autoFocus,
+      ...rest
     },
-    [debouncedOnSearch]
-  )
+    ref
+  ): JSX.Element => {
+    const [searchValue, setSearchValue] = useState('')
 
-  return (
-    <div
-      data-test-id='SearchBar'
-      className={cn('relative w-full', className)}
-      {...rest}
-    >
-      <Icon
-        name='magnifyingGlass'
-        className='absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-[20px]'
-      />
-      <input
-        className={cn(
-          'rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400',
-          'shadow-none !outline-0 !border-0 !ring-0',
-          '!focus:shadow-none !active:shadow-none focus:caret-primary'
-        )}
-        data-test-id='SearchBar-input'
-        placeholder={placeholder}
-        value={searchValue}
-        onChange={({ currentTarget: { value } }) => {
-          setSearchValue(value)
-          debouncedOnSearch(value)
-        }}
-      />
+    const debouncedOnSearch = useCallback(debounce(onSearch, debounceMs), [
+      onSearch
+    ])
 
-      {onClear != null && !isEmpty(searchValue) ? (
-        <button
-          data-test-id='SearchBar-clear'
+    useEffect(() => {
+      setSearchValue(initialValue)
+    }, [initialValue])
+
+    useEffect(
+      function unmountDebounce() {
+        return () => {
+          debouncedOnSearch?.cancel()
+        }
+      },
+      [debouncedOnSearch]
+    )
+
+    return (
+      <div
+        data-test-id='SearchBar'
+        className={cn('relative w-full', className)}
+        {...rest}
+      >
+        <Icon
+          name='magnifyingGlass'
+          className='absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-[20px]'
+        />
+        <input
           className={cn(
-            'flex items-center absolute top-1/2 right-4 transform -translate-y-1/2 text-gray-400',
-            'rounded outline-none ring-0 border-0',
-            'focus-within:shadow-focus focus:text-black'
+            'rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400',
+            'shadow-none !outline-0 !border-0 !ring-0',
+            '!focus:shadow-none !active:shadow-none focus:caret-primary'
           )}
-          aria-label='Clear text'
-          onClick={() => {
-            setSearchValue('')
-            onClear()
+          data-test-id='SearchBar-input'
+          placeholder={placeholder}
+          value={searchValue}
+          onChange={({ currentTarget: { value } }) => {
+            setSearchValue(value)
+            debouncedOnSearch(value)
           }}
-        >
-          <Icon name='x' className='text-[20px]' />
-        </button>
-      ) : null}
-    </div>
-  )
-}
+          ref={ref}
+          autoFocus={autoFocus}
+        />
+
+        {onClear != null && !isEmpty(searchValue) ? (
+          <button
+            data-test-id='SearchBar-clear'
+            className={cn(
+              'flex items-center absolute top-1/2 right-4 transform -translate-y-1/2 text-gray-400',
+              'rounded outline-none ring-0 border-0',
+              'focus-within:shadow-focus focus:text-black'
+            )}
+            aria-label='Clear text'
+            onClick={() => {
+              setSearchValue('')
+              onClear()
+            }}
+          >
+            <Icon name='x' className='text-[20px]' />
+          </button>
+        ) : null}
+      </div>
+    )
+  }
+)
 
 SearchBar.displayName = 'SearchBar'
-export { SearchBar }


### PR DESCRIPTION
## What I did

I've exposed `autoFocus` and  forwarded `ref` in the `SearchBar` UI component.
In this way I can now set autofocus on the filter search bar when a value is present. This solve an issue when user is searching from the home page and is taken to the list page and focus on the input was lost.

I've also added some text to document the component.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
