### PR TITLE
Add parcel customs info

### DIFF
--- a/packages/app-elements/src/ui/atoms/Hr.tsx
+++ b/packages/app-elements/src/ui/atoms/Hr.tsx
@@ -1,14 +1,29 @@
 import cn from 'classnames'
 
-export type HrProps = Omit<React.HTMLProps<HTMLHRElement>, 'children'>
+export type HrProps = Omit<React.HTMLProps<HTMLHRElement>, 'children'> & {
+  /**
+   * The variant of the horizontal rule.
+   * @default solid
+   */
+  variant?: 'solid' | 'dashed'
+}
 
 /**
  * This component wraps an [`<hr>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr) HTML element.
  * <span type='info'>All the props are directly sent to the horizontal rule element.</span>
  */
-export const Hr: React.FC<HrProps> = ({ className, ...rest }) => {
+export const Hr: React.FC<HrProps> = ({ className, variant, ...rest }) => {
   return (
-    <hr className={cn(['border-t border-gray-100', className])} {...rest} />
+    <hr
+      className={cn([
+        'border-t border-gray-100',
+        className,
+        {
+          'border-dashed': variant === 'dashed'
+        }
+      ])}
+      {...rest}
+    />
   )
 }
 

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
@@ -315,15 +315,15 @@ export const parcelWithoutTrackingDetails1 = createParcel({
 
 export const parcelWithCustomsInfo: Parcel = {
   ...parcelWithTracking1,
-  id: 'parcel-with-customs-information',
+  id: 'parcel-with-customs-info',
   incoterm: 'DDP',
   delivery_confirmation: 'signature',
   eel_pfc: 'NOEEI_30_37_a',
-  contents_type: 'merchandise',
+  contents_type: 'other',
   contents_explanation: 'T-shirts, books and other stuff',
   non_delivery_option: 'abandon',
   restriction_type: 'other',
-  restriction_comments: 'Some comments',
+  restriction_comments: 'please do not bend',
   customs_signer: 'John Doe',
   customs_certify: true,
   customs_info_required: true

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
@@ -313,6 +313,22 @@ export const parcelWithoutTrackingDetails1 = createParcel({
   trackingNumber: '12314321ASD1111'
 })
 
+export const parcelWithCustomsInfo: Parcel = {
+  ...parcelWithTracking1,
+  id: 'parcel-with-customs-information',
+  incoterm: 'DDP',
+  delivery_confirmation: 'signature',
+  eel_pfc: 'NOEEI_30_37_a',
+  contents_type: 'merchandise',
+  contents_explanation: 'T-shirts, books and other stuff',
+  non_delivery_option: 'abandon',
+  restriction_type: 'other',
+  restriction_comments: 'Some comments',
+  customs_signer: 'John Doe',
+  customs_certify: true,
+  customs_info_required: true
+}
+
 const rates = [
   {
     id: 'rate_dhl_1111',
@@ -435,4 +451,11 @@ export const shipmentWithoutParcels = createShipment({
   status: 'picking',
   purchaseStartedAt: '2023-07-11',
   parcels: []
+})
+
+export const shipmentWithCustomsInfo = createShipment({
+  id: 'shipment-with-customs-info',
+  status: 'picking',
+  purchaseStartedAt: '2023-07-11',
+  parcels: [parcelWithCustomsInfo]
 })

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -521,6 +521,12 @@ const CustomsInfo = withSkeletonTemplate<{ parcel: ParcelResource }>(
           </Spacer>
         )}
 
+        {parcel.customs_info_required === true && (
+          <Spacer top='4' bottom='4'>
+            <Hr variant='dashed' />
+          </Spacer>
+        )}
+
         {!isEmpty(parcel.eel_pfc) && (
           <Spacer top='4'>
             <FlexRow>
@@ -538,18 +544,10 @@ const CustomsInfo = withSkeletonTemplate<{ parcel: ParcelResource }>(
               <Text variant='info' wrap='nowrap'>
                 Contents type
               </Text>
-              <Text weight='semibold'>{parcel.contents_type}</Text>
-            </FlexRow>
-          </Spacer>
-        )}
-
-        {!isEmpty(parcel.contents_explanation) && (
-          <Spacer top='4'>
-            <FlexRow>
-              <Text variant='info' wrap='nowrap'>
-                Contents explanation
+              <Text weight='semibold'>
+                {/* `contents_explanation` is optional but if exists it means `contents_type` is set. So if it exists we give it priority */}
+                {parcel.contents_explanation ?? parcel.contents_type}
               </Text>
-              <Text weight='semibold'>{parcel.contents_explanation}</Text>
             </FlexRow>
           </Spacer>
         )}
@@ -569,16 +567,12 @@ const CustomsInfo = withSkeletonTemplate<{ parcel: ParcelResource }>(
           <Spacer top='4'>
             <FlexRow>
               <Text variant='info'>Restriction type</Text>
-              <Text weight='semibold'>{parcel.restriction_type}</Text>
-            </FlexRow>
-          </Spacer>
-        )}
-
-        {!isEmpty(parcel.restriction_comments) && (
-          <Spacer top='4'>
-            <FlexRow>
-              <Text variant='info'>Restriction comments</Text>
-              <Text weight='semibold'>{parcel.restriction_comments}</Text>
+              <Text weight='semibold'>
+                {parcel.restriction_type}{' '}
+                {parcel.restriction_comments != null
+                  ? ` - ${parcel.restriction_comments}`
+                  : ''}
+              </Text>
             </FlexRow>
           </Spacer>
         )}

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -15,6 +15,7 @@ import { A } from '#ui/atoms/A'
 import { Avatar } from '#ui/atoms/Avatar'
 import { Badge } from '#ui/atoms/Badge'
 import { Button } from '#ui/atoms/Button'
+import { Hr } from '#ui/atoms/Hr'
 import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
@@ -31,6 +32,7 @@ import {
 } from '@commercelayer/sdk'
 import { Package } from '@phosphor-icons/react'
 import cn from 'classnames'
+import isEmpty from 'lodash/isEmpty'
 import { useCallback, useMemo } from 'react'
 import { type SetNonNullable, type SetRequired } from 'type-fest'
 import { ResourceLineItems } from './ResourceLineItems'
@@ -152,6 +154,7 @@ const Parcel = withSkeletonTemplate<{
             rate={rate}
             showEstimatedDelivery={showEstimatedDelivery}
           />
+          <CustomsInfo parcel={parcel} />
         </Text>
       </Spacer>
     </CardDialog>
@@ -470,3 +473,140 @@ const PrintLabel = withSkeletonTemplate<{ href: string }>(({ href }) => {
     </div>
   )
 })
+
+const CustomsInfo = withSkeletonTemplate<{ parcel: ParcelResource }>(
+  ({ parcel }) => {
+    const hasCustomsInfo = useMemo(
+      () =>
+        !isEmpty(parcel.incoterm) ||
+        !isEmpty(parcel.delivery_confirmation) ||
+        !isEmpty(parcel.eel_pfc) ||
+        !isEmpty(parcel.contents_type) ||
+        !isEmpty(parcel.contents_explanation) ||
+        !isEmpty(parcel.non_delivery_option) ||
+        !isEmpty(parcel.restriction_type) ||
+        !isEmpty(parcel.restriction_comments) ||
+        !isEmpty(parcel.customs_signer) ||
+        !isEmpty(parcel.customs_certify),
+      [parcel]
+    )
+
+    if (!hasCustomsInfo) {
+      return null
+    }
+
+    return (
+      <div>
+        <Spacer top='4' bottom='4'>
+          <Hr variant='dashed' />
+        </Spacer>
+
+        {!isEmpty(parcel.incoterm) && (
+          <FlexRow>
+            <Text variant='info' wrap='nowrap'>
+              Iconterm
+            </Text>
+            <Text weight='semibold'>{parcel.incoterm}</Text>
+          </FlexRow>
+        )}
+
+        {!isEmpty(parcel.delivery_confirmation) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Delivery confirmation
+              </Text>
+              <Text weight='semibold'>{parcel.delivery_confirmation}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.eel_pfc) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                EEL/PFC
+              </Text>
+              <Text weight='semibold'>{parcel.eel_pfc}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.contents_type) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Contents type
+              </Text>
+              <Text weight='semibold'>{parcel.contents_type}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.contents_explanation) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Contents explanation
+              </Text>
+              <Text weight='semibold'>{parcel.contents_explanation}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.non_delivery_option) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Non delivery option
+              </Text>
+              <Text weight='semibold'>{parcel.non_delivery_option}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.restriction_type) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info'>Restriction type</Text>
+              <Text weight='semibold'>{parcel.restriction_type}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.restriction_comments) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info'>Restriction comments</Text>
+              <Text weight='semibold'>{parcel.restriction_comments}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.customs_signer) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Customs signer
+              </Text>
+              <Text weight='semibold'>{parcel.customs_signer}</Text>
+            </FlexRow>
+          </Spacer>
+        )}
+
+        {!isEmpty(parcel.customs_certify) && (
+          <Spacer top='4'>
+            <FlexRow>
+              <Text variant='info' wrap='nowrap'>
+                Customs certify
+              </Text>
+              <Text weight='semibold'>
+                {parcel.customs_certify === true ? 'Yes' : 'No'}
+              </Text>
+            </FlexRow>
+          </Spacer>
+        )}
+      </div>
+    )
+  }
+)

--- a/packages/docs/src/stories/atoms/Hr.stories.tsx
+++ b/packages/docs/src/stories/atoms/Hr.stories.tsx
@@ -1,5 +1,5 @@
 import { Hr } from '#ui/atoms/Hr'
-import { Description, Primary, Subtitle, Title } from '@storybook/addon-docs'
+import { Description, Stories, Subtitle, Title } from '@storybook/addon-docs'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Hr> = {
@@ -13,7 +13,7 @@ const setup: Meta<typeof Hr> = {
           <Title />
           <Subtitle />
           <Description />
-          <Primary />
+          <Stories />
         </>
       )
     }
@@ -25,3 +25,8 @@ const Template: StoryFn<typeof Hr> = (args) => <Hr {...args} />
 
 export const Default = Template.bind({})
 Default.args = {}
+
+export const Dashed = Template.bind({})
+Dashed.args = {
+  variant: 'dashed'
+}

--- a/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
@@ -1,6 +1,7 @@
 import { ResourceShipmentParcels } from '#ui/resources/ResourceShipmentParcels'
 import {
   shipmentHasBeenPurchased,
+  shipmentWithCustomsInfo,
   shipmentWithMultipleParcelsMultipleTrackings,
   shipmentWithMultipleParcelsSingleTracking,
   shipmentWithSingleParcelSingleTracking,
@@ -133,6 +134,19 @@ NoTrackingDetails.args = {
     alert(`removed parcel "${parcelId}"`)
   },
   shipment: shipmentWithoutTrackingDetails
+}
+
+/**
+ * When there's a customs info, it's shown in the parcel box.
+ */
+export const WithCustomsInfo: StoryFn<typeof ResourceShipmentParcels> = (
+  args
+): JSX.Element => <ResourceShipmentParcels {...args} />
+WithCustomsInfo.args = {
+  onRemoveParcel: function (parcelId) {
+    alert(`removed parcel "${parcelId}"`)
+  },
+  shipment: shipmentWithCustomsInfo
 }
 
 /**

--- a/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
@@ -137,7 +137,7 @@ NoTrackingDetails.args = {
 }
 
 /**
- * When there's a customs info, it's shown in the parcel box.
+ * We show customs info, separated by a dashed line, if the parcel has it.
  */
 export const WithCustomsInfo: StoryFn<typeof ResourceShipmentParcels> = (
   args


### PR DESCRIPTION
## What I did

I've enabled the showing of customs info in the parcel box (when available)
https://deploy-preview-417--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceshipmentparcels--docs


<img width="591" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/18083e89-1256-40e4-a2e4-82b8c09c5627">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
