### PR TITLE
Replace `onGoBack` with `navigationButton` in PageHeading

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.test.tsx
@@ -47,14 +47,15 @@ describe('PageHeading', () => {
     ).toBeInTheDocument()
   })
 
-  test('Should also have a button when onGoBack is set', () => {
+  test('Should also have a button when navigationButton is set', () => {
     const foo: string[] = []
     const { element } = setup({
       id: 'heading',
       title: 'My Page Heading',
       description: 'Lorem ipsum...',
-      onGoBack: () => {
-        foo.push('bar')
+      navigationButton: {
+        label: 'Go back',
+        onClick: () => foo.push('bar')
       }
     })
     expect(element.querySelector('button')).toBeVisible()

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -1,7 +1,8 @@
-import { ArrowLeft } from '@phosphor-icons/react'
 import cn from 'classnames'
 import { type ReactNode } from 'react'
 import { Badge, type BadgeProps } from './Badge'
+import { Icon } from './Icon'
+import { Text } from './Text'
 
 export interface PageHeadingProps {
   /**
@@ -12,11 +13,6 @@ export interface PageHeadingProps {
    * A short text that helps to describe the page
    */
   description?: ReactNode
-  /**
-   * Optional callback that will be called when "go back" button is pressed
-   * If missing, the "go back" button will not be shown
-   */
-  onGoBack?: () => void
   /**
    * If `true` removes element vertical paddings
    */
@@ -30,6 +26,20 @@ export interface PageHeadingProps {
    */
   badgeVariant?: BadgeProps['variant']
   /**
+   * When set, it will render a navigation (eg: go back) button on the left side of the first row
+   */
+  navigationButton?: {
+    /* Button label */
+    label: string
+    /* Button callback */
+    onClick: () => void
+    /**
+     * Button icon
+     * @default arrowLeft
+     */
+    icon?: 'x' | 'arrowLeft'
+  }
+  /**
    * When set, it will render a button on the right side of the first row
    */
   actionButton?: React.ReactNode
@@ -38,7 +48,7 @@ export interface PageHeadingProps {
 function PageHeading({
   gap = 'both',
   badgeLabel,
-  onGoBack,
+  navigationButton,
   title,
   description,
   badgeVariant = 'warning-solid',
@@ -57,11 +67,18 @@ function PageHeading({
       ])}
       {...rest}
     >
-      {(onGoBack != null || actionButton != null) && (
+      {(navigationButton != null || actionButton != null) && (
         <div className={cn('mb-4 flex items-center justify-between')}>
-          {onGoBack != null ? (
-            <button type='button' onClick={onGoBack}>
-              <ArrowLeft className='text-2.5xl' />
+          {navigationButton != null ? (
+            <button
+              type='button'
+              className='flex items-center gap-1'
+              onClick={() => {
+                navigationButton.onClick()
+              }}
+            >
+              <Icon name={navigationButton.icon ?? 'arrowLeft'} size={24} />{' '}
+              <Text weight='semibold'>{navigationButton.label}</Text>
             </button>
           ) : null}
           {actionButton != null ? <div>{actionButton}</div> : null}

--- a/packages/app-elements/src/ui/composite/PageError.tsx
+++ b/packages/app-elements/src/ui/composite/PageError.tsx
@@ -1,17 +1,14 @@
 import { Container } from '#ui/atoms/Container'
 import { EmptyState } from '#ui/atoms/EmptyState'
-import { PageHeading } from '#ui/atoms/PageHeading'
+import { PageHeading, type PageHeadingProps } from '#ui/atoms/PageHeading'
 
-export interface PageErrorProps {
+export interface PageErrorProps
+  extends Pick<PageHeadingProps, 'navigationButton'> {
   /**
    * Main page title wrapped in a h1 element
    */
   pageTitle?: string
-  /**
-   * Optional callback that will be called when "go back" button is pressed
-   * If missing, the "go back" button will not be shown
-   */
-  onGoBack?: () => void
+
   /**
    * The name of the error to be show above the detailed message text.
    * Example: 'Not Found'
@@ -30,7 +27,7 @@ export interface PageErrorProps {
 
 export function PageError({
   pageTitle = 'Commerce Layer',
-  onGoBack,
+  navigationButton,
   errorName,
   errorDescription,
   actionButton,
@@ -38,7 +35,7 @@ export function PageError({
 }: PageErrorProps): JSX.Element {
   return (
     <Container {...rest}>
-      <PageHeading title={pageTitle} onGoBack={onGoBack} />
+      <PageHeading title={pageTitle} navigationButton={navigationButton} />
       <EmptyState
         title={errorName}
         description={errorDescription}

--- a/packages/app-elements/src/ui/composite/PageLayout.tsx
+++ b/packages/app-elements/src/ui/composite/PageLayout.tsx
@@ -6,7 +6,7 @@ import { type ReactNode } from 'react'
 export interface PageLayoutProps
   extends Pick<
       PageHeadingProps,
-      'title' | 'description' | 'onGoBack' | 'actionButton' | 'gap'
+      'title' | 'description' | 'navigationButton' | 'actionButton' | 'gap'
     >,
     Pick<ContainerProps, 'minHeight'> {
   /**
@@ -22,7 +22,7 @@ export interface PageLayoutProps
 export function PageLayout({
   title,
   description,
-  onGoBack,
+  navigationButton,
   children,
   actionButton,
   mode,
@@ -35,7 +35,7 @@ export function PageLayout({
       <PageHeading
         title={title}
         description={description}
-        onGoBack={onGoBack}
+        navigationButton={navigationButton}
         actionButton={actionButton}
         badgeLabel={mode === 'test' ? 'TEST DATA' : undefined}
         badgeVariant={mode === 'test' ? 'warning-solid' : undefined}

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -137,8 +137,11 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
             <PageLayout
               title='Edit address'
               minHeight={false}
-              onGoBack={() => {
-                close()
+              navigationButton={{
+                label: 'Back',
+                onClick: () => {
+                  close()
+                }
               }}
             >
               <ResourceAddressForm

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -110,8 +110,11 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
               title={overlay.title}
               description={overlay.description}
               minHeight={false}
-              onGoBack={() => {
-                close()
+              navigationButton={{
+                label: 'Back',
+                onClick: () => {
+                  close()
+                }
               }}
             >
               <ResourceMetadataForm

--- a/packages/app-elements/src/ui/resources/ResourceOrderSummary/AddCouponOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderSummary/AddCouponOverlay.tsx
@@ -86,8 +86,11 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
     >
       <PageLayout
         title='Add coupon'
-        onGoBack={() => {
-          close()
+        navigationButton={{
+          label: 'Back',
+          onClick: () => {
+            close()
+          }
         }}
       >
         <Spacer bottom='8'>

--- a/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderSummary/AdjustTotalOverlay.tsx
@@ -104,8 +104,11 @@ const Form: React.FC<Props> = ({ order, onChange, close }) => {
     >
       <PageLayout
         title='Adjust total'
-        onGoBack={() => {
-          close()
+        navigationButton={{
+          label: 'Back',
+          onClick: () => {
+            close()
+          }
         }}
       >
         <Spacer bottom='8'>

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -281,8 +281,11 @@ const useTrackingDetails = (parcel: ParcelResource, rate?: Rate) => {
         <Overlay>
           <PageLayout
             title={`Tracking #${parcel.tracking_number}`}
-            onGoBack={() => {
-              close()
+            navigationButton={{
+              label: 'Back',
+              onClick: () => {
+                close()
+              }
             }}
           >
             <TrackingDetails parcel={parcel} rate={rate} />

--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -192,8 +192,11 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
             title={overlay.title}
             description={overlay.description}
             minHeight={false}
-            onGoBack={() => {
-              close()
+            navigationButton={{
+              label: 'Back',
+              onClick: () => {
+                close()
+              }
             }}
             actionButton={
               overlay.showManageAction != null &&

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
@@ -99,11 +99,14 @@ export function FieldTimeRange({ item }: FieldTimeRangeProps): JSX.Element {
       >
         <PageLayout
           title='Custom Time Range'
-          onGoBack={() => {
-            setValue('timeFrom', null)
-            setValue('timeTo', null)
-            setValue('timePreset', null)
-            close()
+          navigationButton={{
+            label: 'Back',
+            onClick: () => {
+              setValue('timeFrom', null)
+              setValue('timeTo', null)
+              setValue('timePreset', null)
+              close()
+            }
           }}
         >
           <Spacer bottom='14'>

--- a/packages/docs/src/stories/atoms/PageHeading.stories.tsx
+++ b/packages/docs/src/stories/atoms/PageHeading.stories.tsx
@@ -21,12 +21,28 @@ Default.args = {
   description: 'Lorem ipsum dolor sit'
 }
 
-export const WithGoBack = Template.bind({})
-WithGoBack.args = {
+export const WithNavGoBack = Template.bind({})
+WithNavGoBack.args = {
+  title: 'Order details',
+  description: 'Lorem ipsum dolor sit',
+  navigationButton: {
+    label: 'All orders',
+    onClick: () => {
+      historyGoBack()
+    }
+  }
+}
+
+export const WithNavClose = Template.bind({})
+WithNavClose.args = {
   title: 'SKUs',
   description: 'Lorem ipsum dolor sit',
-  onGoBack: () => {
-    historyGoBack()
+  navigationButton: {
+    label: 'Close',
+    onClick: () => {
+      historyGoBack()
+    },
+    icon: 'x'
   }
 }
 
@@ -34,8 +50,11 @@ export const WithBadge = Template.bind({})
 WithBadge.args = {
   title: 'SKUs',
   badgeLabel: 'TEST DATA',
-  onGoBack: () => {
-    historyGoBack()
+  navigationButton: {
+    label: 'Back',
+    onClick: () => {
+      historyGoBack()
+    }
   }
 }
 

--- a/packages/docs/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/docs/src/stories/composite/PageLayout.stories.tsx
@@ -20,7 +20,10 @@ export const Default = Template.bind({})
 Default.args = {
   title: 'Resources',
   description: 'View all resources',
-  onGoBack: () => undefined,
+  navigationButton: {
+    label: 'Back to dashboard',
+    onClick: () => undefined
+  },
   mode: 'test'
 }
 
@@ -28,7 +31,11 @@ export const WithActionButton = Template.bind({})
 WithActionButton.args = {
   title: 'Resources',
   description: 'View all resources',
-  onGoBack: () => undefined,
+  navigationButton: {
+    label: 'Close',
+    onClick: () => undefined,
+    icon: 'x'
+  },
   mode: 'live',
   actionButton: <Button variant='link'>Add new</Button>
 }

--- a/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
+++ b/packages/docs/src/stories/examples/FiltersCheckboxes.stories.tsx
@@ -53,7 +53,13 @@ const Template: StoryFn<typeof InputCheckbox> = (args) => {
   const [selectedIds, setSelectedId] = useState<string[]>([])
 
   return (
-    <PageLayout title='Filters' onGoBack={() => {}}>
+    <PageLayout
+      title='Filters'
+      navigationButton={{
+        label: 'Back',
+        onClick: () => {}
+      }}
+    >
       <Spacer bottom='4'>
         <Text variant='info' weight='medium'>
           Markets{' '}

--- a/packages/docs/src/stories/examples/ListImports.stories.tsx
+++ b/packages/docs/src/stories/examples/ListImports.stories.tsx
@@ -35,8 +35,9 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
     <PageLayout
       title='All imports'
       mode='test'
-      onGoBack={() => {
-        alert('onGoBack clicked')
+      navigationButton={{
+        label: 'Back to dashboard',
+        onClick: () => {}
       }}
     >
       <Spacer bottom='14'>

--- a/packages/docs/src/stories/examples/ListResources.stories.tsx
+++ b/packages/docs/src/stories/examples/ListResources.stories.tsx
@@ -28,8 +28,11 @@ export default setup
 const Template: StoryFn<typeof List> = (args) => (
   <PageLayout
     title='Resources'
-    onGoBack={() => {
-      alert('onGoBack clicked')
+    navigationButton={{
+      label: 'Back to dashboard',
+      onClick: () => {
+        alert('Back to dashboard')
+      }
     }}
   >
     <Spacer bottom='14'>

--- a/packages/docs/src/stories/examples/ListSkus.stories.tsx
+++ b/packages/docs/src/stories/examples/ListSkus.stories.tsx
@@ -28,8 +28,9 @@ export default setup
 const Template: StoryFn<typeof List> = (args) => (
   <PageLayout
     title='SKUs'
-    onGoBack={() => {
-      alert('onGoBack clicked')
+    navigationButton={{
+      label: 'Home',
+      onClick: () => {}
     }}
   >
     <Spacer bottom='14'>


### PR DESCRIPTION
## What I did

I've replaced `onGoBack` prop with `navigationButton` that requires the following:
```ts
navigationButton?: {
  /* Button label */
  label: string
  /* Button callback */
  onClick: () => void
  /**
   * Button icon
   * @default arrowLeft
   */
  icon?: 'x' | 'arrowLeft'
}
```

In this way we can implement better navigation by providing a label.

<img width="693" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/8c378d81-f7c7-490a-ab5c-885afa01a067">

Examples: 
[#1 ](https://deploy-preview-471--commercelayer-app-elements.netlify.app/?path=/docs/composite-pagelayout--docs)
[#2 ](https://deploy-preview-471--commercelayer-app-elements.netlify.app/?path=/docs/atoms-pageheading--docs#with-nav-go-back)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
