### PR TITLE
Fix hooks order in `ResourceTags` and remove unwanted props in `Tag` and `ListItem`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tag.tsx
+++ b/packages/app-elements/src/ui/atoms/Tag.tsx
@@ -1,5 +1,5 @@
 import { type FlexRowProps } from '#ui/internals/FlexRow'
-import { enforceAllowedTags, removeTagProp } from '#utils/htmltags'
+import { enforceAllowedTags, removeUnwantedProps } from '#utils/htmltags'
 import cn from 'classnames'
 import { useMemo, type FC } from 'react'
 
@@ -39,6 +39,10 @@ export const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
     [rest.tag]
   )
   const hasHover = rest.onClick != null && rest.tag === 'button'
+  const wantedProps =
+    rest.tag === 'button'
+      ? removeUnwantedProps(rest, ['tag', 'buttonStyle'])
+      : removeUnwantedProps(rest, ['tag'])
 
   return (
     <JsxTag
@@ -55,9 +59,9 @@ export const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
         }
       ])}
       type={rest.tag === 'button' ? 'button' : undefined}
-      // we don't want `tag` prop to be present as attribute on html tag
+      // we don't want `tag` and eventually `buttonStyle` props to be present as attribute on html tag
       // still we need to be part of `rest` to discriminate the union type
-      {...(removeTagProp(rest) as any)}
+      {...(wantedProps as any)}
     >
       {icon != null && <div className='flex-shrink-0'>{icon}</div>}
       {children}

--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -1,5 +1,5 @@
 import { FlexRow, type FlexRowProps } from '#ui/internals/FlexRow'
-import { enforceAllowedTags, removeTagProp } from '#utils/htmltags'
+import { enforceAllowedTags, removeUnwantedProps } from '#utils/htmltags'
 import cn from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import { useMemo, type FC } from 'react'
@@ -82,7 +82,7 @@ export const ListItem: FC<ListItemProps> = ({
       )}
       // we don't want `tag` prop to be present as attribute on html tag
       // still we need to be part of `rest` to discriminate the union type
-      {...(removeTagProp(rest) as any)}
+      {...(removeUnwantedProps(rest, ['tag']) as any)}
     >
       <div className={cn('flex gap-4 flex-1 items-center')}>
         {icon != null && (

--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -85,6 +85,14 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
     )
 
     const { sdkClient } = useCoreSdkProvider()
+    const { settings } = useTokenProvider()
+
+    const navigateToTagsManagement = navigateTo({
+      destination: {
+        app: 'tags',
+        mode: settings.mode
+      }
+    })
 
     const tagsToSelectOptions = useCallback(
       (tags: Tag[]): InputSelectValue[] =>
@@ -112,14 +120,6 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
     )
 
     if (resourceTags == null) return <></>
-
-    const { settings } = useTokenProvider()
-    const navigateToTagsManagement = navigateTo({
-      destination: {
-        app: 'tags',
-        mode: settings.mode
-      }
-    })
 
     return (
       <div>

--- a/packages/app-elements/src/utils/htmltags.test.ts
+++ b/packages/app-elements/src/utils/htmltags.test.ts
@@ -1,0 +1,18 @@
+import { removeUnwantedProps } from './htmltags'
+
+describe('removeUnwantedProps', () => {
+  const props = {
+    a: '',
+    b: '',
+    c: ''
+  }
+
+  const cleanedProps = removeUnwantedProps(props, ['c'])
+
+  it("should return the original set of props without the prop 'c'", () => {
+    expect(cleanedProps).toEqual({
+      a: '',
+      b: ''
+    })
+  })
+})

--- a/packages/app-elements/src/utils/htmltags.ts
+++ b/packages/app-elements/src/utils/htmltags.ts
@@ -1,3 +1,5 @@
+import omit from 'lodash/omit'
+
 export function enforceAllowedTags<
   AllowedTags extends ReadonlyArray<keyof JSX.IntrinsicElements>,
   Tag extends AllowedTags[number],
@@ -14,9 +16,9 @@ export function enforceAllowedTags<
   return tag != null && allowedTags.includes(tag) ? tag : defaultTag
 }
 
-export function removeTagProp<T extends object>(props: T): Omit<T, 'tag'> {
-  return {
-    ...props,
-    tag: undefined
-  }
+export function removeUnwantedProps<P extends object, U extends keyof P>(
+  props: P,
+  unwantedProps: U[]
+): Omit<P, (typeof unwantedProps)[number]> {
+  return omit(props, unwantedProps) as Omit<P, (typeof unwantedProps)[number]>
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Fixed hooks order in `ResourceTags` component
- Remove unwanted props in `Tag` and `ListItem` components

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
