### PR TITLE
Add `formatDateWithPredicate` date helper method

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -1,4 +1,9 @@
-import { formatDate, getIsoDateAtDayEdge, getIsoDateAtDaysBefore } from './date'
+import {
+  formatDate,
+  formatDateWithPredicate,
+  getIsoDateAtDayEdge,
+  getIsoDateAtDaysBefore
+} from './date'
 
 describe('formatDate', () => {
   beforeEach(() => {
@@ -179,6 +184,86 @@ describe('formatDate', () => {
         format: 'distanceToNow'
       })
     ).toBe('10 months ago')
+  })
+})
+
+describe('formatDateWithPredicate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers().setSystemTime('2023-12-25T14:30:00.000Z')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('Should return a nice date string with predicate', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Created',
+        isoDate: '2022-10-14T14:32:00.000Z'
+      })
+    ).toBe('Created on Oct 14, 2022 · 14:32')
+  })
+
+  test('Should return the predicate followed by `on` and the date without the year when current year', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Updated',
+        isoDate: '2023-10-14T14:32:00.000Z',
+        format: 'date'
+      })
+    ).toBe('Updated on Oct 14')
+  })
+
+  test('Should return the predicate followed by just "today" when date is today', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Created',
+        isoDate: '2023-12-25T14:32:00.000Z',
+        format: 'date'
+      })
+    ).toBe('Created today')
+  })
+
+  test('Should return the predicate followed by `on` and the date with time', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Updated',
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'full'
+      })
+    ).toBe('Updated on Feb 22 · 10:32')
+  })
+
+  test('Should return the predicate followed by `on` and the date with time and seconds', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Updated',
+        isoDate: '2023-02-22T10:32:47.284Z',
+        format: 'fullWithSeconds'
+      })
+    ).toBe('Updated on Feb 22 · 10:32:47')
+  })
+
+  test('Should return the predicate followed by `at` and the time', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Updated',
+        isoDate: '2023-02-22T05:32:47.284Z',
+        format: 'time'
+      })
+    ).toBe('Updated at 05:32')
+  })
+
+  test('Should return the predicate followed by just the distance to now', () => {
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Updated',
+        isoDate: '2023-12-25T14:30:00.000Z',
+        timezone: 'Australia/Sydney',
+        format: 'distanceToNow'
+      })
+    ).toBe('Updated less than a minute ago')
   })
 })
 

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -69,6 +69,54 @@ export function formatDate({
   }
 }
 
+interface FormatDateWithPredicateOptions extends FormatDateOptions {
+  /**
+   * Date predicate verb string. Example: 'Created' or 'Updated'.
+   */
+  predicate: string
+}
+
+/**
+ * Generate a valid separator string based on provided date format
+ * @param format a string belonging to `Format` type
+ * @returns a string containing the wanted separator. Example: 'on' is valid separator for formats containing a date and 'at' is a valid separator for formats related to time.
+ */
+function getDatePredicateSeparatorByFormat(format: Format): string {
+  switch (format) {
+    case 'distanceToNow':
+      return ''
+    case 'time':
+    case 'timeWithSeconds':
+      return 'at '
+    default:
+      return 'on '
+  }
+}
+
+/**
+ * Generate a string containing provided predicate, a separator and provided date formatted according to `formatDate` method
+ * @param opts a set of `FormatDateOptions` along with a date verb predicate. In this method `format` prop has 'full' default value.
+ * @returns a nice string representation of the predicate, followed by the proper separator and the formatted date. Examples: 'Created today · 1:16 PM', 'Updated on Jul 21, 2022 · 1:16 PM' or 'Updated at 1:16 PM'
+ */
+export function formatDateWithPredicate({
+  isoDate,
+  timezone,
+  format = 'full',
+  predicate
+}: FormatDateWithPredicateOptions): string {
+  const formattedDate = formatDate({
+    isoDate,
+    timezone,
+    format
+  }).replace('Today', 'today')
+
+  const separator = !formattedDate.includes('today')
+    ? `${getDatePredicateSeparatorByFormat(format)}`
+    : ''
+
+  return `${predicate} ${separator}${formattedDate}`
+}
+
 export const timeSeparator = '·'
 
 function getPresetFormatTemplate(

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -5,6 +5,7 @@ export { goBack, navigateTo } from '#helpers/appsNavigation'
 export { isAttachmentValidNote, referenceOrigins } from '#helpers/attachments'
 export {
   formatDate,
+  formatDateWithPredicate,
   getIsoDateAtDayEdge,
   getIsoDateAtDaysBefore,
   sortAndGroupByDate,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added a new `date` helper method called `formatDateWithPredicate`, extending existing `formatDate` method, to generate a nice string like `Created on Jul 21, 2022 · 1:16 PM`.
It expects the same props found in `formatDate` method with in addition the `predicate` string (eg. 'Created').
It generates a string starting from the `predicate`, followed by the proper separator for the chosen format and the formatted date itself.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
