### PR TITLE
Fix typo in `filterable` wording

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { getTimeRangeCustomLabel, getTimeRangePresetName } from './timeUtils'
 import {
-  filtrableTimeRangePreset,
+  filterableTimeRangePreset,
   type FilterItemTime,
   type TimeRangeFormValues
 } from './types'
@@ -69,7 +69,7 @@ export function FieldTimeRange({ item }: FieldTimeRangeProps): JSX.Element {
         label={item.label}
         name='timePreset'
         mode='single'
-        options={filtrableTimeRangePreset.map((option) => {
+        options={filterableTimeRangePreset.map((option) => {
           const label =
             option === 'custom' && timeFrom != null && timeTo != null
               ? getTimeRangeCustomLabel(timeFrom, timeTo, user?.timezone)

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.ts
@@ -2,7 +2,7 @@ import castArray from 'lodash/castArray'
 import compact from 'lodash/compact'
 import qs, { type ParsedQuery } from 'query-string'
 import {
-  filtrableTimeRangePreset,
+  filterableTimeRangePreset,
   isCurrencyRange,
   type FiltersInstructions,
   type FormFullValues,
@@ -38,14 +38,14 @@ export function adaptUrlQueryToFormValues<
 
   // parse a single filter key value to return
   // an array of valid values or an empty array
-  const parseQueryStringValueAsArray = <TFiltrableValue extends string>(
+  const parseQueryStringValueAsArray = <TFilterableValue extends string>(
     value?: ParsedQuery[string],
-    acceptedValues?: Readonly<TFiltrableValue[]>
-  ): TFiltrableValue[] => {
+    acceptedValues?: Readonly<TFilterableValue[]>
+  ): TFilterableValue[] => {
     if (value == null) {
       return []
     }
-    const cleanValue = compact(castArray(value) as TFiltrableValue[])
+    const cleanValue = compact(castArray(value) as TFilterableValue[])
     if (acceptedValues != null) {
       return cleanValue.filter((v) => acceptedValues.includes(v))
     }
@@ -158,7 +158,7 @@ export function adaptUrlQueryToFormValues<
     {
       timePreset: parseQueryStringValueAsArray(
         parsedQuery.timePreset,
-        filtrableTimeRangePreset
+        filterableTimeRangePreset
       )[0],
       timeFrom: parseQueryStringValueAsDate(parsedQuery.timeFrom),
       timeTo: parseQueryStringValueAsDate(parsedQuery.timeTo),

--- a/packages/app-elements/src/ui/resources/useResourceFilters/timeUtils.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/timeUtils.ts
@@ -5,7 +5,7 @@ import {
 } from '#helpers/date'
 import { z } from 'zod'
 import type { TimeRangeFormValues, TimeRangePreset } from './types'
-import { filtrableTimeRangePreset } from './types'
+import { filterableTimeRangePreset } from './types'
 
 interface MakerSdkFilterTimeParams {
   timePreset?: TimeRangePreset
@@ -122,7 +122,7 @@ export const timeRangeValidationSchema = z
   .object({
     timeFrom: z.date().optional().nullable(),
     timeTo: z.date().optional().nullable(),
-    timePreset: z.enum(filtrableTimeRangePreset).optional().nullable()
+    timePreset: z.enum(filterableTimeRangePreset).optional().nullable()
   })
   .passthrough()
   .superRefine((data, ctx) => {

--- a/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
@@ -1,7 +1,7 @@
 import { type InputCurrencyRangeProps } from '#ui/forms/InputCurrencyRange'
 import { type InputResourceGroupProps } from '#ui/forms/InputResourceGroup'
 
-export const filtrableTimeRangePreset = [
+export const filterableTimeRangePreset = [
   'today',
   'last7days',
   'last30days',
@@ -11,7 +11,7 @@ export const filtrableTimeRangePreset = [
 export type UiFilterName = string
 export type UiFilterValue = string | string[] | boolean | Date | undefined
 
-export type TimeRangePreset = (typeof filtrableTimeRangePreset)[number]
+export type TimeRangePreset = (typeof filterableTimeRangePreset)[number]
 
 export interface TimeRangeFormValues {
   timePreset?: TimeRangePreset | null

--- a/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
+++ b/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
@@ -47,7 +47,7 @@ const ToggleInstructions: React.FC<{
 }
 
 /**
- * This sections shows how to configure `useResourceFilters` hook to render a filtrable list of resources.
+ * This sections shows how to configure `useResourceFilters` hook to render a filterable list of resources.
  *
  * The hook takes as argument an array of instructions of type `FilterInstruction`.
  * Each instruction defines a filter that will be rendered in the form.


### PR DESCRIPTION
## What I did
I've replaced all occurrences of `filtrable` with `filterable`.
None of the renamed variable names are being exposed/exported, so this won't break anything (it's internal).

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
