### PR TITLE
Add new `<Alert>` component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -50,6 +50,7 @@ export {
 
 // Atoms
 export { A, type AProps } from '#ui/atoms/A'
+export { Alert, type AlertProps } from '#ui/atoms/Alert'
 export { Avatar, type AvatarProps } from '#ui/atoms/Avatar'
 export { AvatarLetter, type AvatarLetterProps } from '#ui/atoms/AvatarLetter'
 export { Badge, type BadgeProps } from '#ui/atoms/Badge'

--- a/packages/app-elements/src/ui/atoms/Alert.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Alert.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react'
+import { Alert } from './Alert'
+
+describe('Alert', () => {
+  test('Should be rendered', () => {
+    const { getByRole } = render(
+      <Alert status='warning'>Ehi, this is a warning!</Alert>
+    )
+
+    const alert = getByRole('alert')
+    expect(alert).toBeVisible()
+    expect(alert.textContent).toBe('Ehi, this is a warning!')
+    expect(alert.querySelector('svg')).toBeVisible()
+  })
+})

--- a/packages/app-elements/src/ui/atoms/Alert.tsx
+++ b/packages/app-elements/src/ui/atoms/Alert.tsx
@@ -1,0 +1,48 @@
+import { Card } from '#ui/atoms/Card'
+import {
+  CheckCircle,
+  Info,
+  Warning,
+  XCircle,
+  type Icon
+} from '@phosphor-icons/react'
+import classNames from 'classnames'
+
+export interface AlertProps {
+  /** Alert status. This affects the color scheme and icon used. */
+  status: 'error' | 'success' | 'warning' | 'info'
+  children: React.ReactNode
+}
+
+/**
+ * Alerts are visual representations used to communicate a state that affects the page or the interactive element.
+ */
+export const Alert: React.FC<AlertProps> = ({ children, status }) => {
+  const Icon = icons[status]
+
+  return (
+    <Card
+      role='alert'
+      className={classNames('border-0', {
+        'bg-orange-50 text-orange-700': status === 'warning',
+        'bg-red-50 text-red-700': status === 'error',
+        'bg-gray-50 text-gray-700': status === 'info',
+        'bg-green-50 text-green-700': status === 'success'
+      })}
+    >
+      <div className='flex gap-3'>
+        <Icon focusable={false} size={24} />
+        <div>{children}</div>
+      </div>
+    </Card>
+  )
+}
+
+Alert.displayName = 'Alert'
+
+const icons: Record<AlertProps['status'], Icon> = {
+  warning: Warning,
+  error: XCircle,
+  info: Info,
+  success: CheckCircle
+}

--- a/packages/docs/src/stories/atoms/Alert.stories.tsx
+++ b/packages/docs/src/stories/atoms/Alert.stories.tsx
@@ -1,0 +1,21 @@
+import { Alert } from '#ui/atoms/Alert'
+import { type Meta, type StoryFn } from '@storybook/react'
+
+const setup: Meta<typeof Alert> = {
+  title: 'Atoms/Alert',
+  component: Alert
+}
+export default setup
+
+const Template: StoryFn<typeof Alert> = (args) => (
+  <Alert {...args}>
+    The new total is $80,00, $3.00 more than the original total.
+    <br />
+    Adjust the total to make it equal or less.
+  </Alert>
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  status: 'warning'
+}


### PR DESCRIPTION
## What I did

I added a brand new `<Alert>` component. Alerts are visual representations used to communicate a state that affects the page or the interactive element.

<img width="548" alt="Alert component" src="https://github.com/commercelayer/app-elements/assets/1681269/8b3619dd-0812-4d17-ad10-13775c12061a">


## How to test

https://deploy-preview-397--commercelayer-app-elements.netlify.app/?path=/docs/atoms-alert--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
