### PR TITLE
Add `icon` to `Badge` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Badge/Badge.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge/Badge.test.tsx
@@ -29,6 +29,6 @@ describe('Badge', () => {
     })
     expect(element).toBeInTheDocument()
     expect(element.tagName).toBe('DIV')
-    expect(element.innerHTML).toBe('Completed')
+    expect(element.innerHTML).toContain('Completed')
   })
 })

--- a/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
@@ -1,5 +1,4 @@
-import { Icon } from '#ui/atoms/Icon'
-import { type iconMapping } from '#ui/atoms/Icon/icons'
+import { Icon, type IconProps } from '#ui/atoms/Icon'
 import cn from 'classnames'
 import React from 'react'
 import { variantCss } from './badgeVariants'
@@ -8,7 +7,7 @@ export interface BadgeProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Render a different variant. */
   variant: keyof typeof variantCss
-  icon?: keyof typeof iconMapping
+  icon?: IconProps['name']
   children: React.ReactNode
 }
 

--- a/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
+++ b/packages/app-elements/src/ui/atoms/Badge/Badge.tsx
@@ -1,3 +1,5 @@
+import { Icon } from '#ui/atoms/Icon'
+import { type iconMapping } from '#ui/atoms/Icon/icons'
 import cn from 'classnames'
 import React from 'react'
 import { variantCss } from './badgeVariants'
@@ -6,12 +8,14 @@ export interface BadgeProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
   /** Render a different variant. */
   variant: keyof typeof variantCss
+  icon?: keyof typeof iconMapping
   children: React.ReactNode
 }
 
 /** Badges are used to highlight an item's status for quick recognition. */
 export const Badge: React.FC<BadgeProps> = ({
   variant,
+  icon,
   children,
   className,
   ...rest
@@ -25,7 +29,10 @@ export const Badge: React.FC<BadgeProps> = ({
         variantCss[variant]
       ])}
     >
-      {children}
+      <div className='flex items-center gap-1'>
+        {icon != null && <Icon name={icon} size={16} weight='bold' />}
+        {children}
+      </div>
     </div>
   )
 }

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -26,6 +26,7 @@ export const iconMapping = {
   hourglass: phosphor.Hourglass,
   magnifyingGlass: phosphor.MagnifyingGlass,
   minus: phosphor.Minus,
+  minusCircle: phosphor.MinusCircle,
   package: phosphor.Package,
   pencilSimple: phosphor.PencilSimple,
   printer: phosphor.Printer,

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -48,7 +48,11 @@ exports[`ResourceLineItems > should render 1`] = `
             <div
               class="text-xs font-bold py-0.5 px-2 rounded inline-block text-gray-500 bg-gray-500/10"
             >
-              Unit price 9.00€
+              <div
+                class="flex items-center gap-1"
+              >
+                Unit price 9.00€
+              </div>
             </div>
           </div>
         </td>
@@ -142,7 +146,11 @@ exports[`ResourceLineItems > should render the Footer prop when defined 1`] = `
             <div
               class="text-xs font-bold py-0.5 px-2 rounded inline-block text-gray-500 bg-gray-500/10"
             >
-              Unit price 9.00€
+              <div
+                class="flex items-center gap-1"
+              >
+                Unit price 9.00€
+              </div>
             </div>
           </div>
         </td>
@@ -253,7 +261,11 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
             <div
               class="text-xs font-bold py-0.5 px-2 rounded inline-block text-gray-500 bg-gray-500/10"
             >
-              Unit price 9.00€
+              <div
+                class="flex items-center gap-1"
+              >
+                Unit price 9.00€
+              </div>
             </div>
           </div>
         </td>
@@ -435,7 +447,11 @@ exports[`ResourceLineItems > should render the bundle 1`] = `
             <div
               class="text-xs font-bold py-0.5 px-2 rounded inline-block text-gray-500 bg-gray-500/10"
             >
-              Unit price $10.00
+              <div
+                class="flex items-center gap-1"
+              >
+                Unit price $10.00
+              </div>
             </div>
           </div>
         </td>
@@ -584,7 +600,11 @@ exports[`ResourceLineItems > should render the list item options 1`] = `
             <div
               class="text-xs font-bold py-0.5 px-2 rounded inline-block text-gray-500 bg-gray-500/10"
             >
-              Unit price 27.00€
+              <div
+                class="flex items-center gap-1"
+              >
+                Unit price 27.00€
+              </div>
             </div>
           </div>
         </td>

--- a/packages/docs/src/stories/atoms/Badge.stories.tsx
+++ b/packages/docs/src/stories/atoms/Badge.stories.tsx
@@ -20,6 +20,12 @@ Default.args = {
   variant: 'success'
 }
 
+export const WithIcon = Template.bind({})
+WithIcon.args = {
+  variant: 'success',
+  icon: 'pulse'
+}
+
 /** These are all the possible values for the `variant` prop. */
 export const AvailableVariants: StoryFn = () => (
   <div


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified the `Badge` component to let it show a little bold icon, on the left side of its content, based on a new optional `icon` prop. The `icon` prop will expects to be filled with one of our preselected icons name.
Icon size and weight props will be managed internally by the `Badge`.

<img width="600" alt="Screenshot 2023-12-06 alle 10 26 52" src="https://github.com/commercelayer/app-elements/assets/105653649/8f6e4ca3-a1d5-4923-82fc-9ac9614cbe75">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
