### PR TITLE
Add missing `feedback` to` HookedInputCheckbox`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
@@ -1,7 +1,12 @@
+import { useValidationFeedback } from '#ui/forms/ReactHookForm'
 import { useFormContext } from 'react-hook-form'
 import { InputCheckbox, type InputCheckboxProps } from './InputCheckbox'
 
-export interface HookedInputCheckboxProps extends InputCheckboxProps {
+export interface HookedInputCheckboxProps
+  extends Omit<
+    InputCheckboxProps,
+    'onChange' | 'checked' | 'feedback' | 'defaultValue' | 'defaultChecked'
+  > {
   /**
    * field name to match hook-form state
    */
@@ -17,8 +22,9 @@ export function HookedInputCheckbox({
   ...props
 }: HookedInputCheckboxProps): JSX.Element {
   const { register } = useFormContext()
+  const feedback = useValidationFeedback(name)
 
-  return <InputCheckbox {...props} {...register(name)} />
+  return <InputCheckbox {...props} {...register(name)} feedback={feedback} />
 }
 
 HookedInputCheckbox.displayName = 'HookedInputCheckbox'


### PR DESCRIPTION
## What I did

As all the others `HookedInput...` components, feedback to show validation error is controlled internally.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
