### PR TITLE
Add missing `useEffect` for `ResourceAddress` internal state

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -9,7 +9,7 @@ import { PageLayout } from '#ui/composite/PageLayout'
 import { type Address } from '@commercelayer/sdk'
 import { Note, PencilSimple, Phone } from '@phosphor-icons/react'
 import isEmpty from 'lodash/isEmpty'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ResourceAddressForm } from './ResourceAddressForm'
 
 export interface ResourceAddressProps {
@@ -42,6 +42,10 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     const { canUser } = useTokenProvider()
 
     const [address, setAddress] = useState<Address>(resource)
+
+    useEffect(() => {
+      setAddress(resource)
+    }, [resource.id])
 
     return (
       <>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added a `useEffect` hook to update `address` internal state  of `ResourceAddress` component every time component `resource` prop value is changed.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
