### PR TITLE
Prevent `SkeletonTemplate` props to pollute `ListItem` dom node

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -47,8 +47,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
     rightContent,
     showArrow = false,
     tag = 'div',
-    onClick,
-    ...rest
+    onClick
   }) => {
     const showRightContent = rightContent != null && !showArrow
 
@@ -59,7 +58,6 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
         alignItems={showRightContent ? 'top' : 'center'}
         data-test-id='ResourceListItem'
         onClick={onClick}
-        {...rest}
       >
         <div>
           <Text


### PR DESCRIPTION
## What I did
I've removed `isLoading` / `delayMs` props injected from `withSkeletonTemplate`  and passed to `ListItem`.

This to prevent the following warning to appear in development mode

<img width="705" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/5e01d805-6f80-4715-b65a-7b33f1b6e839">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
