### PR TITLE
Fix `Input` with autocomplete disabled

### DIFF
--- a/packages/app-elements/src/ui/forms/Input/Input.tsx
+++ b/packages/app-elements/src/ui/forms/Input/Input.tsx
@@ -42,8 +42,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             className,
             'block w-full px-4 py-2.5 font-medium',
             'rounded outline-0',
-            rest.autoComplete === 'off' &&
-              '!bg-white !shadow-[0_0_0_1000px_white_inset]',
+            rest.autoComplete === 'off' && '!bg-white',
             getFeedbackStyle(feedback)
           )}
           type={type}

--- a/packages/docs/src/stories/forms/ui/Input.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/Input.stories.tsx
@@ -46,6 +46,24 @@ WithError.args = {
   }
 }
 
+export const Email = Template.bind({})
+Email.args = {
+  label: 'Email',
+  name: 'email',
+  defaultValue: '',
+  autoComplete: 'off',
+  type: 'email'
+}
+
+export const Password = Template.bind({})
+Password.args = {
+  label: 'Password',
+  name: 'password',
+  defaultValue: '',
+  autoComplete: 'off',
+  type: 'password'
+}
+
 const TemplateValidation: StoryFn<typeof Input> = () => {
   const [value, setValue] = useState('')
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I changed the behavior of `autocomplete` prop in `Input` to set only a force white background. The force of `box-shadow` is anymore needed because we use it by default to create the border effect in our `input`s.

### Tested on:

#### LastPass

<img width="600" alt="LastPass" src="https://github.com/commercelayer/app-elements/assets/105653649/870f8532-3645-442b-a7cd-4cbdfcc5f436">

#### Apple Keychain

<img width="600" alt="Apple KeyChain" src="https://github.com/commercelayer/app-elements/assets/105653649/4e2833c4-399f-460e-8962-07d03aecdf50">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
