### PR TITLE
Handle more order statuses

### DIFF
--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -61,6 +61,7 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'placed:paid:unfulfilled':
+    case 'placed:partially_refunded:unfulfilled':
       return {
         label: 'Placed',
         icon: 'arrowDown',
@@ -150,6 +151,7 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'approved:paid:not_required':
+    case 'approved:partially_refunded:not_required':
       return {
         label: 'Approved',
         icon: 'check',
@@ -182,6 +184,9 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'cancelled:refunded:unfulfilled':
+    case 'cancelled:refunded:not_required':
+    case 'cancelled:unpaid:unfulfilled':
+    case 'cancelled:free:unfulfilled':
       return {
         label: 'Cancelled',
         icon: 'x',


### PR DESCRIPTION
## What I did

I fixed a few cases where the order status was not handled:

- `placed:partially_refunded:unfulfilled`
- `approved:partially_refunded:not_required`
- `cancelled:refunded:not_required`
- `cancelled:unpaid:unfulfilled`
- `cancelled:free:unfulfilled`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
