### PR TITLE
Add optional `stock transfer` visualization in `ResourceLineItems` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.mocks.ts
@@ -2,9 +2,39 @@ import {
   type LineItem,
   type ParcelLineItem,
   type ReturnLineItem,
-  type StockLineItem
+  type StockLocation,
+  type StockTransfer
 } from '@commercelayer/sdk'
 import { manualAdjustmentReferenceOrigin } from '../ResourceOrderSummary/utils'
+import { type StockLineItemWithStockTransfer } from './types'
+
+const originStockLocation = {
+  type: 'stock_locations',
+  id: '',
+  name: 'US Warehouse',
+  created_at: '',
+  updated_at: ''
+} as const satisfies StockLocation
+
+const destinationStockLocation = {
+  type: 'stock_locations',
+  id: '',
+  name: 'NY Store',
+  created_at: '',
+  updated_at: ''
+} as const satisfies StockLocation
+
+const stockTransfer = {
+  type: 'stock_transfers',
+  id: '',
+  number: 3478,
+  quantity: 1,
+  updated_at: '2023-06-10T06:38:44.964Z',
+  created_at: '2023-06-09T11:00:00.000Z',
+  status: 'upcoming',
+  origin_stock_location: originStockLocation,
+  destination_stock_location: destinationStockLocation
+} as const satisfies StockTransfer
 
 export const presetLineItems = {
   oneLine: {
@@ -219,6 +249,39 @@ export const presetLineItems = {
       reference_origin: '',
       metadata: {}
     }
+  },
+  stockLineItemWithStockTransfer: {
+    id: 'nBJxuxMObm',
+    type: 'stock_line_items',
+    sku_code: 'TSHIRTMMFFFFFFE63E74MXXX',
+    quantity: 3,
+    created_at: '2023-08-09T10:37:26.211Z',
+    updated_at: '2023-08-09T10:37:26.211Z',
+    reference: null,
+    reference_origin: null,
+    metadata: {},
+    sku: {
+      id: 'bnRwRSJQlZ',
+      type: 'skus',
+      code: 'TSHIRTMSFFFFFF000000XLXX_FLAT',
+      name: 'White Men T-Shirt with Black Logo (XL)',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam pellentesque in neque vitae tincidunt. In gravida eu ipsum non condimentum. Curabitur libero leo, gravida a dictum vestibulum, sollicitudin vel quam.',
+      image_url:
+        'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/TSHIRTMSFFFFFF000000LXXX_FLAT.png',
+      weight: 200,
+      unit_of_weight: 'gr',
+      hs_tariff_number: '',
+      do_not_ship: false,
+      do_not_track: false,
+      inventory: null,
+      created_at: '2022-05-13T12:33:45.266Z',
+      updated_at: '2023-07-12T14:43:38.731Z',
+      reference: 'TSHIRTMMFFFFFFE63E74',
+      reference_origin: '',
+      metadata: {}
+    },
+    stockTransfer
   },
   parcelLineItem: {
     id: 'PZEKxtRWrw',
@@ -603,5 +666,5 @@ export const presetLineItems = {
   }
 } satisfies Record<
   string,
-  LineItem | ParcelLineItem | StockLineItem | ReturnLineItem
+  LineItem | ParcelLineItem | StockLineItemWithStockTransfer | ReturnLineItem
 >

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/types.ts
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/types.ts
@@ -1,0 +1,5 @@
+import { type StockLineItem, type StockTransfer } from '@commercelayer/sdk'
+
+export type StockLineItemWithStockTransfer = StockLineItem & {
+  stockTransfer?: StockTransfer
+}

--- a/packages/docs/src/stories/resources/ResourceLineItems.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceLineItems.stories.tsx
@@ -127,7 +127,7 @@ ParcelLineItem.args = {
 
 export const StockLineItem = Template.bind({})
 StockLineItem.args = {
-  preset: ['stockLineItem']
+  preset: ['stockLineItem', 'stockLineItemWithStockTransfer']
 }
 
 export const ReturnLineItem = Template.bind({})


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified `ResourceLineItems` component to support an optional custom attribute `stockTransfer` for items of type `stock_line_item. This attribute expects to be filled with a `StockTransfer` SDK object in order to show below the `stock_line_item` item informations about its related stock transfer.

<img width="804" alt="Screenshot 2023-11-28 alle 16 19 02" src="https://github.com/commercelayer/app-elements/assets/105653649/33f47086-bec0-42b2-9406-0bda818133ed">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
