### PR TITLE
Add header and icons in `Dropdown`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -33,6 +33,7 @@ export const iconMapping = {
   package: phosphor.Package,
   pencilSimple: phosphor.PencilSimple,
   printer: phosphor.Printer,
+  plus: phosphor.Plus,
   pulse: phosphor.Pulse,
   resources: phosphor.Stack,
   settings: phosphor.GearFine,

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -1,18 +1,17 @@
 import { useClickAway } from '#hooks/useClickAway'
 import { useOnBlurFromContainer } from '#hooks/useOnBlurFromContainer'
 import { Button } from '#ui/atoms/Button'
+import { type DropdownMenuProps } from '#ui/composite/Dropdown/DropdownMenu'
 import { CaretDown, DotsThreeCircle } from '@phosphor-icons/react'
 import cn from 'classnames'
 import { useState } from 'react'
 import { DropdownMenu } from './DropdownMenu'
 
-export interface DropdownProps {
+export interface DropdownProps extends Pick<DropdownMenuProps, 'menuHeader'> {
   /** The trigger for the dropdown menu. Can be a JSX Element or simply a `string`. */
   dropdownLabel?: React.ReactNode
   /** List of links and actions. You can use a combination of `DropdownItem` and `DropdownDivider` components. */
   dropdownItems: React.ReactNode
-  /** Optional header for the dropdown menu */
-  menuHeader?: string
 }
 
 /**
@@ -73,7 +72,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
             className='absolute top-0 right-0'
             onClick={closeDropdownMenuIfButtonClicked}
           >
-            <DropdownMenu header={menuHeader}>{dropdownItems}</DropdownMenu>
+            <DropdownMenu menuHeader={menuHeader}>{dropdownItems}</DropdownMenu>
           </div>
         </div>
       )}

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -11,6 +11,8 @@ export interface DropdownProps {
   dropdownLabel?: React.ReactNode
   /** List of links and actions. You can use a combination of `DropdownItem` and `DropdownDivider` components. */
   dropdownItems: React.ReactNode
+  /** Optional header for the dropdown menu */
+  menuHeader?: string
 }
 
 /**
@@ -22,6 +24,7 @@ export interface DropdownProps {
  */
 export const Dropdown: React.FC<DropdownProps> = ({
   dropdownLabel = <DotsThreeCircle size={32} />,
+  menuHeader,
   dropdownItems
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
@@ -70,7 +73,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
             className='absolute top-0 right-0'
             onClick={closeDropdownMenuIfButtonClicked}
           >
-            <DropdownMenu>{dropdownItems}</DropdownMenu>
+            <DropdownMenu header={menuHeader}>{dropdownItems}</DropdownMenu>
           </div>
         </div>
       )}

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
@@ -8,7 +8,7 @@ export function DropdownDivider({
   ...rest
 }: DropdownDividerProps): JSX.Element {
   return (
-    <div {...rest} className='h-px'>
+    <div {...rest} className='h-px my-1'>
       <hr className='border-gray-600' />
     </div>
   )

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
@@ -1,12 +1,14 @@
+import { type FC } from 'react'
+
 export interface DropdownDividerProps
   extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode
 }
 
-export function DropdownDivider({
+export const DropdownDivider: FC<DropdownDividerProps> = ({
   children,
   ...rest
-}: DropdownDividerProps): JSX.Element {
+}) => {
   return (
     <div {...rest} className='h-px my-1'>
       <hr className='border-gray-600' />

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -1,23 +1,40 @@
+import { Icon, type IconProps } from '#ui/atoms/Icon/Icon'
+import { type FC } from 'react'
+
 export interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
   label: string
-  icon?: React.ReactNode
+  icon?: IconProps['name'] | 'keep-space'
 }
 
-export function DropdownItem({
+export const DropdownItem: FC<DropdownItemProps> = ({
   label,
   icon,
   ...rest
-}: DropdownItemProps): JSX.Element {
+}) => {
   return (
     <button
       {...rest}
-      className='w-full bg-black text-white py-2 pl-4 pr-8  text-sm font-semibold cursor-pointer flex items-center hover:bg-primary focus:bg-primary focus:!outline-none'
+      className='w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold cursor-pointer flex items-center hover:bg-primary focus:bg-primary focus:!outline-none'
       aria-label={label}
     >
-      {icon != null && <div>{icon}</div>}
-      {label}
+      {icon != null ? (
+        <div className='mr-2'>
+          {icon === 'keep-space' ? (
+            <FakeIcon /> // keep the gap as if there was an icon
+          ) : (
+            <Icon name={icon} weight='bold' />
+          )}
+        </div>
+      ) : null}
+
+      <span className='text-ellipsis overflow-hidden whitespace-nowrap'>
+        {label}
+      </span>
     </button>
   )
 }
-
 DropdownItem.displayName = 'DropdownItem'
+
+const FakeIcon: FC = () => {
+  return <div className='w-[14px]' />
+}

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -27,7 +27,10 @@ export const DropdownItem: FC<DropdownItemProps> = ({
         </div>
       ) : null}
 
-      <span className='text-ellipsis overflow-hidden whitespace-nowrap'>
+      <span
+        className='text-ellipsis overflow-hidden whitespace-nowrap'
+        title={label}
+      >
         {label}
       </span>
     </button>

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -1,18 +1,22 @@
 import cn from 'classnames'
+import { type FC } from 'react'
 import { DropdownDivider } from './DropdownDivider'
 
-interface Props extends React.HTMLAttributes<HTMLElement> {
+export interface DropdownMenuProps extends React.HTMLAttributes<HTMLElement> {
+  /** Menu content */
   children?: React.ReactNode
+  /** Set to `none` to hide the top arrow */
   arrow?: 'none'
-  header?: string
+  /** Optional header for the dropdown menu */
+  menuHeader?: string
 }
 
-export function DropdownMenu({
+export const DropdownMenu: FC<DropdownMenuProps> = ({
   children,
   arrow,
-  header,
+  menuHeader,
   ...rest
-}: Props): JSX.Element {
+}) => {
   const showArrow = arrow === undefined
   const showArrowMenuCss = showArrow && 'mt-[5px]'
 
@@ -41,13 +45,13 @@ export function DropdownMenu({
           showArrowMenuCss
         ])}
       >
-        {header != null && (
+        {menuHeader != null && (
           <>
             <div
               className='py-2 px-4 text-gray-400 text-xs font-semibold text-ellipsis overflow-hidden whitespace-nowrap'
-              title={header}
+              title={menuHeader}
             >
-              {header}
+              {menuHeader}
             </div>
             <DropdownDivider />
           </>

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -1,11 +1,18 @@
 import cn from 'classnames'
+import { DropdownDivider } from './DropdownDivider'
 
 interface Props extends React.HTMLAttributes<HTMLElement> {
   children?: React.ReactNode
   arrow?: 'none'
+  header?: string
 }
 
-export function DropdownMenu({ children, arrow, ...rest }: Props): JSX.Element {
+export function DropdownMenu({
+  children,
+  arrow,
+  header,
+  ...rest
+}: Props): JSX.Element {
   const showArrow = arrow === undefined
   const showArrowMenuCss = showArrow && 'mt-[5px]'
 
@@ -30,10 +37,21 @@ export function DropdownMenu({ children, arrow, ...rest }: Props): JSX.Element {
       <div
         {...rest}
         className={cn([
-          'bg-black text-white rounded min-w-[150px] overflow-hidden',
+          'bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]',
           showArrowMenuCss
         ])}
       >
+        {header != null && (
+          <>
+            <div
+              className='py-2 px-4 text-gray-400 text-xs font-semibold text-ellipsis overflow-hidden whitespace-nowrap'
+              title={header}
+            >
+              {header}
+            </div>
+            <DropdownDivider />
+          </>
+        )}
         {children}
       </div>
     </div>

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -100,6 +100,35 @@ DropdownLabelAsString.args = {
   )
 }
 
+/** Dropdown menu can have an header  */
+export const MenuWithHeader = Template.bind({})
+MenuWithHeader.args = {
+  menuHeader: 'ringostarr@commercelayer-very-long-text.io',
+  dropdownItems: (
+    <>
+      <DropdownItem onClick={() => {}} label='Edit' />
+      <DropdownItem onClick={() => {}} label='Delete' />
+    </>
+  )
+}
+
+/**
+ * Dropdown items can also have icons. When you need to list them
+ * together with items without icons, you can pass `keep-space` so gap will be mainteined.
+ **/
+export const ItemsWithIcons = Template.bind({})
+ItemsWithIcons.args = {
+  dropdownItems: (
+    <>
+      <DropdownItem onClick={() => {}} icon='userCircle' label='Profile' />
+      <DropdownItem onClick={() => {}} icon='creditCard' label='Subscription' />
+      <DropdownItem onClick={() => {}} icon='keep-space' label='No icon' />
+      <DropdownDivider />
+      <DropdownItem onClick={() => {}} icon='signOut' label='Logout' />
+    </>
+  )
+}
+
 /** Dropdown can also be used as a Section's action button. */
 export const WithinASection: StoryFn<typeof Dropdown> = (args) => {
   return (

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -122,6 +122,11 @@ ItemsWithIcons.args = {
     <>
       <DropdownItem onClick={() => {}} icon='userCircle' label='Profile' />
       <DropdownItem onClick={() => {}} icon='creditCard' label='Subscription' />
+      <DropdownItem
+        onClick={() => {}}
+        icon='keep-space'
+        label='Super long label that eventually will be trimmed'
+      />
       <DropdownItem onClick={() => {}} icon='keep-space' label='No icon' />
       <DropdownDivider />
       <DropdownItem onClick={() => {}} icon='signOut' label='Logout' />


### PR DESCRIPTION
## What I did

- Improve the usage of the `icon` prop on `DropdownItem`, so it can consume directly the `<Icon>` component
- Add `header` to `DropdownMenu`
- Align spacings to the latest design
- Set a max width for the menu (250px + ellipsis for content)

https://deploy-preview-462--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#menu-with-header

Example:
<img width="177" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/c0cdc2a2-1f56-4b42-ac86-8ea3bb5f8c69">


When header or item label is too long it will be ellipsed, html `title` attribute will provide native tooltip
<img width="482" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/49ecac1c-9d0e-4f00-b672-5f1ec89b1872">

 
 
<img width="430" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/3f5c7858-3952-4c39-ad77-ae18f79fee16">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
