### PR TITLE
Add missing case to `getOrderDisplayStatus`

### DIFF
--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -62,6 +62,7 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
 
     case 'placed:paid:unfulfilled':
     case 'placed:partially_refunded:unfulfilled':
+    case 'placed:partially_refunded:not_required':
       return {
         label: 'Placed',
         icon: 'arrowDown',


### PR DESCRIPTION
## What I did
I've added a missing combined status `placed:partially_refunded:not_required` to allow trigger attributes on that type of order.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
