### PR TITLE
Generate proper dashboard url for forked apps

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -134,7 +134,8 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
 
   const dashboardUrl = makeDashboardUrl({
     domain,
-    mode: getCurrentMode({ accessToken })
+    mode: getCurrentMode({ accessToken }),
+    organizationSlug
   })
 
   const emitInvalidAuth = useCallback(function (reason: string): void {


### PR DESCRIPTION
## What I did

The dashboard url for forked apps was wrongly generated, since the `makeDashboardUrl` method was not receiving the proper `organizationSlug`.

I've fixed this by adding the missing argument.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
