### PR TITLE
Add optional tags management link to `ResourceTags`

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -1,5 +1,7 @@
+import { navigateTo } from '#helpers/appsNavigation'
 import { useOverlay } from '#hooks/useOverlay'
 import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
+import { useTokenProvider } from '#providers/TokenProvider'
 import { Button } from '#ui/atoms/Button'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Tag as TagUi } from '#ui/atoms/Tag'
@@ -35,6 +37,7 @@ type TaggableResource = Extract<
 interface TagsOverlay {
   title: string
   description?: string
+  showManageAction?: boolean
 }
 
 export const ResourceTags = withSkeletonTemplate<{
@@ -88,6 +91,14 @@ export const ResourceTags = withSkeletonTemplate<{
   )
 
   if (resourceTags == null) return <></>
+
+  const { settings } = useTokenProvider()
+  const navigateToTagsManagement = navigateTo({
+    destination: {
+      app: 'tags',
+      mode: settings.mode
+    }
+  })
 
   return (
     <div>
@@ -162,6 +173,12 @@ export const ResourceTags = withSkeletonTemplate<{
           onGoBack={() => {
             close()
           }}
+          actionButton={
+            overlay.showManageAction != null &&
+            overlay.showManageAction && (
+              <a {...navigateToTagsManagement}>Manage tags</a>
+            )
+          }
         >
           <InputSelect
             label='Tags'

--- a/packages/docs/src/stories/resources/ResourceTags.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceTags.stories.tsx
@@ -27,7 +27,9 @@ Default.args = {
   resourceType: 'customers',
   resourceId: 'NMWYhbGorj',
   overlay: {
-    title: 'hello@commercelayer.io'
+    title: 'Edit tags',
+    description: 'hello@commercelayer.io',
+    showManageAction: true
   },
   onTagClick: (tagId) => {
     console.log('onTagClick - tadId: ', tagId)


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I edited `ResourceTags` component by:
- adding the `overlay` `queryParam` to be `edit-tags` to be able to navigate to the edit tags overlay
- adding an optional prop to `overlay` called `showManageAction` whose aim is to show the `Manage tags` link that navigates to the `tags` management app if enabled

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
