### PR TITLE
Add DropdownSearch component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -116,9 +116,11 @@ export {
   Dropdown,
   DropdownDivider,
   DropdownItem,
+  DropdownSearch,
   type DropdownDividerProps,
   type DropdownItemProps,
-  type DropdownProps
+  type DropdownProps,
+  type DropdownSearchProps
 } from '#ui/composite/Dropdown'
 export { List, type ListProps } from '#ui/composite/List'
 export { ListDetails, type ListDetailsProps } from '#ui/composite/ListDetails'

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownSearch.test.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownSearch.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render } from '@testing-library/react'
+import { DropdownSearch } from './DropdownSearch'
+
+describe('DropdownSearch', () => {
+  beforeAll(() => {
+    vi.useFakeTimers()
+  })
+
+  afterAll(() => {
+    vi.useRealTimers()
+  })
+
+  it('should render', () => {
+    const { container, getByPlaceholderText } = render(
+      <DropdownSearch onSearch={() => {}} placeholder='type to search' />
+    )
+    expect(container).toBeVisible()
+    expect(getByPlaceholderText('type to search')).toBeVisible()
+  })
+
+  it('should update input value', () => {
+    const { getByPlaceholderText } = render(
+      <DropdownSearch onSearch={() => {}} placeholder='search' />
+    )
+    const input = getByPlaceholderText('search') as HTMLInputElement
+    expect(input.value).toBe('')
+    fireEvent.change(input, { target: { value: 'foobar' } })
+
+    expect(input.value).toBe('foobar')
+  })
+
+  it('should trigger debounced onSearch callback', () => {
+    const mockedConsoleLog = vi
+      .spyOn(console, 'log')
+      .mockImplementation(() => {})
+    const { getByPlaceholderText } = render(
+      <DropdownSearch
+        onSearch={(hint) => {
+          console.log(hint)
+        }}
+        debounceMs={100}
+        placeholder='search'
+      />
+    )
+    const input = getByPlaceholderText('search') as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'he' } })
+    fireEvent.change(input, { target: { value: 'hello' } })
+    fireEvent.change(input, { target: { value: 'hello wo' } })
+    fireEvent.change(input, { target: { value: 'hello world' } })
+    expect(mockedConsoleLog).toHaveBeenCalledTimes(0)
+    vi.advanceTimersByTime(110)
+    expect(mockedConsoleLog).toHaveBeenNthCalledWith(1, 'hello world')
+  })
+})

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownSearch.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownSearch.tsx
@@ -1,0 +1,81 @@
+import { Icon } from '#ui/atoms/Icon'
+import cn from 'classnames'
+import debounce from 'lodash/debounce'
+import { forwardRef, useCallback, useEffect, useState } from 'react'
+
+export interface DropdownSearchProps {
+  /**
+   * Callback triggered when the user types in the search input.
+   * By default, this callback is debounced by 500ms.
+   */
+  onSearch: (hint: string) => void
+  /**
+   * Debounce time in ms for the onSearch callback. Set to 0 to disable debounce.
+   * @default 500
+   */
+  debounceMs?: number
+  /**
+   * Placeholder text for the input element
+   */
+  placeholder?: string
+  /**
+   * Enable auto focus on the input element
+   */
+  autoFocus?: boolean
+}
+
+/**
+ * This component renders an input as dropdown menu item with debounced `onSearch` callback.
+ */
+export const DropdownSearch = forwardRef<HTMLInputElement, DropdownSearchProps>(
+  (
+    {
+      onSearch,
+      debounceMs = 500,
+      placeholder = 'Search...',
+      autoFocus,
+      ...rest
+    },
+    ref
+  ): JSX.Element => {
+    const [searchValue, setSearchValue] = useState('')
+
+    const debouncedOnSearch = useCallback(debounce(onSearch, debounceMs), [
+      onSearch
+    ])
+
+    useEffect(
+      function unmountDebounce() {
+        return () => {
+          debouncedOnSearch?.cancel()
+        }
+      },
+      [debouncedOnSearch]
+    )
+
+    return (
+      <div className='relative w-full' {...rest}>
+        <Icon
+          name='magnifyingGlass'
+          weight='bold'
+          className='absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-sm '
+        />
+        <input
+          className={cn(
+            'pl-10 pr-8 py-2 bg-transparent min-w-max font-semibold text-sm placeholder:text-gray-400 !ring-0'
+          )}
+          placeholder={placeholder}
+          value={searchValue}
+          onChange={({ currentTarget: { value } }) => {
+            setSearchValue(value)
+            debouncedOnSearch(value)
+          }}
+          ref={ref}
+          autoFocus={autoFocus}
+        />
+      </div>
+    )
+  }
+)
+
+DropdownSearch.displayName = 'DropdownSearch'

--- a/packages/app-elements/src/ui/composite/Dropdown/index.ts
+++ b/packages/app-elements/src/ui/composite/Dropdown/index.ts
@@ -1,3 +1,4 @@
 export { Dropdown, type DropdownProps } from './Dropdown'
 export { DropdownDivider, type DropdownDividerProps } from './DropdownDivider'
 export { DropdownItem, type DropdownItemProps } from './DropdownItem'
+export { DropdownSearch, type DropdownSearchProps } from './DropdownSearch'

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -1,6 +1,11 @@
 import { Section } from '#ui/atoms/Section'
 import { Spacer } from '#ui/atoms/Spacer'
-import { Dropdown, DropdownDivider, DropdownItem } from '#ui/composite/Dropdown'
+import {
+  Dropdown,
+  DropdownDivider,
+  DropdownItem,
+  DropdownSearch
+} from '#ui/composite/Dropdown'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Dropdown> = {
@@ -114,7 +119,7 @@ MenuWithHeader.args = {
 
 /**
  * Dropdown items can also have icons. When you need to list them
- * together with items without icons, you can pass `keep-space` so gap will be mainteined.
+ * together with items without icons, you can pass `keep-space` so gap will be maintained.
  **/
 export const ItemsWithIcons = Template.bind({})
 ItemsWithIcons.args = {
@@ -130,6 +135,29 @@ ItemsWithIcons.args = {
       <DropdownItem onClick={() => {}} icon='keep-space' label='No icon' />
       <DropdownDivider />
       <DropdownItem onClick={() => {}} icon='signOut' label='Logout' />
+    </>
+  )
+}
+
+/**
+ * Dropdown can also accept a DropdownSearch item that returns debounced values.
+ **/
+export const WithDropdownSearch = Template.bind({})
+WithDropdownSearch.args = {
+  dropdownItems: (
+    <>
+      <DropdownSearch
+        onSearch={(hint) => {
+          console.log(hint)
+        }}
+        placeholder='Search...'
+      />
+      <DropdownDivider />
+      <DropdownItem onClick={() => {}} icon='check' label='Green' />
+      <DropdownItem onClick={() => {}} icon='keep-space' label='Red' />
+      <DropdownItem onClick={() => {}} icon='keep-space' label='Yellow' />
+      <DropdownItem onClick={() => {}} icon='keep-space' label='Black' />
+      <DropdownItem onClick={() => {}} icon='keep-space' label='White' />
     </>
   )
 }


### PR DESCRIPTION
## What I did

I've added a new component `DropdownSearch` to be used inside the dropdown menu to render an input.
The searched value is debounced by default.

In the future, we might discover that the search pattern is consistent everywhere so we will want to export instead a component that also returns a filtered list, but at the moment let's keep this modular by placing the search input and manually rendering a list of DropdownItem underneath.

https://deploy-preview-463--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#with-dropdown-search

<img width="335" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/03f56f85-a28e-44d3-bec2-0453b914e02d">


Example:

```tsx
<Dropdown
  dropdownItems={
    <>
      <DropdownSearch
        onSearch={(hint) => {
          console.log(hint)
        }}
        placeholder='Search...'
      />
      <DropdownDivider />
      {filteredData.map((item) => (
        <DropdownItem key={item.key} label={item.label} />
      ))}
    </>
  }
/>
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
