### PR TITLE
Set default white background on `Card`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Card.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.tsx
@@ -46,7 +46,7 @@ export const Card = withSkeletonTemplate<CardProps>(
           'border border-solid rounded-md',
           {
             'overflow-hidden': overflow === 'hidden',
-            'border-gray-200': backgroundColor == null,
+            'border-gray-200 bg-white': backgroundColor == null,
             'bg-gray-50 border-gray-50': backgroundColor === 'light',
             'p-1': gap === '1',
             'p-4': gap === '4',

--- a/packages/docs/src/stories/hooks/useOverlay.stories.tsx
+++ b/packages/docs/src/stories/hooks/useOverlay.stories.tsx
@@ -1,5 +1,6 @@
 import { useOverlay } from '#hooks/useOverlay'
 import { Button } from '#ui/atoms/Button'
+import { Card } from '#ui/atoms/Card'
 import {
   Description,
   Primary,
@@ -178,14 +179,24 @@ export const OverlayWithBackgroundVariant: StoryFn = () => {
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
           fringilla, leo vel blandit consequat, arcu tellus tristique ipsum, vel
           accumsan risus urna in ante. Morbi iaculis elit mattis dolor laoreet
-          rhoncus. Aliquam interdum vel dui nec dapibus. Praesent id justo
-          ultricies quam finibus sollicitudin eu nec magna. Pellentesque
-          habitant morbi tristique senectus et netus et malesuada fames ac
-          turpis egestas. Nunc eget luctus nisi. Orci varius natoque penatibus
-          et magnis dis parturient montes, nascetur ridiculus mus. Nam malesuada
-          lacus eget aliquam tempor. Fusce sit amet lorem bibendum, congue dui
-          at, porttitor tellus. Ut venenatis enim ut sapien fringilla, sit amet
-          consequat lectus commodo.
+          rhoncus. Aliquam interdum vel dui nec dapibus.
+        </p>
+        <br />
+        <Card overflow='visible'>
+          Praesent id justo ultricies quam finibus sollicitudin eu nec magna.
+          Pellentesque habitant morbi tristique senectus et netus et malesuada
+          fames ac turpis egestas. Nunc eget luctus nisi. Orci varius natoque
+          penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nam
+          malesuada lacus eget aliquam tempor. Fusce sit amet lorem bibendum,
+          congue dui at, porttitor tellus. Ut venenatis enim ut sapien
+          fringilla, sit amet consequat lectus commodo.
+        </Card>
+        <br />
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+          fringilla, leo vel blandit consequat, arcu tellus tristique ipsum, vel
+          accumsan risus urna in ante. Morbi iaculis elit mattis dolor laoreet
+          rhoncus. Aliquam interdum vel dui nec dapibus.
         </p>
       </Overlay>
     </div>


### PR DESCRIPTION
## What I did

Now that we can have a gray background on the page, the `Card` needs to have a white contrast background as default, instead of transparent.

<img width="697" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/a388fd0b-af07-49a0-aff8-8d7e886799d1">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
