### PR TITLE
Fix phrase in `Restocked on` badge of `ResourceLineItem` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -193,6 +193,13 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                 lineItem.bundle_code != null
 
               const isEditable = editable && lineItem.type === 'line_items'
+              const restockedOnDate =
+                lineItem.type === 'return_line_items' &&
+                lineItem.restocked_at != null
+                  ? formatDate({
+                      isoDate: lineItem.restocked_at
+                    })
+                  : ''
 
               return (
                 <Fragment key={lineItem.id}>
@@ -256,9 +263,9 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                             <Badge variant='secondary'>
                               <div className='flex items-center gap-1'>
                                 <Checks size={16} className='text-gray-500' />{' '}
-                                {`Restocked on ${formatDate({
-                                  isoDate: lineItem.restocked_at
-                                })}`}
+                                {restockedOnDate === 'Today'
+                                  ? 'Restocked today'
+                                  : `Restocked on ${restockedOnDate}`}
                               </div>
                             </Badge>
                           </Spacer>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- I modified the `Restocked on` badge of `ResourceLineItem` component to show `Restocked today` if formatted date is `Today` or otherwise `Restocked on {date}`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
