### PR TITLE
Expose `AvatarLetter` children props

### DIFF
--- a/packages/app-elements/src/ui/atoms/AvatarLetter/AvatarLetter.tsx
+++ b/packages/app-elements/src/ui/atoms/AvatarLetter/AvatarLetter.tsx
@@ -13,6 +13,11 @@ export interface AvatarLetterProps {
    */
   className?: string
   style?: React.CSSProperties
+  children?: (values: {
+    initials: string
+    backgroundColor: string
+    textColor: string
+  }) => JSX.Element
 }
 
 /**
@@ -25,12 +30,27 @@ export function AvatarLetter({
   text,
   className,
   style,
+  children,
   ...rest
 }: AvatarLetterProps): JSX.Element {
+  const initials = useMemo(() => getInitials(text), [text])
   const backgroundColor = useMemo(
     () => getDeterministicValue(text, BG_COLORS) ?? '#FFFFFF',
     [text]
   )
+  const textColor = useMemo(
+    () => getTextColorForBackground(backgroundColor),
+    [backgroundColor]
+  )
+
+  if (children != null) {
+    return children({
+      initials,
+      backgroundColor,
+      textColor
+    })
+  }
+
   return (
     <div
       className={classNames(
@@ -39,8 +59,8 @@ export function AvatarLetter({
         'flex items-center justify-center',
         'font-bold text-sm',
         {
-          'text-white': getTextColorForBackground(backgroundColor) === 'white',
-          'text-black': getTextColorForBackground(backgroundColor) === 'black'
+          'text-white': textColor === 'white',
+          'text-black': textColor === 'black'
         }
       )}
       style={{
@@ -49,7 +69,7 @@ export function AvatarLetter({
       }}
       {...rest}
     >
-      {getInitials(text)}
+      {initials}
     </div>
   )
 }

--- a/packages/docs/src/stories/atoms/AvatarLetter.stories.tsx
+++ b/packages/docs/src/stories/atoms/AvatarLetter.stories.tsx
@@ -29,6 +29,17 @@ SingleWorld.args = {
   text: 'Doe'
 }
 
+/** Access to internal values with children props. */
+export const ChildrenProps: StoryFn<typeof AvatarLetter> = () => (
+  <AvatarLetter text='John Doe'>
+    {({ initials, backgroundColor, textColor }) => (
+      <pre>
+        {JSON.stringify({ initials, backgroundColor, textColor }, null, 2)}
+      </pre>
+    )}
+  </AvatarLetter>
+)
+
 /** This is the list of all available background colors. You cannot choose the background; it is calculated based on the given `text`. */
 export const AvailableBackgroundColors: StoryFn = (_args) => {
   return (


### PR DESCRIPTION
## What I did

I've added child as a function capability to the `<AvatarLetter>` component, so we can access to the generated values.

In this way it could be also used as:
```jsx
<AvatarLetter text='John Doe'>
  {({  initials, backgroundColor, textColor }) => (
    <img src={myCustomImageUrlGenerator(initials, backgroundColor, textColor)}  />
  )}
</AvatarLetter>
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
