### PR TITLE
`<InputCurrency>` can define which are the available `sign`s

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.test.tsx
@@ -55,6 +55,17 @@ describe('InputCurrency', () => {
     )
     expect(queryByTestId('inputCurrency-input')).not.toBeInTheDocument()
   })
+
+  it('should display a negative 0 when default is set to -0', () => {
+    const onChange = vi.fn()
+    const { getByTestId } = render(
+      <InputCurrency currencyCode='EUR' onChange={onChange} cents={-0} />
+    )
+
+    expect(getByTestId('inputCurrency-symbol').innerHTML).toBe('€')
+    const input = getByTestId('inputCurrency-input')
+    expect(input).toHaveValue('-0')
+  })
 })
 
 describe('formatCentsToCurrency', () => {

--- a/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.test.tsx
@@ -56,15 +56,62 @@ describe('InputCurrency', () => {
     expect(queryByTestId('inputCurrency-input')).not.toBeInTheDocument()
   })
 
-  it('should display a negative 0 when default is set to -0', () => {
-    const onChange = vi.fn()
-    const { getByTestId } = render(
-      <InputCurrency currencyCode='EUR' onChange={onChange} cents={-0} />
-    )
+  describe('attribute `sign`', () => {
+    it('should always display a positive value when sign is equal to `+`', () => {
+      const onChange = vi.fn()
+      const { getByTestId } = render(
+        <InputCurrency currencyCode='EUR' onChange={onChange} sign='+' />
+      )
 
-    expect(getByTestId('inputCurrency-symbol').innerHTML).toBe('€')
-    const input = getByTestId('inputCurrency-input')
-    expect(input).toHaveValue('-0')
+      const input = getByTestId('inputCurrency-input')
+      fireEvent.change(input, { target: { value: '-4' } })
+      expect(onChange).lastCalledWith(400, '€4,00')
+
+      fireEvent.change(input, { target: { value: '-4' } })
+      expect(onChange).lastCalledWith(400, '€4,00')
+    })
+
+    it('should display a positive value the first time when sign is equal to `+-`', () => {
+      const onChange = vi.fn()
+      const { getByTestId } = render(
+        <InputCurrency currencyCode='EUR' onChange={onChange} sign='+-' />
+      )
+
+      const input = getByTestId('inputCurrency-input')
+      fireEvent.change(input, { target: { value: '4' } })
+      expect(onChange).lastCalledWith(400, '€4,00')
+
+      fireEvent.change(input, { target: { value: '-4' } })
+      expect(onChange).lastCalledWith(-400, '€-4,00')
+    })
+
+    it('should display a negative value the first time when sign is equal to `-+`', () => {
+      const onChange = vi.fn()
+      const { getByTestId } = render(
+        <InputCurrency currencyCode='EUR' onChange={onChange} sign='-+' />
+      )
+
+      const input = getByTestId('inputCurrency-input')
+      fireEvent.change(input, { target: { value: '4' } })
+      expect(onChange).lastCalledWith(-400, '€-4,00')
+
+      fireEvent.change(input, { target: { value: '4' } })
+      expect(onChange).lastCalledWith(400, '€4,00')
+    })
+
+    it('should always display a negative value when sign is equal to `-`', () => {
+      const onChange = vi.fn()
+      const { getByTestId } = render(
+        <InputCurrency currencyCode='EUR' onChange={onChange} sign='-' />
+      )
+
+      const input = getByTestId('inputCurrency-input')
+      fireEvent.change(input, { target: { value: '4' } })
+      expect(onChange).lastCalledWith(-400, '€-4,00')
+
+      fireEvent.change(input, { target: { value: '4' } })
+      expect(onChange).lastCalledWith(-400, '€-4,00')
+    })
   })
 })
 

--- a/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.tsx
+++ b/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.tsx
@@ -88,6 +88,11 @@ export const InputCurrency = forwardRef<HTMLInputElement, InputCurrencyProps>(
       makeInitialValue({ cents, currency })
     )
 
+    const isNegativeZero =
+      _value != null
+        ? Object.is(-0, typeof _value === 'string' ? parseInt(_value) : _value)
+        : false
+
     const decimalLength = useMemo(
       () => (currency != null ? getDecimalLength(currency) : 0),
       [currency]
@@ -143,7 +148,7 @@ export const InputCurrency = forwardRef<HTMLInputElement, InputCurrencyProps>(
             decimalSeparator={currency.decimal_mark}
             groupSeparator={currency.thousands_separator}
             placeholder={placeholder ?? makePlaceholder(currency)}
-            value={_value ?? ''}
+            value={_value != null ? (isNegativeZero ? '-0' : _value) : ''}
             onValueChange={(val, __, values) => {
               setValue(val)
               if (values?.float == null) {

--- a/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
+++ b/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
@@ -47,13 +47,16 @@ export function addCurrencySymbol({
  * Example: JPY -> 0
  * Example: CLF -> 0,0000
  */
-export function makePlaceholder(currency: Currency): string {
+export function makePlaceholder(
+  currency: Currency,
+  prefix: string = ''
+): string {
   const decimalLength = getDecimalLength(currency)
   if (decimalLength === 0) {
     return '0'
   }
   const decimals = ''.padEnd(decimalLength, '0')
-  return `0${currency.decimal_mark}${decimals}`
+  return `${prefix}0${currency.decimal_mark}${decimals}`
 }
 
 /**

--- a/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
@@ -111,7 +111,7 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
         <Spacer bottom='8'>
           <HookedInputCurrency
             isClearable
-            sign='-'
+            sign='-+'
             disabled={isSubmitting}
             currencyCode={currencyCode}
             label='Amount'

--- a/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
@@ -6,19 +6,43 @@ import { PageLayout } from '#ui/composite/PageLayout'
 import { HookedForm } from '#ui/forms/Form'
 import { HookedInputCurrency } from '#ui/forms/InputCurrency'
 import { type CurrencyCode } from '#ui/forms/InputCurrency/currencies'
+import { HookedValidationApiError } from '#ui/forms/ReactHookForm/HookedValidationApiError'
 import type { CommerceLayerClient, Order } from '@commercelayer/sdk'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod'
 import { getManualAdjustment, manualAdjustmentReferenceOrigin } from './utils'
 
+interface Props {
+  order: Order
+  onChange?: () => void
+  close: () => void
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-export function useAdjustTotalOverlay(order: Order, onChange?: () => void) {
+export function useAdjustTotalOverlay(
+  order: Props['order'],
+  onChange?: Props['onChange']
+) {
+  const { Overlay, open, close } = useOverlay()
+
+  return {
+    close,
+    open,
+    Overlay: () => (
+      <Overlay>
+        <Form order={order} onChange={onChange} close={close} />
+      </Overlay>
+    )
+  }
+}
+
+const Form: React.FC<Props> = ({ order, onChange, close }) => {
   const currencyCode = order.currency_code as Uppercase<CurrencyCode>
   const manualAdjustment = getManualAdjustment(order)
   const { sdkClient } = useCoreSdkProvider()
-  const { Overlay, open, close } = useOverlay()
+  const [apiError, setApiError] = useState<any>()
 
   const validationSchema = useMemo(
     () =>
@@ -32,7 +56,7 @@ export function useAdjustTotalOverlay(order: Order, onChange?: () => void) {
   )
   const formMethods = useForm({
     defaultValues: {
-      adjustTotal: manualAdjustment?.total_amount_cents ?? 0
+      adjustTotal: manualAdjustment?.total_amount_cents ?? -0
     },
     resolver: zodResolver(validationSchema)
   })
@@ -40,60 +64,66 @@ export function useAdjustTotalOverlay(order: Order, onChange?: () => void) {
     formState: { isSubmitting }
   } = formMethods
 
-  return {
-    close,
-    open,
-    Overlay: () => (
-      <Overlay>
-        <HookedForm
-          {...formMethods}
-          onSubmit={async (values) => {
-            if (manualAdjustment == null) {
-              await createManualAdjustmentLineItem({
-                sdkClient,
-                order,
-                amount: values.adjustTotal
-              }).then(() => {
-                onChange?.()
-                close()
-              })
-            } else {
-              await updateManualAdjustmentLineItem({
-                sdkClient,
-                order,
-                lineItemId: manualAdjustment.id,
-                amount: values.adjustTotal
-              }).then(() => {
-                onChange?.()
-                close()
-              })
-            }
-          }}
-        >
-          <PageLayout
-            title='Adjust total'
-            onGoBack={() => {
+  return (
+    <HookedForm
+      {...formMethods}
+      onSubmit={async (values) => {
+        if (manualAdjustment == null) {
+          await createManualAdjustmentLineItem({
+            sdkClient,
+            order,
+            amount: values.adjustTotal
+          })
+            .then(() => {
+              onChange?.()
               close()
-            }}
-          >
-            <Spacer bottom='8'>
-              <HookedInputCurrency
-                isClearable
-                allowNegativeValue
-                disabled={isSubmitting}
-                currencyCode={currencyCode}
-                label='Amount'
-                name='adjustTotal'
-              />
-            </Spacer>
-            <Button type='submit' fullWidth disabled={isSubmitting}>
-              Apply
-            </Button>
-          </PageLayout>
-        </HookedForm>
-      </Overlay>
-    )
-  }
+            })
+            .catch((error) => {
+              setApiError(error)
+            })
+        } else {
+          await updateManualAdjustmentLineItem({
+            sdkClient,
+            order,
+            lineItemId: manualAdjustment.id,
+            amount: values.adjustTotal
+          })
+            .then(() => {
+              onChange?.()
+              close()
+            })
+            .catch((error) => {
+              setApiError(error)
+            })
+        }
+      }}
+    >
+      <PageLayout
+        title='Adjust total'
+        onGoBack={() => {
+          close()
+        }}
+      >
+        <Spacer bottom='8'>
+          <HookedInputCurrency
+            isClearable
+            allowNegativeValue
+            disabled={isSubmitting}
+            currencyCode={currencyCode}
+            label='Amount'
+            name='adjustTotal'
+          />
+        </Spacer>
+        <Button type='submit' fullWidth disabled={isSubmitting}>
+          Apply
+        </Button>
+
+        <Spacer top='4'>
+          <HookedValidationApiError apiError={apiError} />
+        </Spacer>
+      </PageLayout>
+    </HookedForm>
+  )
 }
 
 async function createManualAdjustmentLineItem({
@@ -105,22 +135,24 @@ async function createManualAdjustmentLineItem({
   amount: number
   order: Order
 }): Promise<void> {
-  const currencyCode = order.currency_code as Uppercase<CurrencyCode>
+  if (amount !== 0) {
+    const currencyCode = order.currency_code as Uppercase<CurrencyCode>
 
-  const adjustment = await sdkClient.adjustments.create({
-    currency_code: currencyCode,
-    amount_cents: amount,
-    name: 'Manual adjustment',
-    reference_origin: manualAdjustmentReferenceOrigin
-  })
+    const adjustment = await sdkClient.adjustments.create({
+      currency_code: currencyCode,
+      amount_cents: amount,
+      name: 'Manual adjustment',
+      reference_origin: manualAdjustmentReferenceOrigin
+    })
 
-  await sdkClient.line_items.create({
-    order: sdkClient.orders.relationship(order.id),
-    quantity: 1,
-    item: adjustment,
-    reference_origin: manualAdjustmentReferenceOrigin,
-    compare_at_amount_cents: 0
-  })
+    await sdkClient.line_items.create({
+      order: sdkClient.orders.relationship(order.id),
+      quantity: 1,
+      item: adjustment,
+      reference_origin: manualAdjustmentReferenceOrigin,
+      compare_at_amount_cents: 0
+    })
+  }
 }
 
 async function updateManualAdjustmentLineItem({

--- a/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
@@ -48,15 +48,15 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
     () =>
       z.object({
         adjustTotal: z.number({
-          required_error: 'Please enter a negative or positive value.',
-          invalid_type_error: 'Please enter a negative or positive value.'
+          required_error: 'The amount is required.',
+          invalid_type_error: 'The amount is required.'
         })
       }),
     []
   )
   const formMethods = useForm({
     defaultValues: {
-      adjustTotal: manualAdjustment?.total_amount_cents ?? -0
+      adjustTotal: manualAdjustment?.total_amount_cents
     },
     resolver: zodResolver(validationSchema)
   })
@@ -68,6 +68,10 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
     <HookedForm
       {...formMethods}
       onSubmit={async (values) => {
+        if (values.adjustTotal == null) {
+          return
+        }
+
         if (manualAdjustment == null) {
           await createManualAdjustmentLineItem({
             sdkClient,
@@ -107,7 +111,7 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
         <Spacer bottom='8'>
           <HookedInputCurrency
             isClearable
-            allowNegativeValue
+            sign='-'
             disabled={isSubmitting}
             currencyCode={currencyCode}
             label='Amount'

--- a/packages/docs/src/mocks/data/adjustments.js
+++ b/packages/docs/src/mocks/data/adjustments.js
@@ -3,37 +3,63 @@ import { rest } from 'msw'
 const restPost = rest.post(
   `https://mock.localhost/api/adjustments`,
   async (req, res, ctx) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(
-          res(
-            ctx.status(200),
-            ctx.json({
-              data: {
-                id: 'eqJGhgEeBb',
-                type: 'adjustments',
-                links: {
-                  self: 'https://mock.localhost/api/adjustments/eqJGhgEeBb'
-                },
-                attributes: {
-                  name: 'Manual adjustment',
-                  currency_code: 'EUR',
-                  amount_cents: -100,
-                  amount_float: -1.0,
-                  formatted_amount: '-€1,00',
-                  created_at: '2023-08-23T15:59:30.059Z',
-                  updated_at: '2023-08-23T15:59:30.059Z',
-                  reference: null,
-                  reference_origin: null,
-                  metadata: {}
-                }
-              }
-            })
-          )
-        )
-      }, 1000)
-    })
+    return await res(ctx.status(200), ctx.delay(1000), ctx.json(adjustment))
   }
 )
 
-export default [restPost]
+const restGet = rest.get(
+  `https://mock.localhost/api/adjustments/QWOaGhpKbd`,
+  async (req, res, ctx) => {
+    return await res(ctx.status(200), ctx.delay(1000), ctx.json(adjustment))
+  }
+)
+
+const restPatch = rest.patch(
+  `https://mock.localhost/api/adjustments/QWOaGhpKbd`,
+  async (req, res, ctx) => {
+    return await res(ctx.status(200), ctx.delay(1000), ctx.json(adjustment))
+  }
+)
+
+const restDelete = rest.delete(
+  `https://mock.localhost/api/adjustments/QWOaGhpKbd`,
+  async (req, res, ctx) => {
+    return await res(ctx.status(200), ctx.delay(1000), ctx.json(adjustment))
+  }
+)
+
+const adjustment = {
+  data: {
+    id: 'QWOaGhpKbd',
+    type: 'adjustments',
+    links: {
+      self: 'https://mock.localhost/api/adjustments/QWOaGhpKbd'
+    },
+    attributes: {
+      name: 'Manual adjustment',
+      currency_code: 'EUR',
+      amount_cents: -100,
+      amount_float: -1.0,
+      formatted_amount: '-€1,00',
+      created_at: '2023-10-20T14:11:46.083Z',
+      updated_at: '2023-10-20T14:11:46.083Z',
+      reference: null,
+      reference_origin: 'app-orders--manual-adjustment',
+      metadata: {}
+    },
+    relationships: {
+      versions: {
+        links: {
+          self: 'https://mock.localhost/api/adjustments/QWOaGhpKbd/relationships/versions',
+          related: 'https://mock.localhost/api/adjustments/QWOaGhpKbd/versions'
+        }
+      }
+    },
+    meta: {
+      mode: 'test',
+      organization_id: 'WXlEOFrjnr'
+    }
+  }
+}
+
+export default [restGet, restPost, restPatch, restDelete]

--- a/packages/docs/src/mocks/data/line_items.js
+++ b/packages/docs/src/mocks/data/line_items.js
@@ -3,80 +3,246 @@ import { rest } from 'msw'
 const restPatch = rest.patch(
   `https://mock.localhost/api/line_items/:id`,
   async (req, res, ctx) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(res(ctx.status(200), ctx.body(`Update ${req.params.id}`)))
-      }, 1000)
-    })
+    return await res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.body(`Update ${req.params.id.toString()}`)
+    )
   }
 )
 
 const restDelete = rest.delete(
   `https://mock.localhost/api/line_items/:id`,
   async (req, res, ctx) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(res(ctx.status(200), ctx.body(`Removed ${req.params.id}`)))
-      }, 1000)
-    })
+    return await res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.body(`Removed ${req.params.id.toString()}`)
+    )
   }
 )
 
 const restPost = rest.post(
   `https://mock.localhost/api/line_items`,
   async (req, res, ctx) => {
-    return new Promise((resolve) => {
-      setTimeout(() => {
-        resolve(
-          res(
-            ctx.status(200),
-            ctx.json({
-              data: {
-                id: 'vrEAtOmRaz',
-                type: 'line_items',
-                links: {
-                  self: 'https://mock.localhost/api/line_items/vrEAtOmRaz'
-                },
-                attributes: {
-                  sku_code: null,
-                  bundle_code: null,
-                  quantity: 1,
-                  currency_code: 'EUR',
-                  unit_amount_cents: -100,
-                  unit_amount_float: -1.0,
-                  formatted_unit_amount: '-€1,00',
-                  options_amount_cents: 0,
-                  options_amount_float: 0.0,
-                  formatted_options_amount: '€0,00',
-                  discount_cents: 0,
-                  discount_float: 0.0,
-                  formatted_discount: '€0,00',
-                  total_amount_cents: -100,
-                  total_amount_float: -1.0,
-                  formatted_total_amount: '-€1,00',
-                  tax_amount_cents: 0,
-                  tax_amount_float: 0.0,
-                  formatted_tax_amount: '€0,00',
-                  name: 'Manual adjustment',
-                  image_url: null,
-                  discount_breakdown: {},
-                  tax_rate: 0.0,
-                  tax_breakdown: {},
-                  item_type: 'adjustments',
-                  frequency: null,
-                  created_at: '2023-08-23T15:59:30.205Z',
-                  updated_at: '2023-08-23T15:59:30.205Z',
-                  reference: null,
-                  reference_origin: null,
-                  metadata: {}
-                }
-              }
-            })
-          )
-        )
-      }, 1000)
-    })
+    return await res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json({
+        data: {
+          id: 'vrEAtOmRaz',
+          type: 'line_items',
+          links: {
+            self: 'https://mock.localhost/api/line_items/vrEAtOmRaz'
+          },
+          attributes: {
+            sku_code: null,
+            bundle_code: null,
+            quantity: 1,
+            currency_code: 'EUR',
+            unit_amount_cents: -100,
+            unit_amount_float: -1.0,
+            formatted_unit_amount: '-€1,00',
+            options_amount_cents: 0,
+            options_amount_float: 0.0,
+            formatted_options_amount: '€0,00',
+            discount_cents: 0,
+            discount_float: 0.0,
+            formatted_discount: '€0,00',
+            total_amount_cents: -100,
+            total_amount_float: -1.0,
+            formatted_total_amount: '-€1,00',
+            tax_amount_cents: 0,
+            tax_amount_float: 0.0,
+            formatted_tax_amount: '€0,00',
+            name: 'Manual adjustment',
+            image_url: null,
+            discount_breakdown: {},
+            tax_rate: 0.0,
+            tax_breakdown: {},
+            item_type: 'adjustments',
+            frequency: null,
+            created_at: '2023-08-23T15:59:30.205Z',
+            updated_at: '2023-08-23T15:59:30.205Z',
+            reference: null,
+            reference_origin: null,
+            metadata: {}
+          }
+        }
+      })
+    )
   }
 )
 
-export default [restPatch, restDelete, restPost]
+const restGet = rest.get(
+  `https://mock.localhost/api/line_items/:id`,
+  async (req, res, ctx) => {
+    return await res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json({
+        data: {
+          id: 'kxnXtlMPoN',
+          type: 'line_items',
+          links: {
+            self: 'https://mock.localhost/api/line_items/kxnXtlMPoN'
+          },
+          attributes: {
+            sku_code: null,
+            bundle_code: null,
+            quantity: 1,
+            currency_code: 'EUR',
+            unit_amount_cents: -100,
+            unit_amount_float: -1.0,
+            formatted_unit_amount: '-€1,00',
+            options_amount_cents: 0,
+            options_amount_float: 0.0,
+            formatted_options_amount: '€0,00',
+            discount_cents: 0,
+            discount_float: 0.0,
+            formatted_discount: '€0,00',
+            total_amount_cents: -100,
+            total_amount_float: -1.0,
+            formatted_total_amount: '-€1,00',
+            tax_amount_cents: 0,
+            tax_amount_float: 0.0,
+            formatted_tax_amount: '€0,00',
+            name: 'Manual adjustment',
+            image_url: null,
+            discount_breakdown: {},
+            tax_rate: 0.0,
+            tax_breakdown: {},
+            item_type: 'adjustments',
+            frequency: null,
+            coupon_code: null,
+            created_at: '2023-10-20T14:11:46.223Z',
+            updated_at: '2023-10-20T14:11:46.223Z',
+            reference: null,
+            reference_origin: 'app-orders--manual-adjustment',
+            metadata: {}
+          },
+          relationships: {
+            order: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/order',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/order'
+              }
+            },
+            item: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/item',
+                related: 'https://mock.localhost/api/line_items/kxnXtlMPoN/item'
+              },
+              data: {
+                type: 'adjustments',
+                id: 'QWOaGhpKbd'
+              }
+            },
+            sku: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/sku',
+                related: 'https://mock.localhost/api/line_items/kxnXtlMPoN/sku'
+              }
+            },
+            bundle: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/bundle',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/bundle'
+              }
+            },
+            line_item_options: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/line_item_options',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/line_item_options'
+              }
+            },
+            shipment_line_items: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/shipment_line_items',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/shipment_line_items'
+              }
+            },
+            stock_reservations: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/stock_reservations',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/stock_reservations'
+              }
+            },
+            stock_line_items: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/stock_line_items',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/stock_line_items'
+              }
+            },
+            stock_transfers: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/stock_transfers',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/stock_transfers'
+              }
+            },
+            events: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/events',
+                related:
+                  'https://mock.localhost/api/line_items/kxnXtlMPoN/events'
+              }
+            },
+            tags: {
+              links: {
+                self: 'https://mock.localhost/api/line_items/kxnXtlMPoN/relationships/tags',
+                related: 'https://mock.localhost/api/line_items/kxnXtlMPoN/tags'
+              }
+            }
+          },
+          meta: {
+            mode: 'test',
+            organization_id: 'WXlEOFrjnr'
+          }
+        },
+        included: [
+          {
+            id: 'QWOaGhpKbd',
+            type: 'adjustments',
+            links: {
+              self: 'https://mock.localhost/api/adjustments/QWOaGhpKbd'
+            },
+            attributes: {
+              name: 'Manual adjustment',
+              currency_code: 'EUR',
+              amount_cents: -100,
+              amount_float: -1.0,
+              formatted_amount: '-€1,00',
+              created_at: '2023-10-20T14:11:46.083Z',
+              updated_at: '2023-10-20T14:11:46.083Z',
+              reference: null,
+              reference_origin: 'app-orders--manual-adjustment',
+              metadata: {}
+            },
+            relationships: {
+              versions: {
+                links: {
+                  self: 'https://mock.localhost/api/adjustments/QWOaGhpKbd/relationships/versions',
+                  related:
+                    'https://mock.localhost/api/adjustments/QWOaGhpKbd/versions'
+                }
+              }
+            },
+            meta: {
+              mode: 'test',
+              organization_id: 'WXlEOFrjnr'
+            }
+          }
+        ]
+      })
+    )
+  }
+)
+
+export default [restGet, restPatch, restDelete, restPost]

--- a/packages/docs/src/stories/forms/ui/InputCurrency.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputCurrency.stories.tsx
@@ -46,3 +46,31 @@ WithError.args = {
     message: 'Required field'
   }
 }
+
+export const ForcePositiveValue = Template.bind({})
+ForcePositiveValue.args = {
+  name: 'input-force-positive-value',
+  currencyCode: 'USD',
+  sign: '+'
+}
+
+export const PositiveAndNegativeValues = Template.bind({})
+PositiveAndNegativeValues.args = {
+  name: 'input-positive-and-negative-values',
+  currencyCode: 'USD',
+  sign: '+-'
+}
+
+export const NegativeAndPositiveValues = Template.bind({})
+NegativeAndPositiveValues.args = {
+  name: 'input-negative-and-positive-values',
+  currencyCode: 'USD',
+  sign: '-+'
+}
+
+export const ForceNegativeValue = Template.bind({})
+ForceNegativeValue.args = {
+  name: 'input-force-negative-value',
+  currencyCode: 'USD',
+  sign: '-'
+}

--- a/packages/docs/src/stories/resources/ResourceOrderSummary.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceOrderSummary.stories.tsx
@@ -169,7 +169,7 @@ WithoutAManualAdjustment.args = {
 export const WithAManualAdjustment = Template.bind({})
 WithAManualAdjustment.args = {
   ...Default.args,
-  editable: true,
+  editable: false,
   order: {
     ...order,
     coupon_code: undefined,


### PR DESCRIPTION
## What I did

The `<InputCurrency>` component now have a `sign` prop that accepts `'+' | '-' | '+-' | '-+'`. This defines which are the available signs:

- `+` can accepts only positive numbers.
- `-` can accepts only negative numbers.
- `+-` can accepts both positive and negative numbers, with the default to positive.
- `-+` can accepts both positive and negative numbers, with the default to negative.

----

In the `<ResourceOrderSummary>` the adjustment can be set to a positive or a negative value (default to negative).

<img width="400" alt="Screenshot 2023-10-20 alle 22 51 39" src="https://github.com/commercelayer/app-elements/assets/1681269/3ceb9c0c-e96d-4df6-97b3-a94162740a0e">


## How to test

https://deploy-preview-403--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputcurrency--docs

https://deploy-preview-403--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceordersummary--docs#without-a-manual-adjustment

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
