### PR TITLE
Add user timezone to `Restocked on` badge

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -1,4 +1,4 @@
-import { formatDate } from '#helpers/date'
+import { formatDateWithPredicate } from '#helpers/date'
 import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { Avatar } from '#ui/atoms/Avatar'
@@ -146,6 +146,8 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
       )
     }
 
+    const { user } = useTokenProvider()
+
     return (
       <table className='w-full'>
         <tbody>
@@ -193,13 +195,6 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                 lineItem.bundle_code != null
 
               const isEditable = editable && lineItem.type === 'line_items'
-              const restockedOnDate =
-                lineItem.type === 'return_line_items' &&
-                lineItem.restocked_at != null
-                  ? formatDate({
-                      isoDate: lineItem.restocked_at
-                    })
-                  : ''
 
               return (
                 <Fragment key={lineItem.id}>
@@ -263,9 +258,11 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                             <Badge variant='secondary'>
                               <div className='flex items-center gap-1'>
                                 <Checks size={16} className='text-gray-500' />{' '}
-                                {restockedOnDate === 'Today'
-                                  ? 'Restocked today'
-                                  : `Restocked on ${restockedOnDate}`}
+                                {formatDateWithPredicate({
+                                  predicate: 'Restocked',
+                                  isoDate: lineItem.restocked_at,
+                                  timezone: user?.timezone
+                                })}
                               </div>
                             </Badge>
                           </Spacer>


### PR DESCRIPTION
## What I did

I generated the `Restocked on` predicate in a badge of `ResourceLineItems` component using the new `formatDateWithPredicate` date helper method.
The `timezone` setting, actually missing, is now filled by reading it from the TokenProvider.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
