### PR TITLE
Add `countBy` prop in `InputCheckBoxGroup` component

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
@@ -48,6 +48,10 @@ interface Props extends Pick<InputWrapperBaseProps, 'feedback'> {
    * Callback triggered when the user checks/unchecks an option or changes the quantity
    */
   onChange: (selected: SelectedItem[]) => void
+  /**
+   * Show total count based on the sum of items quantities or items count itself
+   */
+  countBy?: 'quantity' | 'items'
 }
 
 /**
@@ -60,7 +64,15 @@ interface Props extends Pick<InputWrapperBaseProps, 'feedback'> {
  * <span type="info">Quantity for each option item has a min/max range, to prevent selecting less or more than the allowed number.</span>
  */
 export const InputCheckboxGroup = withSkeletonTemplate<Props>(
-  ({ options, defaultValues = [], onChange, title, isLoading, feedback }) => {
+  ({
+    options,
+    defaultValues = [],
+    onChange,
+    title,
+    isLoading,
+    feedback,
+    countBy = 'quantity'
+  }) => {
     const [_state, dispatch] = useReducer(
       reducer,
       makeInitialState({ options, defaultValues })
@@ -76,14 +88,14 @@ export const InputCheckboxGroup = withSkeletonTemplate<Props>(
       []
     )
 
-    const totalSelected = useMemo(
-      () =>
-        prepareSelected(_state).reduce(
-          (total, item) => total + (item.quantity ?? 1),
-          0
-        ),
-      [_state]
-    )
+    const totalSelected = useMemo(() => {
+      const selected = prepareSelected(_state)
+      if (countBy === 'quantity') {
+        return selected.reduce((total, item) => total + (item.quantity ?? 1), 0)
+      }
+
+      return selected.length
+    }, [_state, countBy])
 
     const isFirstRender = useRef(true)
     useEffect(


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added to `InputCheckBoxGroup` component a new optional prop called `countBy` to set how the total of selected items is calculated. The prop accepts a value between `quantity` or `items`. The first one is the default if no option is provided.
If `countBy` is set to `quantity` the behavior of the total count will be same as previous counting the sum of the quantity attribute of selected items.
On the other end if  `countBy` is set to `items` it will return the count of selected items.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
