### PR TITLE
Add `<SwitchMode>` component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -134,6 +134,7 @@ export {
 } from '#ui/composite/PageSkeleton'
 export { Report, type ReportProps } from '#ui/composite/Report'
 export { SearchBar, type SearchBarProps } from '#ui/composite/SearchBar'
+export { SwitchMode, type SwitchModeProps } from '#ui/composite/SwitchMode'
 export { TableData, type TableDataProps } from '#ui/composite/TableData'
 export {
   Timeline,

--- a/packages/app-elements/src/ui/composite/SwitchMode.test.tsx
+++ b/packages/app-elements/src/ui/composite/SwitchMode.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render } from '@testing-library/react'
+import { useState, type FC } from 'react'
+import { SwitchMode } from './SwitchMode'
+
+const ControlledSwitchMode: FC = () => {
+  const [mode, setMode] = useState<'test' | 'live'>('test')
+
+  return (
+    <div>
+      <div data-testid='current-mode'>{mode}</div>
+      <SwitchMode mode={mode} onChange={setMode} />
+    </div>
+  )
+}
+
+describe('SwitchMode', () => {
+  test('Should be rendered', async () => {
+    const { getByTestId } = render(<ControlledSwitchMode />)
+
+    expect(getByTestId('switch-mode')).toBeInTheDocument()
+  })
+
+  test('Should toggle mode', async () => {
+    const { getByTestId } = render(<ControlledSwitchMode />)
+    expect(getByTestId('current-mode')).toHaveTextContent('test')
+
+    fireEvent.click(getByTestId('switch-mode'))
+    expect(getByTestId('current-mode')).toHaveTextContent('live')
+
+    fireEvent.click(getByTestId('switch-mode'))
+    expect(getByTestId('current-mode')).toHaveTextContent('test')
+  })
+})

--- a/packages/app-elements/src/ui/composite/SwitchMode.tsx
+++ b/packages/app-elements/src/ui/composite/SwitchMode.tsx
@@ -1,0 +1,47 @@
+import cn from 'classnames'
+import { type FC } from 'react'
+
+export interface SwitchModeProps {
+  mode: 'test' | 'live'
+  onChange: (newMode: 'test' | 'live') => void
+}
+
+export const SwitchMode: FC<SwitchModeProps> = ({ mode, onChange }) => {
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-2 w-fit',
+        'focus-within:rounded focus-within:outline focus-within:outline-2 focus-within:!outline-orange-700 focus-within:outline-offset-2'
+      )}
+    >
+      <div className={cn('relative flex')}>
+        <input
+          id='mode-switch'
+          type='checkbox'
+          checked={mode === 'test'}
+          className={cn(
+            'absolute cursor-pointer top-0 left-0 w-full h-full peer appearance-none opacity-0 z-10'
+          )}
+          onChange={() => {
+            onChange(mode === 'test' ? 'live' : 'test')
+          }}
+          data-testid='switch-mode'
+        />
+        <span
+          className={cn(
+            'w-8 h-5 flex items-center flex-shrink-0 p-[1px] bg-gray-300 rounded-full duration-300 ease-in-out peer-checked:bg-orange-700 after:w-4 after:h-4 after:bg-white after:rounded-full after:shadow-md after:duration-300 peer-checked:after:translate-x-3'
+          )}
+        />
+      </div>
+      <label
+        htmlFor='mode-switch'
+        className={cn('font-bold cursor-pointer select-none duration-300', {
+          'text-orange-700': mode === 'test',
+          'text-gray-300': mode === 'live'
+        })}
+      >
+        Test mode
+      </label>
+    </div>
+  )
+}

--- a/packages/docs/src/stories/composite/SwitchMode.stories.tsx
+++ b/packages/docs/src/stories/composite/SwitchMode.stories.tsx
@@ -1,0 +1,18 @@
+import { SwitchMode } from '#ui/composite/SwitchMode'
+import { type Meta, type StoryFn } from '@storybook/react'
+import { useState } from 'react'
+
+const setup: Meta<typeof SwitchMode> = {
+  title: 'Composite/SwitchMode',
+  component: SwitchMode,
+  parameters: {
+    layout: 'padded'
+  }
+}
+export default setup
+
+export const Default: StoryFn<typeof SwitchMode> = () => {
+  const [mode, setMode] = useState<'test' | 'live'>('test')
+
+  return <SwitchMode mode={mode} onChange={setMode} />
+}


### PR DESCRIPTION
## What I did

I've added a custom switch component to be used to show the current mode (test or live) and to change it.

<img width="163" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/ff0dbf8e-8c54-4d9a-b853-ab245c51686b">

https://deploy-preview-449--commercelayer-app-elements.netlify.app/?path=/docs/composite-switchmode--docs

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
