### PR TITLE
Uniform `<InputSelect>` style as other inputs

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/styles.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/styles.ts
@@ -104,18 +104,11 @@ export const getSelectStyles = (
       ...style,
       ...feedbackStyle,
       borderWidth: 0,
-      minHeight: '46px',
-      // boxShadow: 'inset 0 0 0 1px #E6E7E7',
-      boxShadow: `inset 0 0 0 1px ${feedbackStyle.borderColor}`,
+      minHeight: '44px',
+
+      outline: 'none',
       borderRadius: 5,
-      cursor: 'pointer',
-      '&:focus-within': {
-        // we enforce feedback color as hover style, otherwise default brand color will be used as border
-        outline: 'none',
-        boxShadow: `inset 0 0 0 2px ${
-          feedbackVariant != null ? feedbackStyle.borderColor : '#666EFF'
-        }`
-      }
+      cursor: 'pointer'
     }
   },
   placeholder: (style) => ({

--- a/packages/app-elements/src/ui/internals/InputWrapper.tsx
+++ b/packages/app-elements/src/ui/internals/InputWrapper.tsx
@@ -124,30 +124,42 @@ export function getFeedbackStyle(
 
 export function getFeedbackCssInJs(
   variant?: InputFeedbackProps['variant']
-): Pick<CSSStyleDeclaration, 'borderColor' | 'borderWidth'> {
+): Pick<CSSStyleDeclaration, 'boxShadow'> & {
+  '&:focus-within': {
+    boxShadow: string
+  }
+} {
   switch (variant) {
     case 'danger':
       return {
-        borderColor: '#FF656B',
-        borderWidth: '2px'
+        boxShadow: 'inset 0 0 0 2px #FF656B',
+        '&:focus-within': {
+          boxShadow: 'inset 0 0 0 2px #FF656B'
+        }
       }
 
     case 'success':
       return {
-        borderColor: '#1FDA8A',
-        borderWidth: '2px'
+        boxShadow: 'inset 0 0 0 2px #1FDA8A',
+        '&:focus-within': {
+          boxShadow: 'inset 0 0 0 2px #1FDA8A'
+        }
       }
 
     case 'warning':
       return {
-        borderColor: '#FFAB2E',
-        borderWidth: '2px'
+        boxShadow: 'inset 0 0 0 2px #FFAB2E',
+        '&:focus-within': {
+          boxShadow: 'inset 0 0 0 2px #FFAB2E'
+        }
       }
 
     default:
       return {
-        borderColor: 'rgb(230 231 231)',
-        borderWidth: '1px'
+        boxShadow: 'inset 0 0 0 1px #E6E7E7',
+        '&:focus-within': {
+          boxShadow: 'inset 0 0 0 2px #666EFF'
+        }
       }
   }
 }


### PR DESCRIPTION
## What I did

The `InputSelect` style did not match the same as other inputs.
This PR solves this by setting outlines using box-shadow instead of borders.

Before: 
<img width="500" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/0cd60dc9-37d5-4fe9-83c5-5d34171a706d7">

Now:
<img width="500" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/cc9650b3-5970-417b-ba24-9a5fcb2ec7e7">

<img width="500" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/c5f549c8-da46-497f-a6e8-3dd50eff41ac">



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
