### PR TITLE
Use a form in `OrderSummary > adjustments` overlay

### DIFF
--- a/packages/app-elements/src/ui/hook-form/HookedForm.tsx
+++ b/packages/app-elements/src/ui/hook-form/HookedForm.tsx
@@ -8,7 +8,7 @@ interface FormProps<T extends FieldValues> extends FormProviderProps<T> {
   /**
    * Callback invoked on submit when form has been successfully validated
    */
-  onSubmit: (data: T) => void
+  onSubmit: (data: T) => Promise<void> | void
 }
 
 /**
@@ -39,8 +39,8 @@ export const HookedForm = <T extends FieldValues>({
   handleSubmit,
   ...rest
 }: FormProps<T>): JSX.Element => {
-  const doSubmit = handleSubmit((data) => {
-    onSubmit(data)
+  const doSubmit = handleSubmit(async (data) => {
+    await onSubmit(data)
   })
 
   return (


### PR DESCRIPTION
## What I did

Now that we can use `react-hook-form` directly in `app-elements`, I've updated the adjustments form inside the `OrderSummay` to use the hooked components.

In this way we can easily handle form state and perform input validation
<img width="606" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/55ff175d-266d-4f39-ab73-01e540e54ac2">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
