### PR TITLE
Handle missing order statuses

### DIFF
--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -43,42 +43,10 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
 
   switch (combinedStatus) {
     case 'placed:authorized:unfulfilled':
-      return {
-        label: 'Placed',
-        icon: 'arrowDown',
-        color: 'orange',
-        task: 'Awaiting approval',
-        triggerAttributes: ['_approve', '_cancel']
-      }
-
     case 'placed:authorized:not_required':
-      return {
-        label: 'Placed',
-        icon: 'arrowDown',
-        color: 'orange',
-        task: 'Awaiting approval',
-        triggerAttributes: ['_approve', '_cancel']
-      }
-
     case 'placed:paid:unfulfilled':
     case 'placed:partially_refunded:unfulfilled':
-      return {
-        label: 'Placed',
-        icon: 'arrowDown',
-        color: 'orange',
-        task: 'Awaiting approval',
-        triggerAttributes: ['_approve', '_cancel']
-      }
-
     case 'placed:free:unfulfilled':
-      return {
-        label: 'Placed',
-        icon: 'arrowDown',
-        color: 'orange',
-        task: 'Awaiting approval',
-        triggerAttributes: ['_approve', '_cancel']
-      }
-
     case 'placed:free:not_required':
       return {
         label: 'Placed',
@@ -89,14 +57,6 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'approved:authorized:unfulfilled':
-      return {
-        label: 'Approved',
-        icon: 'creditCard',
-        color: 'orange',
-        task: 'Payment to capture',
-        triggerAttributes: ['_capture']
-      }
-
     case 'approved:authorized:not_required':
       return {
         label: 'Approved',
@@ -107,14 +67,6 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'approved:paid:in_progress':
-      return {
-        label: 'In progress',
-        icon: 'arrowClockwise',
-        color: 'orange',
-        task: 'Fulfillment in progress',
-        triggerAttributes: ['_refund']
-      }
-
     case 'approved:partially_refunded:in_progress':
       return {
         label: 'In progress',
@@ -176,13 +128,6 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'cancelled:voided:unfulfilled':
-      return {
-        label: 'Cancelled',
-        icon: 'x',
-        color: 'gray',
-        triggerAttributes: [archiveTriggerAttribute]
-      }
-
     case 'cancelled:refunded:unfulfilled':
     case 'cancelled:refunded:not_required':
     case 'cancelled:unpaid:unfulfilled':
@@ -212,21 +157,7 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
       }
 
     case 'pending:unpaid:unfulfilled':
-      return {
-        label: 'Pending',
-        icon: 'shoppingBag',
-        color: 'white',
-        triggerAttributes: []
-      }
-
     case 'pending:authorized:unfulfilled':
-      return {
-        label: 'Pending',
-        icon: 'shoppingBag',
-        color: 'white',
-        triggerAttributes: []
-      }
-
     case 'pending:free:unfulfilled':
       return {
         label: 'Pending',

--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -45,7 +45,9 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
     case 'placed:authorized:unfulfilled':
     case 'placed:authorized:not_required':
     case 'placed:paid:unfulfilled':
+    case 'placed:paid:not_required':
     case 'placed:partially_refunded:unfulfilled':
+    case 'placed:partially_refunded:not_required':
     case 'placed:free:unfulfilled':
     case 'placed:free:not_required':
       return {
@@ -54,6 +56,15 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
         color: 'orange',
         task: 'Awaiting approval',
         triggerAttributes: ['_approve', '_cancel']
+      }
+
+    case 'placed:unpaid:unfulfilled':
+      return {
+        label: 'Placed',
+        icon: 'x',
+        color: 'red',
+        task: 'Error to cancel',
+        triggerAttributes: ['_cancel']
       }
 
     case 'approved:authorized:unfulfilled':
@@ -145,15 +156,6 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
         icon: 'x',
         color: 'gray',
         triggerAttributes: ['_return', archiveTriggerAttribute]
-      }
-
-    case 'placed:unpaid:unfulfilled':
-      return {
-        label: 'Placed',
-        icon: 'x',
-        color: 'red',
-        task: 'Error to cancel',
-        triggerAttributes: ['_cancel']
       }
 
     case 'pending:unpaid:unfulfilled':


### PR DESCRIPTION
## What I did

I fixed a few cases where the order status was not handled:

- `placed:paid:not_required`
- `placed:partially_refunded:not_required`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
