### PR TITLE
Add `alignItems` prop in `<Grid>` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Grid.tsx
+++ b/packages/app-elements/src/ui/atoms/Grid.tsx
@@ -3,20 +3,35 @@ import React, { type ReactNode } from 'react'
 
 export interface GridProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'children'> {
+  /**
+   * Grid items
+   */
   children: ReactNode
+  /**
+   * Number of columns
+   */
   columns: '1' | '2'
+  /**
+   * Items alignment
+   * @default start
+   */
+  alignItems?: 'center' | 'start' | 'end'
 }
 
 function Grid({
   children,
   columns,
   className,
+  alignItems = 'start',
   ...rest
 }: GridProps): JSX.Element {
   return (
     <div
       className={cn('grid grid-cols-1 gap-4', className, {
-        'sm:grid-cols-2': columns === '2'
+        'sm:grid-cols-2': columns === '2',
+        'items-center': alignItems === 'center',
+        'items-start': alignItems === 'start',
+        'items-end': alignItems === 'end'
       })}
       {...rest}
     >


### PR DESCRIPTION
## What I did

Now it's possible to set items alignment in Grid component

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
