### PR TITLE
Add new icons

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/Icon.tsx
@@ -1,12 +1,21 @@
-import { type IconProps as PhosphorIconProps } from '@phosphor-icons/react'
-import { useMemo } from 'react'
+import { useMemo, type ComponentPropsWithRef } from 'react'
 import { iconMapping } from './icons'
 
-export interface IconProps extends PhosphorIconProps {
+type IconWeight = 'regular' | 'bold'
+
+export interface IconProps extends ComponentPropsWithRef<'svg'> {
   /**
    * Name of the icon to display
    */
   name: keyof typeof iconMapping
+  /**
+   * Size in CSS units or a number of pixels.
+   */
+  size?: string | number
+  /**
+   * Weight of the icon
+   */
+  weight?: IconWeight
 }
 
 /** `app-elements` provides a subset of [Phosphor Icons](https://phosphoricons.com/) out-of-the-box. */

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -1,8 +1,9 @@
 import * as phosphor from '@phosphor-icons/react'
 
 export const iconMapping = {
-  arrowBendDownRight: phosphor.ArrowBendDownRight,
   apps: phosphor.SquaresFour,
+  appWindow: phosphor.AppWindow,
+  arrowBendDownRight: phosphor.ArrowBendDownRight,
   arrowCircleDown: phosphor.ArrowCircleDown,
   arrowClockwise: phosphor.ArrowClockwise,
   arrowDown: phosphor.ArrowDown,
@@ -23,6 +24,7 @@ export const iconMapping = {
   flag: phosphor.Flag,
   funnel: phosphor.FunnelSimple,
   github: phosphor.GithubLogo,
+  globe: phosphor.GlobeSimple,
   google: phosphor.GoogleLogo,
   home: phosphor.HouseSimple,
   hourglass: phosphor.Hourglass,
@@ -32,9 +34,10 @@ export const iconMapping = {
   minusCircle: phosphor.MinusCircle,
   package: phosphor.Package,
   pencilSimple: phosphor.PencilSimple,
-  printer: phosphor.Printer,
   plus: phosphor.Plus,
+  printer: phosphor.Printer,
   pulse: phosphor.Pulse,
+  puzzle: phosphor.PuzzlePiece,
   resources: phosphor.Stack,
   settings: phosphor.GearFine,
   shoppingBag: phosphor.ShoppingBag,


### PR DESCRIPTION
## What I did

I've added new icons: 
- appWindow
- globe
- puzzle

and replace Icon props from phosphor with a custom subset.
In this way, the consumer app does not need to include phosphor package just to use proper typings


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
