### PR TITLE
Update `InputReadonly` style

### DIFF
--- a/packages/app-elements/src/ui/forms/InputReadonly.tsx
+++ b/packages/app-elements/src/ui/forms/InputReadonly.tsx
@@ -1,4 +1,5 @@
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
+import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import {
   InputWrapper,
   type InputWrapperBaseProps
@@ -24,42 +25,46 @@ export interface InputReadonlyProps extends InputWrapperBaseProps {
   showCopyAction?: boolean
 }
 
-export function InputReadonly({
-  value,
-  wrapperClassName,
-  inputClassName,
-  showCopyAction = false,
-  label,
-  hint,
-  feedback,
-  ...rest
-}: InputReadonlyProps): JSX.Element {
-  return (
-    <InputWrapper
-      {...rest}
-      className={wrapperClassName}
-      feedback={feedback}
-      label={label}
-      hint={hint}
-    >
-      <div className='relative w-full select-none'>
-        <input
-          className={cn(
-            'block w-full bg-gray-50 px-4 h-10 text-teal font-bold border-none',
-            'rounded outline-0',
-            inputClassName
+export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
+  ({
+    value,
+    wrapperClassName,
+    inputClassName,
+    showCopyAction = false,
+    label,
+    hint,
+    feedback,
+    isLoading,
+    delayMs,
+    ...rest
+  }) => {
+    return (
+      <InputWrapper
+        {...rest}
+        className={wrapperClassName}
+        feedback={feedback}
+        label={label}
+        hint={hint}
+      >
+        <div className='relative w-full select-none group'>
+          <input
+            className={cn(
+              'block w-full bg-gray-50 px-4 h-[44px] text-teal text-sm font-mono font-medium marker:font-bold border-none',
+              'rounded outline-0 !ring-0 group-hover:bg-gray-100',
+              inputClassName
+            )}
+            value={isLoading === true ? '' : value}
+            readOnly
+          />
+          {showCopyAction && (
+            <div className='absolute top-[2px] bottom-[2px] right-4 group-hover:bg-gray-100 flex items-center opacity-0 group-hover:opacity-100'>
+              <CopyToClipboard value={value} showValue={false} />
+            </div>
           )}
-          value={value}
-          readOnly
-        />
-        {showCopyAction && (
-          <div className='absolute top-0 bottom-0 right-4 flex items-center'>
-            <CopyToClipboard value={value} showValue={false} />
-          </div>
-        )}
-      </div>
-    </InputWrapper>
-  )
-}
+        </div>
+      </InputWrapper>
+    )
+  }
+)
 
 InputReadonly.displayName = 'InputReadonly'

--- a/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
@@ -23,7 +23,7 @@ const Template: StoryFn<typeof InputReadonly> = (args) => {
 export const Default = Template.bind({})
 Default.args = {
   label: 'Secret',
-  value: 'asd6as78d6asds',
+  value: 'elyFpGvqXsOSsvEko6ues2Ua4No1_HxaKH_0rUaFuYiX9',
   showCopyAction: true
 }
 
@@ -42,4 +42,12 @@ WithError.args = {
     variant: 'danger',
     message: 'Do not share this secret with others'
   }
+}
+
+export const Loading = Template.bind({})
+Loading.args = {
+  label: 'Secret',
+  value: 'asd6as78d6asds',
+  isLoading: true,
+  hint: { text: 'Do not share this secret with others' }
 }


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've applied a new style for `<InputReadonly>` with new hover effect and support for SkeletonTemplate.

 
<img width="675" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/8f35a72c-71b4-4011-9179-8678ee5a6690">


## How to test

https://deploy-preview-473--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputreadonly--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
