### PR TITLE
The `Badge` component now uses `children` prop instead of `label`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Badge.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge.test.tsx
@@ -3,7 +3,7 @@ import { Badge, type BadgeVariant } from './Badge'
 
 interface SetupProps {
   id: string
-  label: string
+  children: string
   variant: BadgeVariant
 }
 
@@ -24,7 +24,7 @@ describe('Badge', () => {
   test('Should be rendered', () => {
     const { element } = setup({
       id: 'my-badge',
-      label: 'Completed',
+      children: 'Completed',
       variant: 'success'
     })
     expect(element).toBeInTheDocument()

--- a/packages/app-elements/src/ui/atoms/Badge.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge.tsx
@@ -16,8 +16,9 @@ export type BadgeVariant =
   | 'warning'
 
 interface Props extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Render a different variant. */
   variant: BadgeVariant
-  label: string
+  children: string
 }
 
 const variantCss: Record<BadgeVariant, string> = {
@@ -39,7 +40,13 @@ export const badgeVariants = Object.keys(variantCss) as Array<
   keyof typeof variantCss
 >
 
-function Badge({ variant, label, className, ...rest }: Props): JSX.Element {
+/** Badges are used to highlight an item's status for quick recognition. */
+export const Badge: React.FC<Props> = ({
+  variant,
+  children,
+  className,
+  ...rest
+}) => {
   return (
     <div
       {...rest}
@@ -49,10 +56,9 @@ function Badge({ variant, label, className, ...rest }: Props): JSX.Element {
         variantCss[variant]
       ])}
     >
-      {label}
+      {children}
     </div>
   )
 }
 
 Badge.displayName = 'Badge'
-export { Badge }

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -69,7 +69,7 @@ function PageHeading({
       )}
       {badgeLabel != null && (
         <div className='flex mb-4 md:!mt-0' data-testid='page-heading-badge'>
-          <Badge variant={badgeVariant} label={badgeLabel} />
+          <Badge variant={badgeVariant}>{badgeLabel}</Badge>
         </div>
       )}
       <h1 className='font-semibold text-title leading-title'>{title}</h1>

--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.test.tsx
@@ -67,7 +67,9 @@ describe('SkeletonTemplate', () => {
   test('Should render <Badge> as "loading item"', () => {
     const { getByTestId } = render(
       <SkeletonTemplate isLoading>
-        <Badge data-testid='element' label='APPROVED' variant='danger' />
+        <Badge data-testid='element' variant='danger'>
+          APPROVED
+        </Badge>
       </SkeletonTemplate>
     )
 

--- a/packages/app-elements/src/ui/atoms/Tag.tsx
+++ b/packages/app-elements/src/ui/atoms/Tag.tsx
@@ -28,7 +28,7 @@ export type TagProps = Props &
       } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'children'>)
   )
 
-const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
+export const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
   const JsxTag = useMemo(
     () =>
       enforceAllowedTags({
@@ -66,4 +66,3 @@ const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
 }
 
 Tag.displayName = 'Tag'
-export { Tag }

--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -54,9 +54,10 @@ export const Timeline = withSkeletonTemplate<Props>(
                 <Badge
                   data-testid='timeline-date-group'
                   className='rounded-full bg-gray-100 py-1 px-3 font-bold'
-                  label={date}
                   variant='secondary'
-                />
+                >
+                  {date}
+                </Badge>
               </div>
               {eventsByDate.map((event) => (
                 <Fragment key={event.date}>

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -215,18 +215,12 @@ export const ResourceLineItems = withSkeletonTemplate<{
                     {lineItem.type === 'line_items' &&
                       lineItem.formatted_unit_amount != null && (
                         <Spacer top='2'>
-                          <Badge
-                            label={`Unit price ${lineItem.formatted_unit_amount}`}
-                            variant='secondary'
-                          />
+                          <Badge variant='secondary'>{`Unit price ${lineItem.formatted_unit_amount}`}</Badge>
                         </Spacer>
                       )}
                     {lineItem.type !== 'line_items' &&
                       lineItem.bundle_code != null && (
-                        <Badge
-                          label={`BUNDLE ${lineItem.bundle_code}`}
-                          variant='secondary'
-                        />
+                        <Badge variant='secondary'>{`BUNDLE ${lineItem.bundle_code}`}</Badge>
                       )}
                   </td>
                   <td valign='top' align='right'>

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -402,9 +402,10 @@ const TrackingDetails = withSkeletonTemplate<{
                 <Badge
                   data-testid='timeline-date-group'
                   className='rounded-full bg-gray-200 py-1 px-3 font-bold'
-                  label={date}
                   variant='secondary'
-                />
+                >
+                  {date}
+                </Badge>
                 <table className='mt-4 mb-6 ml-1 w-full h-full'>
                   <tbody>
                     {eventsByDate.map((event) => (

--- a/packages/docs/src/stories/atoms/Badge.stories.tsx
+++ b/packages/docs/src/stories/atoms/Badge.stories.tsx
@@ -8,12 +8,13 @@ const setup: Meta<typeof Badge> = {
 }
 export default setup
 
-const Template: StoryFn<typeof Badge> = (args) => <Badge {...args} />
+const Template: StoryFn<typeof Badge> = (args) => (
+  <Badge {...args}>completed</Badge>
+)
 
 export const Default = Template.bind({})
 Default.args = {
-  variant: 'success',
-  label: 'completed'
+  variant: 'success'
 }
 
 /** These are all the possible values for the `variant` prop. */
@@ -28,7 +29,9 @@ export const AvailableVariants: StoryFn = () => (
   >
     {badgeVariants.sort().map((name) => (
       <div key={name} className='flex flex-row gap-2 items-center align-middle'>
-        <Badge key={name} variant={name} label={name} />
+        <Badge key={name} variant={name}>
+          {name}
+        </Badge>
         <CopyToClipboard showValue={false} value={name} />
       </div>
     ))}
@@ -40,16 +43,4 @@ AvailableVariants.parameters = {
       code: null
     }
   }
-}
-
-export const Simple = Template.bind({})
-Simple.args = {
-  variant: 'warning',
-  label: 'TEST DATA'
-}
-
-export const Solid = Template.bind({})
-Solid.args = {
-  variant: 'warning-solid',
-  label: 'TEST DATA'
 }

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -75,7 +75,7 @@ const children = (
     <ListItem tag='div' borderStyle='dashed'>
       <div>
         <Text tag='div'>Ehi there!</Text>
-        <Badge label='APPROVED' variant='primary' />
+        <Badge variant='primary'>APPROVED</Badge>
       </div>
       <Button
         onClick={() => {

--- a/packages/docs/src/stories/atoms/Stack.stories.tsx
+++ b/packages/docs/src/stories/atoms/Stack.stories.tsx
@@ -31,7 +31,7 @@ export const Steps: StoryFn<typeof Stack> = (args) => (
           Order
         </Text>
       </Spacer>
-      <Badge label='APPROVED' variant='success-solid' />
+      <Badge variant='success-solid'>APPROVED</Badge>
     </div>
     <div>
       <Spacer bottom='2'>
@@ -39,7 +39,7 @@ export const Steps: StoryFn<typeof Stack> = (args) => (
           Payment
         </Text>
       </Spacer>
-      <Badge label='AUTHORIZED' variant='secondary' />
+      <Badge variant='secondary'>AUTHORIZED</Badge>
     </div>
     <div>
       <Spacer bottom='2'>
@@ -47,7 +47,7 @@ export const Steps: StoryFn<typeof Stack> = (args) => (
           Fulfillment
         </Text>
       </Spacer>
-      <Badge label='UNFULFILLED' variant='secondary' />
+      <Badge variant='secondary'>UNFULFILLED</Badge>
     </div>
   </Stack>
 )


### PR DESCRIPTION

## What I did

The `Badge` component now uses a `children` prop instead of a `label`.

before:

```tsx
<Badge variant="primary" label="Ehi" />
```

after:

```tsx
<Badge variant="primary">Ehi</Badge>
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
