### PR TITLE
Add optional background color to Card and allow overflowing content

### DIFF
--- a/packages/app-elements/src/ui/atoms/Alert.tsx
+++ b/packages/app-elements/src/ui/atoms/Alert.tsx
@@ -23,6 +23,7 @@ export const Alert: React.FC<AlertProps> = ({ children, status }) => {
   return (
     <Card
       role='alert'
+      overflow='hidden'
       className={classNames('border-0', {
         'bg-orange-50 text-orange-700': status === 'warning',
         'bg-red-50 text-red-700': status === 'error',

--- a/packages/app-elements/src/ui/atoms/Card.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.test.tsx
@@ -1,35 +1,49 @@
-import { render, type RenderResult } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { Card } from './Card'
-
-interface SetupProps {
-  id: string
-  content: React.ReactElement
-}
-
-type SetupResult = RenderResult & {
-  element: HTMLElement
-}
-
-const setup = ({ id, content }: SetupProps): SetupResult => {
-  const utils = render(<Card data-testid={id}>{content}</Card>)
-  const element = utils.getByTestId(id)
-  return {
-    element,
-    ...utils
-  }
-}
 
 describe('Card', () => {
   test('Should be rendered', () => {
-    const { element } = setup({
-      id: 'card',
-      content: (
+    const { getByText, container } = render(
+      <Card overflow='visible'>
         <p>
-          <strong>I'm a Card</strong>
+          <strong>I am a Card</strong>
         </p>
-      )
-    })
-    expect(element.innerHTML).toContain("I'm a Card")
-    expect(element.tagName).toBe('DIV')
+      </Card>
+    )
+    expect(getByText('I am a Card')).toBeVisible()
+    expect(container.firstElementChild?.tagName).toBe('DIV')
+  })
+
+  test('Should have light gray background', () => {
+    const { container } = render(
+      <Card overflow='visible' backgroundColor='light'>
+        I am a Card
+      </Card>
+    )
+    expect(container.firstElementChild).toHaveClass('bg-gray-50')
+  })
+
+  test('Should have overflow hidden', () => {
+    const { container } = render(
+      <Card overflow='hidden' backgroundColor='light'>
+        I am a Card
+      </Card>
+    )
+    const mainDiv = container.firstElementChild
+    const innerDiv = container.firstElementChild?.firstElementChild
+    expect(mainDiv).toHaveClass('overflow-hidden')
+    expect(innerDiv).toHaveClass('overflow-hidden')
+  })
+
+  test('Should NOT have overflow hidden', () => {
+    const { container } = render(
+      <Card overflow='visible' backgroundColor='light'>
+        I am a Card
+      </Card>
+    )
+    const mainDiv = container.firstElementChild
+    const innerDiv = container.firstElementChild?.firstElementChild
+    expect(mainDiv).not.toHaveClass('overflow-hidden')
+    expect(innerDiv).not.toHaveClass('overflow-hidden')
   })
 })

--- a/packages/app-elements/src/ui/atoms/Card.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.tsx
@@ -15,17 +15,39 @@ export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
    * Footer will render in a dedicated section below the main content.
    */
   footer?: React.ReactNode
+  /**
+   * Set the overflow behavior. In most of the cases you might want to keep overflow visible,
+   * but when you have inner content with hover effects you might want to set overflow to hidden.
+   */
+  overflow: 'visible' | 'hidden'
+  /**
+   * Set a gray background color
+   */
+  backgroundColor?: 'light'
 }
 
 /** Card is a flexible component used to group and display content in a clear and concise format. */
 export const Card = withSkeletonTemplate<CardProps>(
-  ({ className, children, gap = '6', isLoading, delayMs, footer, ...rest }) => {
+  ({
+    className,
+    children,
+    gap = '6',
+    isLoading,
+    delayMs,
+    footer,
+    backgroundColor,
+    overflow,
+    ...rest
+  }) => {
     return (
       <div
         className={cn([
           className,
-          'border border-solid border-gray-200 rounded-md overflow-hidden',
+          'border border-solid rounded-md',
           {
+            'overflow-hidden': overflow === 'hidden',
+            'border-gray-200': backgroundColor == null,
+            'bg-gray-50 border-gray-50': backgroundColor === 'light',
             'p-1': gap === '1',
             'p-4': gap === '4',
             'p-6': gap === '6'
@@ -33,7 +55,13 @@ export const Card = withSkeletonTemplate<CardProps>(
         ])}
         {...rest}
       >
-        <div className='rounded overflow-hidden h-full'>{children}</div>
+        <div
+          className={cn('rounded h-full', {
+            'overflow-hidden': overflow === 'hidden'
+          })}
+        >
+          {children}
+        </div>
         {footer != null && (
           <div
             className={cn([

--- a/packages/app-elements/src/ui/composite/CardDialog.tsx
+++ b/packages/app-elements/src/ui/composite/CardDialog.tsx
@@ -61,7 +61,7 @@ export const CardDialog = withSkeletonTemplate<CardDialogProps>(
   }) => {
     const hasChildren = Children.toArray(children).length > 0
     return (
-      <Card {...rest} footer={footer}>
+      <Card {...rest} overflow='visible' footer={footer}>
         <ListItem
           tag='div'
           alignItems='top'

--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -102,6 +102,7 @@ export const Timeline = withSkeletonTemplate<TimelineProps>(
                         <div className='w-6' />
                       </div>
                       <Card
+                        overflow='hidden'
                         data-testid='timeline-event-note'
                         className='w-full mt-1'
                       >

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
@@ -104,7 +104,11 @@ export const InputCheckboxGroup = withSkeletonTemplate<Props>(
         label={`${title} · ${totalSelected}`}
         feedback={feedback}
       >
-        <Card gap='1' className={cn(getFeedbackStyle(feedback))}>
+        <Card
+          gap='1'
+          overflow='hidden'
+          className={cn(getFeedbackStyle(feedback))}
+        >
           {options.map((optionItem) => {
             const currentItem = _state.find(
               ({ value }) => value === optionItem.value

--- a/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
@@ -88,6 +88,7 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
             return (
               <Card
                 key={optionItem.value}
+                overflow='hidden'
                 className={cn({
                   '!p-1': !isSelected,
                   'border-primary-500 border-2 !p-[calc(theme(space.1)-1px)]':

--- a/packages/app-elements/src/ui/forms/InputResourceGroup/FullList.tsx
+++ b/packages/app-elements/src/ui/forms/InputResourceGroup/FullList.tsx
@@ -137,7 +137,7 @@ export function FullList({
             totalCount
           })}
         >
-          <Card gap='1'>
+          <Card gap='1' overflow='hidden'>
             <ResourceList
               type={resource}
               emptyState={<div>No items found</div>}

--- a/packages/app-elements/src/ui/forms/InputResourceGroup/InputResourceGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputResourceGroup/InputResourceGroup.tsx
@@ -109,7 +109,7 @@ export const InputResourceGroup: React.FC<InputResourceGroupProps> = ({
           totalCount
         })}
       >
-        <Card gap='1'>
+        <Card gap='1' overflow='hidden'>
           {list.map((item, idx) => {
             return (
               <InputCheckboxGroupItem

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -1,8 +1,11 @@
 import { Button } from '#ui/atoms/Button'
 import { Card } from '#ui/atoms/Card'
 import { Icon } from '#ui/atoms/Icon'
+import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
+import { Input } from '#ui/forms/Input'
+import { InputSelect } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Card> = {
@@ -23,13 +26,16 @@ const Template: StoryFn<typeof Card> = (args) => (
 )
 
 export const Default = Template.bind({})
-Default.args = {}
+Default.args = {
+  overflow: 'visible'
+}
 
 /** Card can have a `footer` that renders in dedicated section. */
 export const Footer: StoryFn<typeof Card> = (args) => (
   <Card {...args}>I'm the card content</Card>
 )
 Footer.args = {
+  overflow: 'visible',
   footer: (
     <div className='text-center'>
       <Button variant='link'>
@@ -40,7 +46,10 @@ Footer.args = {
   )
 }
 
-/** The rounded corner should also be visible when children have a background. */
+/**
+ * The rounded corner should also be visible when children have a background.
+ * In this case you can set `overflow` prop to `hidden` to keep rounded corners on children background.
+ */
 export const ChildrenWithBackground: StoryFn<typeof Card> = (args) => (
   <Card {...args}>
     <ListItem tag='a' onClick={() => {}} borderStyle='none'>
@@ -55,5 +64,51 @@ export const ChildrenWithBackground: StoryFn<typeof Card> = (args) => (
   </Card>
 )
 ChildrenWithBackground.args = {
-  gap: '1'
+  gap: '1',
+  overflow: 'hidden'
 }
+
+/** Card can have a background color */
+export const WithBackgroundColor: StoryFn<typeof Card> = (args) => (
+  <Card {...args}>
+    <p>
+      <strong>I am a card</strong>
+    </p>
+    <p>I am a card content row</p>
+    <p>I am a card content row</p>
+    <p>I am a card content row</p>
+  </Card>
+)
+WithBackgroundColor.args = {
+  backgroundColor: 'light',
+  overflow: 'hidden'
+}
+
+/**
+ * When you are rending content like a select or dropdown you might want to have `overflow: visible`
+ * to prevent inner content clipping.
+ */
+export const WithOverflowingContent: StoryFn<typeof Card> = (args) => (
+  <Card backgroundColor='light' overflow='visible'>
+    <Spacer bottom='4'>
+      <Input label='Fullname' />
+    </Spacer>
+    <Spacer bottom='4'>
+      <InputSelect
+        label='Favorite color'
+        initialValues={['red', 'blue'].map((v) => ({
+          label: v,
+          value: v
+        }))}
+        onSelect={() => {}}
+      />
+    </Spacer>
+  </Card>
+)
+WithOverflowingContent.decorators = [
+  (Story) => (
+    <div style={{ paddingBottom: '2rem' }}>
+      <Story />
+    </div>
+  )
+]

--- a/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
+++ b/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
@@ -62,7 +62,7 @@ const Template: StoryFn<typeof InputCheckbox> = (args) => {
             : options.length}
         </Text>
       </Spacer>
-      <Card>
+      <Card overflow='hidden'>
         {options.map((opt, idx) => {
           const isChecked = selectedIds.includes(opt.id)
           return (


### PR DESCRIPTION
## What I did
In order to apply the pattern from the screenshots attached I've added:
- optional `backgroundColor` prop that can be set to `light`
- mandatory `overflow` prop that can allow inner content to overflow or not the card. Before overflow was always hidden since it was required when card was used to group list items with hover effect.
- update all components that use `<Card>` to set proper overflow value

<img width="318" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/dbc975d2-d7d6-4f17-96ed-231e95fd37ed">


<img width="400" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/c1bcbd0a-3d6f-42e5-a00b-4d922192d7ed">

As you can see, the dropdown menu of the select needs to overflow the card boundaries.

[Preview link](https://deploy-preview-421--commercelayer-app-elements.netlify.app/?path=/docs/atoms-card--docs#with-overflowing-content)


### Breaking change
The new prop `overflow` is required, so at the next update consumer apps that use `<Card>` need to specify the wanted behavior.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
