### PR TITLE
Set correct border radius in `OrganizationMenu`

### DIFF
--- a/packages/app-elements/src/ui/composite/OrganizationMenu.tsx
+++ b/packages/app-elements/src/ui/composite/OrganizationMenu.tsx
@@ -48,7 +48,7 @@ export const OrganizationMenuItem: FC<OrganizationMenuItemProps> = ({
       href={href}
       onClick={onClick}
       className={cn(
-        'flex items-center gap-3 p-2 font-semibold rounded-s text-gray-700 hover:bg-gray-100 hover:text-black',
+        'flex items-center gap-3 p-2 font-semibold rounded text-gray-700 hover:bg-gray-100 hover:text-black',
         { 'bg-gray-100 text-black': isActive === true }
       )}
     >


### PR DESCRIPTION
## What I did

Border radius in Organization menu was wrong, since it was set only on the right `-r`.
I've fixed that

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
