### PR TITLE
Use `return.stock_location` instead of `order.market`

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
@@ -9,8 +9,8 @@ import { type ResourceToProps } from '../types'
 export const returnToProps: ResourceToProps<Return> = ({ resource, user }) => {
   const displayStatus = getReturnDisplayStatus(resource)
   const returnStockLocationName =
-    resource.order?.market?.name != null
-      ? `To ${resource.order.market.name} `
+    resource.stock_location?.name != null
+      ? `To ${resource.stock_location.name} `
       : ''
   const number = resource.number != null ? `#${resource.number}` : ''
 


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified the `ResourceListItem` component to use as destination the `return.stock_location` instead of `order.market`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
