### PR TITLE
Enforce `ResourceListItem` right column management

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -34,9 +34,13 @@ export interface ResourceListItemProps {
   onClick?: (
     e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement, MouseEvent>
   ) => void
+  /**
+   * Optional setting to show right content, if available, instead of right arrow
+   */
+  showRightContent?: boolean
 }
 
-type ResourceListItemConfig = Pick<ResourceListItemProps, 'tag' | 'onClick'> &
+type ResourceListItemConfig = Omit<ResourceListItemProps, 'resource'> &
   ResourceListItemComponentProps
 
 const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
@@ -45,15 +49,13 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
     description,
     icon,
     rightContent,
-    showArrow = false,
     tag = 'div',
-    onClick
+    onClick,
+    showRightContent = false
   }) => {
-    const showRightContent = rightContent != null && !showArrow
-
     return (
       <ListItem
-        tag={tag}
+        tag={onClick !== undefined ? 'a' : tag}
         icon={icon}
         alignItems={showRightContent ? 'top' : 'center'}
         data-test-id='ResourceListItem'
@@ -78,7 +80,9 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
           </Text>
         </div>
         <div>
-          {showRightContent ? rightContent : <Icon name='caretRight' />}
+          {showRightContent
+            ? rightContent
+            : onClick != null && <Icon name='caretRight' />}
         </div>
       </ListItem>
     )

--- a/packages/app-elements/src/ui/resources/ResourceListItem/types.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/types.ts
@@ -8,7 +8,6 @@ export interface ResourceListItemComponentProps {
   description: JSX.Element | string
   icon: JSX.Element
   rightContent?: JSX.Element
-  showArrow?: boolean
 }
 
 export type ResourceToProps<Resource> = (options: {


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I enforced `ResourceListItem` component to provide a complete management of the behavior of its right side. Right side of the `ResourceListItem` could be: empty, a right arrow in case of linkable list item or a custom right content defined per resource in each transformer helper when needed.

First of all I set the right arrow to be shown if the `onClick` prop is defined. In the same condition also the `ListItem` `tag` prop is set to `a` in the same case.
Then I added a new prop called `showRightContent` to let the component to show the custom right content instead of right arrow when needed and controlled by app.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
