### PR TITLE
Restrict `ResourceListItem` usage of `stock_transfers` to some defined statuses

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
@@ -11,8 +11,15 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
   resource,
   user
 }) => {
-  const awaitingStockTransfer =
-    resource.stock_transfers != null && resource.stock_transfers.length > 0
+  const stockTransfersToBeAwaited =
+    resource.stock_transfers?.filter(
+      (stockTransfer) =>
+        stockTransfer.status !== 'completed' &&
+        stockTransfer.status !== 'cancelled' &&
+        stockTransfer.status !== 'draft'
+    ) ?? []
+
+  const awaitingStockTransfer = stockTransfersToBeAwaited.length > 0
   const displayStatus = getShipmentDisplayStatus(
     resource,
     awaitingStockTransfer


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified the `ResourceListItem` component to consider only `stock_transfers` with a `status` not in `completed`, `cancelled` and `draft`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
