### PR TITLE
Replace `@ac-dev/countries-service` in ResourceAddress with static list of countries and states from cdn

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -29,7 +29,6 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@ac-dev/countries-service": "^1.2.0",
     "@commercelayer/sdk": "5.21.1",
     "@types/lodash": "^4.14.200",
     "@types/react": "^18.2.34",

--- a/packages/app-elements/src/mocks/data/countries.ts
+++ b/packages/app-elements/src/mocks/data/countries.ts
@@ -1,0 +1,158 @@
+import { rest } from 'msw'
+
+export default [
+  rest.get(
+    `https://data.commercelayer.app/assets/lists/countries.json`,
+    async (req, res, ctx) => {
+      return await res(
+        ctx.status(200),
+        ctx.json([
+          {
+            label: 'Angola',
+            value: 'AO'
+          },
+          {
+            label: 'Hungary',
+            value: 'HU'
+          },
+          {
+            label: 'Iraq',
+            value: 'IQ'
+          },
+          {
+            label: 'Ireland',
+            value: 'IE'
+          },
+          {
+            label: 'Italy',
+            value: 'IT'
+          },
+          {
+            label: 'Jamaica',
+            value: 'JM'
+          },
+          {
+            label: 'Japan',
+            value: 'JP'
+          },
+          {
+            label: 'Philippines',
+            value: 'PH'
+          },
+          {
+            label: 'Pitcairn Island',
+            value: 'PN'
+          },
+          {
+            label: 'Poland',
+            value: 'PL'
+          },
+          {
+            label: 'Portugal',
+            value: 'PT'
+          },
+          {
+            label: 'United Kingdom',
+            value: 'GB'
+          },
+          {
+            label: 'United States',
+            value: 'US'
+          },
+          {
+            label: 'United States Minor Outlying Islands',
+            value: 'UM'
+          },
+          {
+            label: 'Uruguay',
+            value: 'UY'
+          }
+        ])
+      )
+    }
+  ),
+  rest.get(
+    `https://data.commercelayer.app/assets/lists/states/IT.json`,
+    async (req, res, ctx) => {
+      return await res(
+        ctx.status(200),
+        ctx.json([
+          {
+            label: 'Agrigento',
+            value: 'AG'
+          },
+          {
+            label: 'Alessandria',
+            value: 'AL'
+          },
+          {
+            label: 'Como',
+            value: 'CO'
+          },
+          {
+            label: 'Firenze',
+            value: 'FI'
+          },
+          {
+            label: 'Genoa',
+            value: 'GE'
+          },
+          {
+            label: 'Milano',
+            value: 'MI'
+          },
+          {
+            label: 'Napoli',
+            value: 'NA'
+          }
+        ])
+      )
+    }
+  ),
+  rest.get(
+    `https://data.commercelayer.app/assets/lists/states/US.json`,
+    async (req, res, ctx) => {
+      return await res(
+        ctx.status(200),
+        ctx.json([
+          {
+            label: 'Alabama',
+            value: 'AL'
+          },
+          {
+            label: 'Alaska',
+            value: 'AK'
+          },
+          {
+            label: 'Arizona',
+            value: 'AZ'
+          },
+          {
+            label: 'Arkansas',
+            value: 'AR'
+          },
+          {
+            label: 'California',
+            value: 'CA'
+          },
+          {
+            label: 'Colorado',
+            value: 'CO'
+          },
+          {
+            label: 'Connecticut',
+            value: 'CT'
+          },
+          {
+            label: 'Delaware',
+            value: 'DE'
+          },
+          {
+            label: 'District of Columbia',
+            value: 'DC'
+          }
+        ])
+      )
+    }
+  )
+]

--- a/packages/app-elements/src/mocks/handlers.ts
+++ b/packages/app-elements/src/mocks/handlers.ts
@@ -1,5 +1,6 @@
 import { rest } from 'msw'
 
+import countries from './data/countries'
 import customers from './data/customers'
 
 export const handlers = [
@@ -105,7 +106,8 @@ export const handlers = [
     )
   }),
 
-  ...customers
+  ...customers,
+  ...countries
 ]
 
 function returnEmptyList(url: URL): boolean {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
 
   packages/app-elements:
     dependencies:
-      '@ac-dev/countries-service':
-        specifier: ^1.2.0
-        version: 1.2.0
       '@commercelayer/sdk':
         specifier: 5.21.1
         version: 5.21.1
@@ -314,11 +311,6 @@ packages:
     resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
     engines: {node: '>=0.10.0'}
     dev: true
-
-  /@ac-dev/countries-service@1.2.0:
-    resolution: {integrity: sha512-9+LUUTALFa17EKL7l93ExcjYgHdkcHWlOyvAqMdrVWie6/105eGryQqaba0yIwM4rBYfvs/b/KJHkbcAdSFD2Q==}
-    engines: {node: '>=10'}
-    dev: false
 
   /@adobe/css-tools@4.3.1:
     resolution: {integrity: sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==}


### PR DESCRIPTION
## What I did

I've removed the`@ac-dev/countries-service`  package that was used to generate a list of countries for the address form select options (`ResourceAddress` component).
Now we dynamically fetch countries and states from cdn (just IT and US for now) and populate the select according.
 

https://github.com/commercelayer/app-elements/assets/30926550/3ae12dce-552d-4f28-9d2c-1242ba2cbb57




## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
