### PR TITLE
Hide `noOptionMessage` for `AsyncSelect` with empty search and empty `initialValues`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/AsyncComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/AsyncComponent.tsx
@@ -1,4 +1,5 @@
 import debounce from 'lodash/debounce'
+import isEmpty from 'lodash/isEmpty'
 import { useCallback, useEffect } from 'react'
 import { type GroupBase, type StylesConfig } from 'react-select'
 import AsyncSelect from 'react-select/async'
@@ -53,7 +54,12 @@ export const AsyncSelectComponent: React.FC<AsyncSelectComponentProps> = ({
       {...rest}
       defaultOptions={initialValues}
       onChange={onSelect}
-      noOptionsMessage={() => noOptionsMessage}
+      noOptionsMessage={({ inputValue }) =>
+        isEmpty(inputValue) &&
+        (initialValues === undefined || initialValues.length === 0)
+          ? null
+          : noOptionsMessage
+      }
       loadOptions={loadOptions}
       components={{
         ...components,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Modified `AsyncSelect` to hide `noOptionsMessage` if `initialValues` prop is set as an empty array `[]` and select `search` field is empty.

<img width="600" alt="Screenshot 2023-12-19 alle 14 18 45" src="https://github.com/commercelayer/app-elements/assets/105653649/4425f630-0f8a-4b44-b84b-15196b347a2b">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
