### PR TITLE
Add `Restocked on` badge to `ResourceLineItems`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
@@ -6,7 +6,7 @@ export interface BadgeProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Render a different variant. */
   variant: keyof typeof variantCss
-  children: string
+  children: React.ReactNode
 }
 
 /** Badges are used to highlight an item's status for quick recognition. */

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -1,3 +1,4 @@
+import { formatDate } from '#helpers/date'
 import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { Avatar } from '#ui/atoms/Avatar'
@@ -15,7 +16,7 @@ import type {
   ReturnLineItem,
   StockLineItem
 } from '@commercelayer/sdk'
-import { Trash } from '@phosphor-icons/react'
+import { Checks, Trash } from '@phosphor-icons/react'
 import cn from 'classnames'
 import { Fragment, useMemo, useState, type ComponentProps } from 'react'
 
@@ -247,6 +248,19 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                         lineItem.formatted_unit_amount != null && (
                           <Spacer top='2'>
                             <Badge variant='secondary'>{`Unit price ${lineItem.formatted_unit_amount}`}</Badge>
+                          </Spacer>
+                        )}
+                      {lineItem.type === 'return_line_items' &&
+                        lineItem.restocked_at != null && (
+                          <Spacer top='2'>
+                            <Badge variant='secondary'>
+                              <div className='flex items-center gap-1'>
+                                <Checks size={16} className='text-gray-500' />{' '}
+                                {`Restocked on ${formatDate({
+                                  isoDate: lineItem.restocked_at
+                                })}`}
+                              </div>
+                            </Badge>
                           </Spacer>
                         )}
                       {lineItem.type !== 'line_items' &&


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Enabled children of type `React.ReactNode` for `Badge` component
- Added a badge for `ResourceLineItems` component to show `restocked_at` attribute in case of item of type `return_line_items`

<img width="600" alt="Screenshot 2023-11-02 alle 21 51 43" src="https://github.com/commercelayer/app-elements/assets/105653649/bea5cb38-dfe6-4e38-af65-14dc73586fd6">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
