### PR TITLE
Rename `navigateToDetail` to `navigateTo`

### DIFF
--- a/packages/app-elements/src/helpers/appsNavigation.test.ts
+++ b/packages/app-elements/src/helpers/appsNavigation.test.ts
@@ -1,8 +1,4 @@
-import {
-  goBack,
-  navigateToDetail,
-  type BackToItem
-} from '#helpers/appsNavigation'
+import { goBack, navigateTo, type BackToItem } from '#helpers/appsNavigation'
 
 // should always match version set in appsNavigation.ts
 const currentVersion = 0.2
@@ -23,7 +19,7 @@ function allowLocationMocks(): void {
   }
 }
 
-describe('navigateToDetail', () => {
+describe('navigateTo', () => {
   beforeEach(() => {
     sessionStorage.clear()
     allowLocationMocks()
@@ -31,7 +27,7 @@ describe('navigateToDetail', () => {
   })
 
   test('should return an href string', () => {
-    const navigate = navigateToDetail({
+    const navigate = navigateTo({
       destination: {
         app: 'customers',
         resourceId: 'xBszDaQsAZ',
@@ -51,7 +47,7 @@ describe('navigateToDetail', () => {
     window.location.assign = vi.fn()
 
     // we want to x-link to a customer details in app-customers
-    const navigate = navigateToDetail({
+    const navigate = navigateTo({
       destination: {
         app: 'customers',
         resourceId: '<customerId>',
@@ -81,7 +77,7 @@ describe('navigateToDetail', () => {
     const mockedSetLocation = vi.fn()
 
     // we want to x-link to customers app
-    const navigate = navigateToDetail({
+    const navigate = navigateTo({
       setLocation: mockedSetLocation,
       destination: {
         app: 'orders',
@@ -112,7 +108,7 @@ describe('navigateToDetail', () => {
     const mockedSetLocation = vi.fn()
 
     // we want to x-link to customers app
-    const navigate = navigateToDetail({
+    const navigate = navigateTo({
       setLocation: mockedSetLocation,
       destination: {
         app: 'orders',
@@ -134,7 +130,7 @@ describe('navigateToDetail', () => {
     window.location.origin = 'https://my-custom-domain.com'
 
     // we want to x-link to customers app
-    const navigate = navigateToDetail({
+    const navigate = navigateTo({
       destination: {
         app: 'customers',
         resourceId: 'xbSzDaQsAZ',

--- a/packages/app-elements/src/helpers/appsNavigation.ts
+++ b/packages/app-elements/src/helpers/appsNavigation.ts
@@ -121,7 +121,7 @@ export function goBack({
   window.location.assign(item.url)
 }
 
-interface NavigateToInternalDetailsParams {
+interface NavigateToInternalParams {
   /**
    * React router's history.push method, this is used when linking internal app pages.
    */
@@ -137,11 +137,11 @@ interface NavigateToInternalDetailsParams {
     /**
      * resource id to open
      */
-    resourceId: string
+    resourceId?: string
   }
 }
 
-interface NavigateToExternalDetailsParams {
+interface NavigateToExternalParams {
   /**
    * destination instructions to navigate to a detail page
    */
@@ -153,7 +153,7 @@ interface NavigateToExternalDetailsParams {
     /**
      * resource id to open
      */
-    resourceId: string
+    resourceId?: string
     /**
      * required when linking to another app, it indicates if the destination app should be opened in test or live mode
      */
@@ -165,8 +165,8 @@ interface NavigateToExternalDetailsParams {
  * Navigate to an internal or external URL or pathname and store the current url in sessionStorage
  * to be able to navigate back to it with the `goBack` function.
  */
-export function navigateToDetail(
-  params: NavigateToInternalDetailsParams | NavigateToExternalDetailsParams
+export function navigateTo(
+  params: NavigateToInternalParams | NavigateToExternalParams
 ): {
   href: string
   onClick: (
@@ -208,7 +208,7 @@ export function navigateToDetail(
 }
 
 function isNavigateToInternalParams(
-  params: NavigateToInternalDetailsParams | NavigateToExternalDetailsParams
-): params is NavigateToInternalDetailsParams {
+  params: NavigateToInternalParams | NavigateToExternalParams
+): params is NavigateToInternalParams {
   return 'setLocation' in params
 }

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -1,7 +1,7 @@
 import '#styles/global.css'
 
 // Helpers
-export { goBack, navigateToDetail } from '#helpers/appsNavigation'
+export { goBack, navigateTo } from '#helpers/appsNavigation'
 export { isAttachmentValidNote, referenceOrigins } from '#helpers/attachments'
 export {
   formatDate,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I renamed `navigateToDetail` helper method to `navigateTo` and set its prop `resourceId` to be optional in order to be more generic and to support navigation to applications without being required to navigate to a detail page.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
