### PR TITLE
Handle special case for `organization` resource on abilities page

### DIFF
--- a/packages/docs/src/generate-abilities.mjs
+++ b/packages/docs/src/generate-abilities.mjs
@@ -176,8 +176,8 @@ function roleToTable({
 }) {
   return `|${[
     createLink(
-      `https://docs.commercelayer.io/core/v/api-reference/${subject}/object`,
-      subject,
+      `https://docs.commercelayer.io/core/v/api-reference/${checkSubject(subject)}/object`,
+      checkSubject(subject),
       '_blank'
     ),
     booleanToIcon(can_create),
@@ -186,6 +186,14 @@ function roleToTable({
     booleanToIcon(can_destroy),
     restrictions != null ? `\`${JSON.stringify(restrictions)}\`` : ''
   ].join('|')}`
+}
+
+/**
+ * @param {string} subject
+ * @returns {string}
+ */
+function checkSubject(subject) {
+ return subject === 'organizations' ? 'organization' : subject
 }
 
 // ------------------------------------------------------------


### PR DESCRIPTION
## What I did

I've added a special check for the `organizazion` resource that is referenced in core API documentation as singular, but arrives from the yaml as plural.

This was resulting in broken URL:
`.../api-reference/organizations/object` instead of `.../api-reference/organization/object`

Before
<img width="547" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/efcebfc3-50c4-431c-81b4-92419d7a0da1">

Now
<img width="439" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/6aeb62f3-f9e0-4de5-a1a8-7650a93359fa">


## How to test

https://deploy-preview-387--commercelayer-app-elements.netlify.app/?path=/docs/getting-started-applications--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
