### PR TITLE
Show return `reason` in ResourceLineItem only if filled

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -406,7 +406,7 @@ const LineItemOptions = withSkeletonTemplate<{
 const ReturnLineItemReason = withSkeletonTemplate<{
   reason: ReturnLineItem['return_reason']
 }>(({ reason }) => {
-  if (reason == null || Object.entries(reason).length === 0) {
+  if (reason == null || Object.keys(reason).length === 0) {
     return null
   }
 

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -406,7 +406,7 @@ const LineItemOptions = withSkeletonTemplate<{
 const ReturnLineItemReason = withSkeletonTemplate<{
   reason: ReturnLineItem['return_reason']
 }>(({ reason }) => {
-  if (reason == null) {
+  if (reason == null || Object.entries(reason).length === 0) {
     return null
   }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added a conditional check to verify that at least one reason is provided in `return_reason` object before to render the block.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
