### PR TITLE
Add missing `notes` field to address form schema

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
@@ -36,7 +36,8 @@ const addressFormSchema = z.object({
   state_code: zodString,
   country_code: zodString,
   phone: zodString,
-  billing_info: z.string().nullish()
+  billing_info: z.string().nullish(),
+  notes: z.string().nullish()
 })
 
 export type ResourceAddressFormValues = z.infer<typeof addressFormSchema>


### PR DESCRIPTION
## What I did

I've added `notes` to the address form schema, without it that field was not passed to the address PATCH request.
(by default zod removes all data not defined in the schema, so `notes` was not available in the `onSubmit` callback)


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
