### PR TITLE
Remove `display: block` from the Dropdown button

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -52,7 +52,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
         variant='link'
         aria-haspopup
         aria-expanded={isExpanded}
-        className={cn('m-0 p-0 block', {
+        className={cn('m-0 p-0 align-top', {
           '!text-black': typeof dropdownLabel !== 'string'
         })}
         onClick={() => {

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -1,3 +1,5 @@
+import { Section } from '#ui/atoms/Section'
+import { Spacer } from '#ui/atoms/Spacer'
 import { Dropdown, DropdownDivider, DropdownItem } from '#ui/composite/Dropdown'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -96,4 +98,17 @@ DropdownLabelAsString.args = {
       />
     </>
   )
+}
+
+/** Dropdown can also be used as a Section's action button. */
+export const WithinASection: StoryFn<typeof Dropdown> = (args) => {
+  return (
+    <Section title='Summary' actionButton={<Dropdown {...args} />}>
+      <Spacer top='4'>Content here ..</Spacer>
+    </Section>
+  )
+}
+WithinASection.args = DropdownLabelAsString.args
+WithinASection.parameters = {
+  layout: 'padded'
 }


### PR DESCRIPTION
## What I did

The `Button` inside the dropdown should behave like a `Button`.

before
<img width="587" alt="Screenshot 2023-09-28 alle 15 28 15" src="https://github.com/commercelayer/app-elements/assets/1681269/cff63327-2327-4fd4-826b-5980c1d040eb">

after
<img width="594" alt="Screenshot 2023-09-28 alle 15 28 39" src="https://github.com/commercelayer/app-elements/assets/1681269/eba821d7-9572-49b6-b9f7-454bdc8dd9e4">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
