### PR TITLE
Add auto flow cols to grid component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Grid.tsx
+++ b/packages/app-elements/src/ui/atoms/Grid.tsx
@@ -10,7 +10,7 @@ export interface GridProps
   /**
    * Number of columns
    */
-  columns: '1' | '2'
+  columns?: '1' | '2' | 'auto'
   /**
    * Items alignment.
    * When not set all items will hame same height (items-stretch)
@@ -33,6 +33,7 @@ function Grid({
   return (
     <div
       className={cn('grid grid-cols-1 gap-4', className, {
+        'grid-flow-col': columns === 'auto',
         'sm:!grid-cols-2': columns === '2',
         'items-center': alignItems === 'center',
         'items-start': alignItems === 'start',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added a new `auto` option for `columns` prop of `Grid` component to enable auto flow of grid columns. When the `columns` prop is set to `auto` the TW classname `grid-flow-col` is added to the `Grid` main element.
This setup will behave in having the first column to fill all the available space and the other columns to shrink and adapt to their minimum outer size.

### With `columns` prop set to `2`

<img width="500" alt="Screenshot 2023-12-22 alle 12 24 45" src="https://github.com/commercelayer/app-elements/assets/105653649/49795eaa-b4c2-43c9-8f8f-7e40550fd759">

### With `columns` prop set to `auto`

<img width="500" alt="Screenshot 2023-12-22 alle 12 25 23" src="https://github.com/commercelayer/app-elements/assets/105653649/f8b4d7b4-7ae1-4948-8d7e-5e15df7bcb37">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
