### PR TITLE
Allow to interact with inner checkbox in `InputCheckboxGroup`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup.test.tsx
@@ -167,4 +167,24 @@ describe('InputCheckboxGroup', () => {
     fireEvent.click(firstItem)
     expect(mockedOnChange).toHaveBeenCalledWith([])
   })
+
+  test('Should trigger change clicking on inner InputCheckbox', () => {
+    const mockedOnChange = vi.fn()
+    const { getAllByTestId } = render(
+      <InputCheckboxGroup options={options} onChange={mockedOnChange} />
+    )
+
+    const [firstItem] = getAllByTestId('InputCheckboxGroup-item')
+    const inputCheckbox = firstItem?.getElementsByTagName('input')[0]
+    assertToBeDefined(inputCheckbox)
+
+    expect(inputCheckbox).not.toBeChecked()
+
+    // select item by clicking on inner checkbox
+    fireEvent.click(inputCheckbox)
+    expect(inputCheckbox).toBeChecked()
+    expect(mockedOnChange).toHaveBeenCalledWith([
+      { value: 'BABYBIBXA19D9D000000XXXX', quantity: 5 }
+    ])
+  })
 })

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup.tsx
@@ -133,7 +133,12 @@ export function InputCheckboxGroup({
                 name={inputName}
                 checked={isSelected}
                 onChange={() => {
-                  // controlled by the parent div, since clicks in on the entire row
+                  dispatch({
+                    type: 'toggleSelection',
+                    payload: {
+                      value: optionItem.value
+                    }
+                  })
                 }}
               />
 


### PR DESCRIPTION
## What I did

Since `InputCheckbox` prevents click propagation, I've fixed a behaviour where click on inner checkbox was not working in `InputCheckboxGroup`

## How to test

In current (at the time of writing) version clicking on checkbox is not working (you must click on the entire item)
https://commercelayer.github.io/app-elements/?path=/docs/forms-ui-inputcheckboxgroup--docs

With the fix, you can also click on the inner checkbox
https://deploy-preview-392--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputcheckboxgroup--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
