### PR TITLE
Add `unitsOfWeight` helper library

### DIFF
--- a/packages/app-elements/src/helpers/unitsOfWeight.test.ts
+++ b/packages/app-elements/src/helpers/unitsOfWeight.test.ts
@@ -1,0 +1,32 @@
+import { getUnitOfWeightName, getUnitsOfWeightForSelect } from './unitsOfWeight'
+
+describe('getUnitsOfWeightForSelect', () => {
+  test('Should return the array of units of weight suitable for a select', () => {
+    expect(getUnitsOfWeightForSelect()).toStrictEqual([
+      {
+        value: 'gr',
+        label: 'Grams'
+      },
+      {
+        value: 'lb',
+        label: 'Pounds'
+      },
+      {
+        value: 'oz',
+        label: 'Ounces'
+      }
+    ])
+  })
+})
+
+describe('getUnitOfWeightName', () => {
+  test('Should return `Grams`', () => {
+    expect(getUnitOfWeightName('gr')).toBe('Grams')
+  })
+  test('Should return `Pounds`', () => {
+    expect(getUnitOfWeightName('lb')).toBe('Pounds')
+  })
+  test('Should return `Ounces`', () => {
+    expect(getUnitOfWeightName('oz')).toBe('Ounces')
+  })
+})

--- a/packages/app-elements/src/helpers/unitsOfWeight.ts
+++ b/packages/app-elements/src/helpers/unitsOfWeight.ts
@@ -1,0 +1,27 @@
+const unitsOfWeight = ['gr', 'lb', 'oz'] as const
+
+const unitsOfWeightLabels = {
+  gr: 'Grams',
+  lb: 'Pounds',
+  oz: 'Ounces'
+} as const
+
+export type UnitOfWeight = (typeof unitsOfWeight)[number]
+
+interface UnitOfWeightForSelect {
+  label: (typeof unitsOfWeightLabels)[keyof typeof unitsOfWeightLabels]
+  value: UnitOfWeight
+}
+
+/**
+ * Get a units of weight list suitable for select options usage
+ * @returns an array of objects with `value` and `label` props
+ */
+export const getUnitsOfWeightForSelect = (): UnitOfWeightForSelect[] => {
+  return unitsOfWeight.map((unitOfWeight) => {
+    return {
+      value: unitOfWeight,
+      label: unitsOfWeightLabels[unitOfWeight]
+    }
+  })
+}

--- a/packages/app-elements/src/helpers/unitsOfWeight.ts
+++ b/packages/app-elements/src/helpers/unitsOfWeight.ts
@@ -1,15 +1,17 @@
 const unitsOfWeight = ['gr', 'lb', 'oz'] as const
 
-const unitsOfWeightLabels = {
+const unitsOfWeightNames = {
   gr: 'Grams',
   lb: 'Pounds',
   oz: 'Ounces'
 } as const
 
 export type UnitOfWeight = (typeof unitsOfWeight)[number]
+type UnitOfWeightLabel =
+  (typeof unitsOfWeightNames)[keyof typeof unitsOfWeightNames]
 
 interface UnitOfWeightForSelect {
-  label: (typeof unitsOfWeightLabels)[keyof typeof unitsOfWeightLabels]
+  label: UnitOfWeightLabel
   value: UnitOfWeight
 }
 
@@ -21,7 +23,13 @@ export const getUnitsOfWeightForSelect = (): UnitOfWeightForSelect[] => {
   return unitsOfWeight.map((unitOfWeight) => {
     return {
       value: unitOfWeight,
-      label: unitsOfWeightLabels[unitOfWeight]
+      label: unitsOfWeightNames[unitOfWeight]
     }
   })
+}
+
+export function getUnitOfWeightName(
+  unitOfWeight: UnitOfWeight
+): UnitOfWeightLabel {
+  return unitsOfWeightNames[unitOfWeight]
 }

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -25,6 +25,10 @@ export {
   type Rate,
   type TrackingDetail
 } from '#helpers/tracking'
+export {
+  getUnitsOfWeightForSelect,
+  type UnitOfWeight
+} from '#helpers/unitsOfWeight'
 // Hooks
 export { useClickAway } from '#hooks/useClickAway'
 export { useDelayShow } from '#hooks/useDelayShow'

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -26,6 +26,7 @@ export {
   type TrackingDetail
 } from '#helpers/tracking'
 export {
+  getUnitOfWeightName,
   getUnitsOfWeightForSelect,
   type UnitOfWeight
 } from '#helpers/unitsOfWeight'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `helper` library to introduce and describe units of weight that we share in our apps.
The library will add:
- a `UnitOfWeight` type that is a union of `'gr' | 'oz' | 'lb'`
- a `getUnitsOfWeightForSelect` method to have all units of weight listed as `value` / `label` objects suitable for `InputSelect` options usage
- a `getUnitOfWeightName` method to obtain the name of given unit of weight (eg. `getUnitOfWeightName('gr') = 'Grams'`)

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
