### PR TITLE
Allow to use multiple Stack

### DIFF
--- a/packages/app-elements/src/ui/atoms/Stack.tsx
+++ b/packages/app-elements/src/ui/atoms/Stack.tsx
@@ -14,11 +14,19 @@ function renderChild(child: ReactNode): JSX.Element {
 
 function Stack({ children, ...props }: StackProps): JSX.Element {
   return (
-    <div {...props} className='border-t border-b border-gray-100 py-6'>
-      <div className='flex'>
-        {Children.map(children, (child) => child != null && renderChild(child))}
+    <>
+      <div
+        {...props}
+        className='border-t border-b border-gray-100 py-6 [&:not(:first-child)]:mt-[-1px]' // make multiple stack possible even across different siblings
+      >
+        <div className='flex'>
+          {Children.map(
+            children,
+            (child) => child != null && renderChild(child)
+          )}
+        </div>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/packages/docs/src/stories/atoms/Stack.stories.tsx
+++ b/packages/docs/src/stories/atoms/Stack.stories.tsx
@@ -110,3 +110,29 @@ export const Addresses: StoryFn<typeof Stack> = (args) => (
   </Stack>
 )
 Addresses.args = {}
+
+/**
+ * By using multiple `Stack` components it's possible to make a grid. Border top won't be duplicated.
+ *
+ * However it's always suggested, but not required, to group them in a parent `div` since the `nth+1` sibling will have a negative `1px` margin-top.
+ */
+export const MultipleStacks: StoryFn<typeof Stack> = (args) => (
+  <>
+    <div>first sibling</div>
+    <Stack>
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+    </Stack>
+    <Stack>
+      <div>4</div>
+      <div>5</div>
+      <div>6</div>
+    </Stack>
+    <Stack>
+      <div>7</div>
+      <div>8</div>
+    </Stack>
+    <div>last sibling</div>
+  </>
+)


### PR DESCRIPTION
## What I did
To allow multiple Stack(s) to be used, I've added a negative margin of 1px when it is not the first sibling.

In this way when Stack is used as the only sibling (99% of cases, since it is always wrapped in a Spacer) this rule won't be triggered.
And, in case the Stack component is used at the same level of other div, it will just steal an imperceptible 1px on top of the previous element


## How to test

From this preview https://deploy-preview-494--commercelayer-app-elements.netlify.app/?path=/docs/atoms-stack--docs#multiple-stacks
try to inspect and remove `<div>first sibling<div>` to notice the difference

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
