### PR TITLE
Add border variants to Alert

### DIFF
--- a/packages/app-elements/src/ui/atoms/Alert.tsx
+++ b/packages/app-elements/src/ui/atoms/Alert.tsx
@@ -1,4 +1,3 @@
-import { Card } from '#ui/atoms/Card'
 import {
   CheckCircle,
   Info,
@@ -21,21 +20,20 @@ export const Alert: React.FC<AlertProps> = ({ children, status }) => {
   const Icon = icons[status]
 
   return (
-    <Card
+    <div
       role='alert'
-      overflow='hidden'
-      className={classNames('border-0', {
-        'bg-orange-50 text-orange-700': status === 'warning',
-        'bg-red-50 text-red-700': status === 'error',
-        'bg-gray-50 text-gray-700': status === 'info',
-        'bg-green-50 text-green-700': status === 'success'
+      className={classNames('border p-6 rounded-md', {
+        'border-orange-200 bg-orange-50 text-orange-700': status === 'warning',
+        'border-red-200 bg-red-50 text-red-700': status === 'error',
+        'border-gray-200 bg-gray-50 text-gray-700': status === 'info',
+        'border-green-200 bg-green-50 text-green-700': status === 'success'
       })}
     >
       <div className='flex gap-3'>
         <Icon className='flex-shrink-0' focusable={false} size={24} />
         <div>{children}</div>
       </div>
-    </Card>
+    </div>
   )
 }
 


### PR DESCRIPTION
## What I did

Now `Alert` component has a border that matches the variant.
I've also removed the usage of the `Card` inside the `Alert` because it was clashing with css classes that have been recently added to the first one

<img width="580" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/73fb782e-e99c-4efc-affb-5e9103e59f24">


## How to test
https://deploy-preview-490--commercelayer-app-elements.netlify.app/?path=/docs/atoms-alert--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
