### PR TITLE
Add Dropdown menu position

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,62 @@
+import { Dropdown, DropdownDivider, DropdownItem } from '#ui/composite/Dropdown'
+import { fireEvent, render } from '@testing-library/react'
+
+const items = (
+  <>
+    <DropdownItem onClick={() => {}} icon='creditCard' label='Payments' />
+    <DropdownItem
+      onClick={() => {}}
+      icon='keep-space' // no icon, keep same gap
+      label='Items'
+    />
+
+    <DropdownDivider />
+    <DropdownItem onClick={() => {}} icon='xCircle' label='Delete' />
+  </>
+)
+
+describe('Dropdown', () => {
+  test('Should be rendering with default bottom-right position', () => {
+    const { container, getByText } = render(
+      <Dropdown dropdownLabel='open dropdown' dropdownItems={items} />
+    )
+    fireEvent.click(getByText('open dropdown'))
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should be rendering bottom-left', () => {
+    const { container, getByText } = render(
+      <Dropdown
+        dropdownLabel='open dropdown'
+        menuPosition='bottom-left'
+        dropdownItems={<div />}
+      />
+    )
+    fireEvent.click(getByText('open dropdown'))
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should be rendering top-left', () => {
+    const { container, getByText } = render(
+      <Dropdown
+        dropdownLabel='open dropdown'
+        menuPosition='top-left'
+        dropdownItems={<div />}
+      />
+    )
+    fireEvent.click(getByText('open dropdown'))
+    expect(container).toMatchSnapshot()
+  })
+
+  test('Should be rendering top-right', () => {
+    const { container, getByText } = render(
+      <Dropdown
+        dropdownLabel='open dropdown'
+        menuPosition='top-right'
+        dropdownItems={<div />}
+      />
+    )
+    fireEvent.click(getByText('open dropdown'))
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -7,7 +7,8 @@ import cn from 'classnames'
 import { useState } from 'react'
 import { DropdownMenu } from './DropdownMenu'
 
-export interface DropdownProps extends Pick<DropdownMenuProps, 'menuHeader'> {
+export interface DropdownProps
+  extends Pick<DropdownMenuProps, 'menuHeader' | 'menuPosition'> {
   /** The trigger for the dropdown menu. Can be a JSX Element or simply a `string`. */
   dropdownLabel?: React.ReactNode
   /** List of links and actions. You can use a combination of `DropdownItem` and `DropdownDivider` components. */
@@ -24,7 +25,8 @@ export interface DropdownProps extends Pick<DropdownMenuProps, 'menuHeader'> {
 export const Dropdown: React.FC<DropdownProps> = ({
   dropdownLabel = <DotsThreeCircle size={32} />,
   menuHeader,
-  dropdownItems
+  dropdownItems,
+  menuPosition = 'bottom-right'
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -49,7 +51,11 @@ export const Dropdown: React.FC<DropdownProps> = ({
   const handleBlur = useOnBlurFromContainer(close)
 
   return (
-    <div ref={isExpanded ? clickAwayRef : undefined} onBlur={handleBlur}>
+    <div
+      ref={isExpanded ? clickAwayRef : undefined}
+      onBlur={handleBlur}
+      className='relative'
+    >
       <Button
         variant='link'
         aria-haspopup
@@ -67,13 +73,18 @@ export const Dropdown: React.FC<DropdownProps> = ({
         ) : null}
       </Button>
       {isExpanded && (
-        <div className='relative'>
-          <div
-            className='absolute top-0 right-0'
-            onClick={closeDropdownMenuIfButtonClicked}
-          >
-            <DropdownMenu menuHeader={menuHeader}>{dropdownItems}</DropdownMenu>
-          </div>
+        <div
+          className={cn('absolute z-30', {
+            'top-full mt-[5px] right-0': menuPosition === 'bottom-right',
+            'top-full mt-[5px] left-0': menuPosition === 'bottom-left',
+            'bottom-full mb-[5px] right-0': menuPosition === 'top-right',
+            'bottom-full mb-[5px] left-0': menuPosition === 'top-left'
+          })}
+          onClick={closeDropdownMenuIfButtonClicked}
+        >
+          <DropdownMenu menuHeader={menuHeader} menuPosition={menuPosition}>
+            {dropdownItems}
+          </DropdownMenu>
         </div>
       )}
     </div>

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -82,7 +82,11 @@ export const Dropdown: React.FC<DropdownProps> = ({
           })}
           onClick={closeDropdownMenuIfButtonClicked}
         >
-          <DropdownMenu menuHeader={menuHeader} menuPosition={menuPosition}>
+          <DropdownMenu
+            menuHeader={menuHeader}
+            menuPosition={menuPosition}
+            parentElementRef={clickAwayRef}
+          >
             {dropdownItems}
           </DropdownMenu>
         </div>

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -9,41 +9,35 @@ export interface DropdownMenuProps extends React.HTMLAttributes<HTMLElement> {
   arrow?: 'none'
   /** Optional header for the dropdown menu */
   menuHeader?: string
+  /**
+   * Opening position of the dropdown menu
+   * @default bottom-right
+   */
+  menuPosition?: 'bottom-left' | 'bottom-right' | 'top-left' | 'top-right'
 }
 
 export const DropdownMenu: FC<DropdownMenuProps> = ({
   children,
   arrow,
   menuHeader,
+  menuPosition = 'bottom-right',
   ...rest
 }) => {
-  const showArrow = arrow === undefined
-  const showArrowMenuCss = showArrow && 'mt-[5px]'
-
-  // const arrowHeight = 5
-  // const arrowWidth = 12
-
-  const menuLabelSizeCss: Record<number, string[]> = {
-    32: [
-      'w-0 h-0',
-      `absolute top-[-5px] right-[10px]`, // arrowHeight / 2 & (menuLabelSize - arrowWidth) / 2
-      `border-b-[5px] border-b-black`, // arrowHeight / 2
-      `border-l-[6px] border-l-transparent`, // arrowWidth / 2
-      `border-r-[6px] border-r-transparent` // arrowWidth / 2
-    ]
-  }
-
-  const arrowCss = cn(menuLabelSizeCss[32])
-
   return (
-    <div className='relative'>
-      {showArrow && <span className={arrowCss} />}
+    <div
+      className={cn('flex', {
+        'flex-col items-end': menuPosition === 'bottom-right',
+        'flex-col items-start': menuPosition === 'bottom-left',
+        'flex-col-reverse items-end': menuPosition === 'top-right',
+        'flex-col-reverse items-start': menuPosition === 'top-left'
+      })}
+    >
+      {arrow === 'none' ? null : (
+        <Arrow menuPosition={menuPosition} centerForWidth={32} />
+      )}
       <div
         {...rest}
-        className={cn([
-          'bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]',
-          showArrowMenuCss
-        ])}
+        className='bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]'
       >
         {menuHeader != null && (
           <>
@@ -63,3 +57,42 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
 }
 
 DropdownMenu.displayName = 'DropdownMenu'
+
+const Arrow: FC<{
+  menuPosition: DropdownMenuProps['menuPosition']
+  centerForWidth: number
+}> = ({ menuPosition = 'bottom-right', centerForWidth }) => {
+  const arrowHeight = 5
+  const arrowWidth = 12
+  const centeringOffset = centerForWidth / 2 - arrowWidth / 2
+
+  const alignProp = menuPosition.includes('right') ? 'right' : 'left'
+  const arrowDirection =
+    menuPosition === 'bottom-right' || menuPosition === 'bottom-left'
+      ? 'top'
+      : 'bottom'
+  const cssForPointingDirection =
+    arrowDirection === 'top'
+      ? {
+          borderBottomWidth: arrowHeight,
+          borderTopColor: 'transparent'
+        }
+      : {
+          borderTopWidth: arrowHeight,
+          borderBottomColor: 'transparent'
+        }
+
+  return (
+    <span
+      className='relative border-black border-l-transparent border-r-transparent'
+      style={{
+        // base styles
+        borderLeftWidth: arrowWidth / 2,
+        borderRightWidth: arrowWidth / 2,
+        ...cssForPointingDirection,
+        // keep the arrow centered on the dropdown button
+        [alignProp]: centeringOffset
+      }}
+    />
+  )
+}

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -1,0 +1,257 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Dropdown > Should be rendering bottom-left 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <button
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="m-0 p-0 align-top rounded text-center font-bold focus:outline-none text-primary hover:opacity-80"
+    >
+      open dropdown
+      <svg
+        class="inline-block ml-1 -mt-0.5"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"
+        />
+      </svg>
+    </button>
+    <div
+      class="absolute z-30 top-full mt-[5px] left-0"
+    >
+      <div
+        class="flex flex-col items-start"
+      >
+        <span
+          class="relative border-black border-l-transparent border-r-transparent"
+          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: 10px;"
+        />
+        <div
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+        >
+          <div />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown > Should be rendering top-left 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <button
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="m-0 p-0 align-top rounded text-center font-bold focus:outline-none text-primary hover:opacity-80"
+    >
+      open dropdown
+      <svg
+        class="inline-block ml-1 -mt-0.5"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"
+        />
+      </svg>
+    </button>
+    <div
+      class="absolute z-30 bottom-full mb-[5px] left-0"
+    >
+      <div
+        class="flex flex-col-reverse items-start"
+      >
+        <span
+          class="relative border-black border-l-transparent border-r-transparent"
+          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: 10px;"
+        />
+        <div
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+        >
+          <div />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown > Should be rendering top-right 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <button
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="m-0 p-0 align-top rounded text-center font-bold focus:outline-none text-primary hover:opacity-80"
+    >
+      open dropdown
+      <svg
+        class="inline-block ml-1 -mt-0.5"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"
+        />
+      </svg>
+    </button>
+    <div
+      class="absolute z-30 bottom-full mb-[5px] right-0"
+    >
+      <div
+        class="flex flex-col-reverse items-end"
+      >
+        <span
+          class="relative border-black border-l-transparent border-r-transparent"
+          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: 10px;"
+        />
+        <div
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+        >
+          <div />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Dropdown > Should be rendering with default bottom-right position 1`] = `
+<div>
+  <div
+    class="relative"
+  >
+    <button
+      aria-expanded="true"
+      aria-haspopup="true"
+      class="m-0 p-0 align-top rounded text-center font-bold focus:outline-none text-primary hover:opacity-80"
+    >
+      open dropdown
+      <svg
+        class="inline-block ml-1 -mt-0.5"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M216.49,104.49l-80,80a12,12,0,0,1-17,0l-80-80a12,12,0,0,1,17-17L128,159l71.51-71.52a12,12,0,0,1,17,17Z"
+        />
+      </svg>
+    </button>
+    <div
+      class="absolute z-30 top-full mt-[5px] right-0"
+    >
+      <div
+        class="flex flex-col items-end"
+      >
+        <span
+          class="relative border-black border-l-transparent border-r-transparent"
+          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: 10px;"
+        />
+        <div
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+        >
+          <button
+            aria-label="Payments"
+            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold cursor-pointer flex items-center hover:bg-primary focus:bg-primary focus:!outline-none"
+          >
+            <div
+              class="mr-2"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 256 256"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M224,44H32A20,20,0,0,0,12,64V192a20,20,0,0,0,20,20H224a20,20,0,0,0,20-20V64A20,20,0,0,0,224,44Zm-4,24V88H36V68ZM36,188V112H220v76Zm172-24a12,12,0,0,1-12,12H164a12,12,0,0,1,0-24h32A12,12,0,0,1,208,164Zm-68,0a12,12,0,0,1-12,12H116a12,12,0,0,1,0-24h12A12,12,0,0,1,140,164Z"
+                />
+              </svg>
+            </div>
+            <span
+              class="text-ellipsis overflow-hidden whitespace-nowrap"
+              title="Payments"
+            >
+              Payments
+            </span>
+          </button>
+          <button
+            aria-label="Items"
+            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold cursor-pointer flex items-center hover:bg-primary focus:bg-primary focus:!outline-none"
+          >
+            <div
+              class="mr-2"
+            >
+              <div
+                class="w-[14px]"
+              />
+            </div>
+            <span
+              class="text-ellipsis overflow-hidden whitespace-nowrap"
+              title="Items"
+            >
+              Items
+            </span>
+          </button>
+          <div
+            class="h-px my-1"
+          >
+            <hr
+              class="border-gray-600"
+            />
+          </div>
+          <button
+            aria-label="Delete"
+            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold cursor-pointer flex items-center hover:bg-primary focus:bg-primary focus:!outline-none"
+          >
+            <div
+              class="mr-2"
+            >
+              <svg
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 256 256"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M168.49,104.49,145,128l23.52,23.51a12,12,0,0,1-17,17L128,145l-23.51,23.52a12,12,0,0,1-17-17L111,128,87.51,104.49a12,12,0,0,1,17-17L128,111l23.51-23.52a12,12,0,0,1,17,17ZM236,128A108,108,0,1,1,128,20,108.12,108.12,0,0,1,236,128Zm-24,0a84,84,0,1,0-84,84A84.09,84.09,0,0,0,212,128Z"
+                />
+              </svg>
+            </div>
+            <span
+              class="text-ellipsis overflow-hidden whitespace-nowrap"
+              title="Delete"
+            >
+              Delete
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -32,7 +32,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
       >
         <span
           class="relative border-black border-l-transparent border-r-transparent"
-          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: 10px;"
+          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: -6px;"
         />
         <div
           class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
@@ -77,7 +77,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
       >
         <span
           class="relative border-black border-l-transparent border-r-transparent"
-          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: 10px;"
+          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: -6px;"
         />
         <div
           class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
@@ -122,7 +122,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
       >
         <span
           class="relative border-black border-l-transparent border-r-transparent"
-          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: 10px;"
+          style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: -6px;"
         />
         <div
           class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
@@ -167,7 +167,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
       >
         <span
           class="relative border-black border-l-transparent border-r-transparent"
-          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: 10px;"
+          style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: -6px;"
         />
         <div
           class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { Spacer } from '#ui/atoms/Spacer'
 import {
@@ -175,8 +176,34 @@ WithinASection.parameters = {
   layout: 'padded'
 }
 
+/**
+ * Arrow will try to center itself to the parent element when is smaller than 50px.
+ **/
+export const AutoCenterArrow: StoryFn = (args) => {
+  return (
+    <div>
+      <div className='flex gap-8'>
+        <div>
+          <Dropdown
+            dropdownLabel={<Icon name='arrowCircleDown' size={30} />}
+            dropdownItems={Default.args?.dropdownItems}
+            menuPosition='bottom-left'
+          />
+        </div>
+        <div>
+          <Dropdown
+            dropdownLabel={<Icon name='arrowCircleDown' size={48} />}
+            dropdownItems={Default.args?.dropdownItems}
+            menuPosition='bottom-right'
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
 /** Dropdown can also be used with different opening positions */
-export const Positioning: StoryFn<typeof Dropdown> = (args) => {
+export const Positioning: StoryFn = (args) => {
   const items = Default.args?.dropdownItems
   return (
     <div>

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -174,3 +174,45 @@ WithinASection.args = DropdownLabelAsString.args
 WithinASection.parameters = {
   layout: 'padded'
 }
+
+/** Dropdown can also be used with different opening positions */
+export const Positioning: StoryFn<typeof Dropdown> = (args) => {
+  const items = Default.args?.dropdownItems
+  return (
+    <div>
+      <div className='flex flex-wrap gap-8 justify-around'>
+        <Dropdown
+          dropdownLabel={<div>top-left</div>}
+          dropdownItems={items}
+          menuPosition='top-left'
+        />
+        <Dropdown
+          dropdownLabel={<div>top-right</div>}
+          dropdownItems={items}
+          menuPosition='top-right'
+        />
+        <Dropdown
+          dropdownLabel={<div>bottom-left</div>}
+          dropdownItems={items}
+          menuPosition='bottom-left'
+        />
+        <Dropdown
+          dropdownLabel={<div>bottom-right</div>}
+          dropdownItems={items}
+          menuPosition='bottom-right'
+        />
+      </div>
+    </div>
+  )
+}
+Positioning.decorators = [
+  (Story) => (
+    <div
+      style={{
+        paddingTop: '120px'
+      }}
+    >
+      <Story />
+    </div>
+  )
+]


### PR DESCRIPTION
## What I did

`Dropdown` can now be opened in different positions (relative to the trigger button):
- top-left
- top-right
- bottom-right
- bottom-left

Plus, the dropdown arrow is now automatically centered on the base of a maximum 50px button.
This means that if the trigger button is smaller than 50px the arrow will be centered, otherwise will be aligned to the menu position

https://deploy-preview-464--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#positioning
 
<img width="268" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/27761a34-81cd-4a1f-b228-7f8853fc48a4">

<img width="523" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/7ebfbe27-25ef-4da7-bbec-109abcdd4c0a">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
