### PR TITLE
Add `GTMProvider`

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@types/node": "^20.8.2",
+    "@types/react-gtm-module": "^2.0.2",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@vitejs/plugin-react": "^4.1.0",
     "autoprefixer": "^10.4.16",
@@ -69,6 +70,7 @@
     "msw": "^1.3.2",
     "polished": "^4.2.2",
     "postcss": "^8.4.31",
+    "react-gtm-module": "^2.0.11",
     "tailwindcss": "^3.3.3",
     "typescript": "^5.2.2",
     "vite": "^4.4.10",
@@ -81,6 +83,7 @@
     "query-string": "^8.1.x",
     "react": "^18.2.x",
     "react-dom": "^18.2.x",
+    "react-gtm-module": "^2.x",
     "react-hook-form": "^7.43.x",
     "wouter": "^2.x"
   }

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -37,6 +37,7 @@ export {
   useCoreSdkProvider
 } from '#providers/CoreSdkProvider'
 export { ErrorBoundary } from '#providers/ErrorBoundary'
+export { GTMProvider, useTagManager } from '#providers/GTMProvider'
 export {
   MetaTags,
   TokenProvider,

--- a/packages/app-elements/src/providers/GTMProvider.test.tsx
+++ b/packages/app-elements/src/providers/GTMProvider.test.tsx
@@ -1,0 +1,82 @@
+import { render, waitFor } from '@testing-library/react'
+import { useEffect } from 'react'
+import TagManager from 'react-gtm-module'
+import { GTMProvider, useTagManager } from './GTMProvider'
+
+vi.mock('react-gtm-module', async () => {
+  return {
+    default: {
+      initialize: vi.fn(),
+      dataLayer: vi.fn()
+    }
+  }
+})
+
+describe('GTMProvider', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('Should initialize GTM', async () => {
+    const { getByText } = render(
+      <GTMProvider gtmId='GTM-123456A'>
+        <div>App</div>
+      </GTMProvider>
+    )
+
+    expect(getByText('App')).toBeInTheDocument()
+    expect(TagManager.initialize).toHaveBeenNthCalledWith(1, {
+      gtmId: 'GTM-123456A'
+    })
+  })
+
+  test('Should not initialize GTM if gtmId is invalid', async () => {
+    const { getByText } = render(
+      <GTMProvider gtmId='GT-123456'>
+        <div>App</div>
+      </GTMProvider>
+    )
+
+    expect(getByText('App')).toBeInTheDocument()
+    expect(TagManager.initialize).toHaveBeenCalledTimes(0)
+  })
+
+  test('Should render children also when gtmId is not provided', async () => {
+    const { getByText } = render(
+      <GTMProvider>
+        <div>App</div>
+      </GTMProvider>
+    )
+
+    expect(getByText('App')).toBeInTheDocument()
+    expect(TagManager.initialize).toHaveBeenCalledTimes(0)
+  })
+})
+
+describe('useTagManager', () => {
+  test('Should push data with useTagManager hook', async () => {
+    const InnerComponent = (): JSX.Element => {
+      const gtm = useTagManager()
+
+      useEffect(() => {
+        gtm?.push({ event: 'test-event' })
+      }, [])
+
+      return <div>inner component</div>
+    }
+
+    const { getByText } = render(
+      <GTMProvider>
+        <InnerComponent />
+      </GTMProvider>
+    )
+
+    expect(getByText('inner component')).toBeInTheDocument()
+
+    void waitFor(() => {
+      expect(TagManager.dataLayer).toHaveBeenNthCalledWith(1, {
+        event: 'test-event'
+      })
+    })
+  })
+})

--- a/packages/app-elements/src/providers/GTMProvider.tsx
+++ b/packages/app-elements/src/providers/GTMProvider.tsx
@@ -1,0 +1,65 @@
+import isEmpty from 'lodash/isEmpty'
+import { createContext, useContext, useEffect, useMemo } from 'react'
+import TagManager, { type DataLayerArgs } from 'react-gtm-module'
+
+interface GTMProviderValue {
+  push: (
+    data: DataLayerArgs['dataLayer'],
+    customDataLayerName?: DataLayerArgs['dataLayerName']
+  ) => void
+}
+
+const GTMContext = createContext<GTMProviderValue | null>(null)
+
+/**
+ * Hook that is aimed to expose the provider context containing the `tagManager` object and its methods.
+ */
+export const useTagManager = (): GTMProviderValue | null => {
+  return useContext(GTMContext)
+}
+
+interface GTMProviderProps {
+  /**
+   * Entire app content
+   */
+  children: React.ReactNode
+  /**
+   * Optional Google Tag Manager id. If set the provider will take care of GTM initialization.
+   */
+  gtmId?: string
+}
+
+/**
+ * Provider that is aimed to initialize a `TagManager` instance of `react-gtm-module` package if a valid `gtmId` prop is set.
+ */
+export const GTMProvider: React.FC<GTMProviderProps> = ({
+  children,
+  gtmId
+}) => {
+  useEffect(() => {
+    if (isValidGtmId(gtmId)) {
+      TagManager.initialize({ gtmId })
+    }
+  }, [gtmId])
+
+  const push = useMemo<GTMProviderValue['push']>(
+    () => (data, customDataLayerName) => {
+      TagManager.dataLayer({
+        dataLayer: data,
+        dataLayerName: customDataLayerName
+      })
+    },
+    []
+  )
+
+  if (gtmId == null || isEmpty(gtmId)) {
+    return <>{children}</>
+  }
+
+  return <GTMContext.Provider value={{ push }}>{children}</GTMContext.Provider>
+}
+
+function isValidGtmId(gtmId?: string): gtmId is string {
+  const gtmIdRegex = /^GTM-[A-Z0-9]{1,7}$/
+  return gtmIdRegex.test(gtmId ?? '')
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 importers:
 
   .:
@@ -105,6 +101,9 @@ importers:
       '@types/node':
         specifier: ^20.8.2
         version: 20.8.2
+      '@types/react-gtm-module':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@types/testing-library__jest-dom':
         specifier: ^5.14.9
         version: 5.14.9
@@ -138,6 +137,9 @@ importers:
       postcss:
         specifier: ^8.4.31
         version: 8.4.31
+      react-gtm-module:
+        specifier: ^2.0.11
+        version: 2.0.11
       tailwindcss:
         specifier: ^3.3.3
         version: 3.3.3
@@ -4877,6 +4879,10 @@ packages:
     resolution: {integrity: sha512-bAIvO5lN/U8sPGvs1Xm61rlRHHaq5rp5N3kp9C+NJ/Q41P8iqjkXSu0+/qu8POsjH9pNWb0OYabFez7taP7omw==}
     dependencies:
       '@types/react': 18.2.24
+
+  /@types/react-gtm-module@2.0.2:
+    resolution: {integrity: sha512-1BwWKEtpbUB3lojX6SlQOH32CKEc/F4kKxUToSYuraeN9I0tgqtcoLC1TGDHB3X6dSmyUyOz5ZHADtucpUeyzw==}
+    dev: true
 
   /@types/react-transition-group@4.4.5:
     resolution: {integrity: sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==}
@@ -12419,6 +12425,10 @@ packages:
     resolution: {integrity: sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==}
     dev: false
 
+  /react-gtm-module@2.0.11:
+    resolution: {integrity: sha512-8gyj4TTxeP7eEyc2QKawEuQoAZdjKvMY4pgWfycGmqGByhs17fR+zEBs0JUDq4US/l+vbTl+6zvUIx27iDo/Vw==}
+    dev: true
+
   /react-hook-form@7.47.0(react@18.2.0):
     resolution: {integrity: sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==}
     engines: {node: '>=12.22.0'}
@@ -15160,3 +15170,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: true
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `GTMProvider` to introduce a straightforward Google Tag Manager implementation for our apps by using `react-gtm-module` with a provided `gtmId`.

Usage of the provider should be something like this:

```JSX
<GTMProvider gtmId='ABC-1234567'>
    <div>App</div>
</GTMProvider>
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
