### PR TITLE
Allow `DropdownItem` to be used as anchor

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.test.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render } from '@testing-library/react'
+import { DropdownItem } from './DropdownItem'
+
+describe('DropdownItem', () => {
+  const mockedOnClick = vi.fn()
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('Should render with width default options as button', () => {
+    const { getByText, container } = render(
+      <DropdownItem label='Edit item' onClick={mockedOnClick} />
+    )
+    const element = container.firstElementChild
+    assertToBeDefined(element)
+    expect(element.tagName).toBe('BUTTON')
+    expect(getByText('Edit item')).toBeVisible()
+    expect(mockedOnClick).toHaveBeenCalledTimes(0)
+  })
+
+  test('Should handle onClick event', () => {
+    const { getByText } = render(
+      <DropdownItem label='Edit item' onClick={mockedOnClick} />
+    )
+    expect(getByText('Edit item')).toBeVisible()
+    fireEvent.click(getByText('Edit item'))
+    expect(mockedOnClick).toHaveBeenCalledTimes(1)
+  })
+
+  test('Should be rendered as anchor when used with href', () => {
+    const { container, getByText } = render(
+      <DropdownItem
+        label='Visit documentation'
+        href='https://commercelayer.io/'
+        target='_blank'
+      />
+    )
+    const element = container.firstElementChild
+    assertToBeDefined(element)
+    expect(getByText('Visit documentation')).toBeVisible()
+    expect(element.tagName).toBe('A')
+    expect(element.getAttribute('href')).toBe('https://commercelayer.io/')
+    expect(element.getAttribute('target')).toBe('_blank')
+  })
+})

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -1,25 +1,54 @@
 import { Icon, type IconProps } from '#ui/atoms/Icon/Icon'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import { enforceAllowedTags } from '#utils/htmltags'
 import cn from 'classnames'
-import { type FC } from 'react'
+import { useMemo, type FC } from 'react'
 
-export interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
+export type DropdownItemProps = React.HTMLAttributes<HTMLElement> & {
   label: string
   icon?: IconProps['name'] | 'keep-space'
-}
+} & (
+    | {
+        /**
+         * render the component as anchor tag
+         */
+        href: string
+        target?: string
+      }
+    | {
+        href?: never
+      }
+  )
 
+/**
+ * Render a dropdown item to be used inside a `Dropdown` component.
+ * By default the component renders as a `button` tag, but you can provide an `href` prop to render it as an `a` tag.
+ * When no `href` or `onClick` is provided, the component still renders as `button` tag to prevent the dropdown to be closed when clicked.
+ */
 export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
-  ({ label, icon, isLoading, delayMs, className, ...rest }) => {
+  ({ label, icon, isLoading, delayMs, href, className, onClick, ...rest }) => {
+    const JsxTag = useMemo(
+      () =>
+        enforceAllowedTags({
+          tag: href != null ? 'a' : 'button',
+          allowedTags: ['a', 'button'],
+          defaultTag: 'button'
+        }),
+      [href, onClick]
+    )
+
     return (
-      <button
+      <JsxTag
         {...rest}
+        onClick={onClick}
+        href={href}
         className={cn(
-          'w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none',
+          'w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none',
           className,
           {
             'hover:bg-primary cursor-pointer focus:bg-primary':
-              rest.onClick != null,
-            'cursor-default': rest.onClick == null
+              onClick != null || href != null,
+            'cursor-default': onClick == null && href == null
           }
         )}
         aria-label={label}
@@ -40,7 +69,7 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
         >
           {label}
         </span>
-      </button>
+      </JsxTag>
     )
   }
 )

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
         >
           <button
             aria-label="Payments"
-            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
           >
             <div
               class="mr-2"
@@ -200,7 +200,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </button>
           <button
             aria-label="Items"
-            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
           >
             <div
               class="mr-2"
@@ -225,7 +225,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </div>
           <button
             aria-label="Delete"
-            class="w-full bg-black text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
           >
             <div
               class="mr-2"

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -134,6 +134,27 @@ ItemsWithSkeleton.args = {
   )
 }
 
+/** Dropdown items can be anchor or button on div depending on the existence of `href` or `onClick`  */
+export const ItemsDifferentTags = Template.bind({})
+ItemsDifferentTags.args = {
+  dropdownItems: (
+    <>
+      <DropdownItem
+        onClick={() => {
+          alert('clicked!')
+        }}
+        label='I am a button with onClick'
+      />
+      <DropdownItem label='I am a button without onClick' />
+      <DropdownItem
+        href='https://commercelayer.io/'
+        target='_blank'
+        label='I am a link'
+      />
+    </>
+  )
+}
+
 /**
  * Dropdown items can also have icons. When you need to list them
  * together with items without icons, you can pass `keep-space` so gap will be maintained.
@@ -170,7 +191,7 @@ WithDropdownSearch.args = {
         placeholder='Search...'
       />
       <DropdownDivider />
-      <DropdownItem onClick={() => {}} icon='check' label='Green' />
+      <DropdownItem icon='check' label='Green' />
       <DropdownItem onClick={() => {}} icon='keep-space' label='Red' />
       <DropdownItem onClick={() => {}} icon='keep-space' label='Yellow' />
       <DropdownItem onClick={() => {}} icon='keep-space' label='Black' />


### PR DESCRIPTION
## What I did

I've added an `href` prop to the dropdown item so it can be rendered also as `<a>` when provided.

<img width="716" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/392f47d4-b8ed-4bf9-8c96-f2b302864e94">


## How to test

https://deploy-preview-487--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#items-different-tags

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
