### PR TITLE
Add `returns` in `ResourceOrderTimeline` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
@@ -448,6 +448,90 @@ const useTimelineReducer = (order: Order) => {
     [order.shipments]
   )
 
+  useEffect(
+    function addReturns() {
+      order.returns?.forEach((returnObj) => {
+        dispatchAttachments(returnObj.attachments)
+
+        if (returnObj.approved_at != null) {
+          dispatch({
+            type: 'add',
+            payload: {
+              date: returnObj.approved_at,
+              message: (
+                <>
+                  Return #{returnObj.number} was{' '}
+                  <Text weight='bold'>approved</Text>
+                </>
+              )
+            }
+          })
+        }
+
+        if (returnObj.cancelled_at != null) {
+          dispatch({
+            type: 'add',
+            payload: {
+              date: returnObj.cancelled_at,
+              message: (
+                <>
+                  Return #{returnObj.number} was{' '}
+                  <Text weight='bold'>cancelled</Text>
+                </>
+              )
+            }
+          })
+        }
+
+        if (returnObj.shipped_at != null) {
+          dispatch({
+            type: 'add',
+            payload: {
+              date: returnObj.shipped_at,
+              message: (
+                <>
+                  Return #{returnObj.number} was{' '}
+                  <Text weight='bold'>shipped</Text>
+                </>
+              )
+            }
+          })
+        }
+
+        if (returnObj.rejected_at != null) {
+          dispatch({
+            type: 'add',
+            payload: {
+              date: returnObj.rejected_at,
+              message: (
+                <>
+                  Return #{returnObj.number} was{' '}
+                  <Text weight='bold'>rejected</Text>
+                </>
+              )
+            }
+          })
+        }
+
+        if (returnObj.received_at != null) {
+          dispatch({
+            type: 'add',
+            payload: {
+              date: returnObj.received_at,
+              message: (
+                <>
+                  Return #{returnObj.number} was{' '}
+                  <Text weight='bold'>received</Text>
+                </>
+              )
+            }
+          })
+        }
+      })
+    },
+    [order.returns]
+  )
+
   return [events, dispatch] as const
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added `order` `returns` status changes in `ResourceOrderTimeline` component.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
