### PR TITLE
Enforce and update `ResourceListItem` `returns` name

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
@@ -10,7 +10,7 @@ export const returnToProps: ResourceToProps<Return> = ({ resource, user }) => {
   const displayStatus = getReturnDisplayStatus(resource)
   const returnStockLocationName =
     resource.order?.market?.name != null
-      ? `to ${resource.order?.market?.name} `
+      ? `to ${resource.order.market.name} `
       : ''
   const returnNumber = resource.number != null ? `#${resource.number}` : ''
 

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
@@ -8,8 +8,14 @@ import { type ResourceToProps } from '../types'
 
 export const returnToProps: ResourceToProps<Return> = ({ resource, user }) => {
   const displayStatus = getReturnDisplayStatus(resource)
+  const returnStockLocationName =
+    resource.order?.market?.name != null
+      ? `to ${resource.order?.market?.name} `
+      : ''
+  const returnNumber = resource.number != null ? `#${resource.number}` : ''
+
   return {
-    name: `${resource.order?.market?.name ?? ''} #${resource.number ?? ''}`,
+    name: `Return ${returnStockLocationName}${returnNumber}`,
     description: (
       <ListItemDescription
         displayStatus={displayStatus}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I updated the generation of the `name` prop of `ResourceListItem` of resource type `returns` by enforcing some checks about possible `null` / `undefined` parts of the string and adding a prefix according to design decisions.

### Actual
<img width="559" alt="Screenshot 2023-10-05 alle 12 19 48" src="https://github.com/commercelayer/app-elements/assets/105653649/31c77099-b712-4287-81d6-b2a44efcf38a">

### Wanted
<img width="555" alt="Screenshot 2023-10-05 alle 12 20 24" src="https://github.com/commercelayer/app-elements/assets/105653649/62760ecc-90b6-492f-b779-468488442aca">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
