### PR TITLE
Add `shipments` support to `ResourceTags` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -32,6 +32,7 @@ type TaggableResource = Extract<
   | 'returns'
   | 'sku_options'
   | 'skus'
+  | 'shipments'
 >
 
 interface TagsOverlay {


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added `shipments` to the taggable resource types of `ResourceTags` component in order to let it to be used also for this kind of resource type in our apps.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
