### PR TITLE
Add gap `none` to Card

### DIFF
--- a/packages/app-elements/src/ui/atoms/Card.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.tsx
@@ -1,31 +1,41 @@
+import { removeUnwantedProps } from '#utils/htmltags'
 import cn from 'classnames'
 import { withSkeletonTemplate } from './SkeletonTemplate'
 
-export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
-  /**
-   * Possible values are:
-   * - `none`: 0rem, 0px
-   * - `"1"`: 0.25rem, 4px
-   * - `"4"`: 1rem, 16px
-   * - `"6"`: 1.5rem, 24px
-   *
-   * @default 6
-   */
-  gap?: 'none' | '1' | '4' | '6'
+export type CardProps = React.HTMLAttributes<HTMLDivElement> & {
   /**
    * Footer will render in a dedicated section below the main content.
    */
   footer?: React.ReactNode
   /**
-   * Set the overflow behavior. In most of the cases you might want to keep overflow visible,
-   * but when you have inner content with hover effects you might want to set overflow to hidden.
-   */
-  overflow: 'visible' | 'hidden'
-  /**
    * Set a gray background color
    */
   backgroundColor?: 'light'
-}
+} & (
+    | {
+        /**
+         * Possible values are:
+         * - `"1"`: 0.25rem, 4px
+         * - `"4"`: 1rem, 16px
+         * - `"6"`: 1.5rem, 24px
+         *
+         * @default 6
+         */
+        gap?: '1' | '4' | '6'
+        /**
+         * Set the overflow behavior. In most of the cases you might want to keep overflow visible,
+         * but when you have inner content with hover effects you might want to set overflow to hidden.
+         */
+        overflow: 'visible' | 'hidden'
+      }
+    | {
+        /**
+         * When card is rendered with no gap, overflow is always intended as hidden and cannot be controlled via props,
+         * otherwise inner content will overlap the rounded corners of the card.
+         */
+        gap: 'none'
+      }
+  )
 
 /** Card is a flexible component used to group and display content in a clear and concise format. */
 export const Card = withSkeletonTemplate<CardProps>(
@@ -37,9 +47,12 @@ export const Card = withSkeletonTemplate<CardProps>(
     delayMs,
     footer,
     backgroundColor,
-    overflow,
     ...rest
   }) => {
+    const overflow = 'overflow' in rest ? rest.overflow : 'hidden'
+    const divProps =
+      'overflow' in rest ? removeUnwantedProps(rest, ['overflow']) : rest
+
     return (
       <div
         className={cn([
@@ -54,7 +67,7 @@ export const Card = withSkeletonTemplate<CardProps>(
             'p-6': gap === '6'
           }
         ])}
-        {...rest}
+        {...divProps}
       >
         <div
           className={cn('rounded h-full', {

--- a/packages/app-elements/src/ui/atoms/Card.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.tsx
@@ -4,13 +4,14 @@ import { withSkeletonTemplate } from './SkeletonTemplate'
 export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Possible values are:
+   * - `none`: 0rem, 0px
    * - `"1"`: 0.25rem, 4px
    * - `"4"`: 1rem, 16px
    * - `"6"`: 1.5rem, 24px
    *
    * @default 6
    */
-  gap?: '1' | '4' | '6'
+  gap?: 'none' | '1' | '4' | '6'
   /**
    * Footer will render in a dedicated section below the main content.
    */
@@ -65,8 +66,10 @@ export const Card = withSkeletonTemplate<CardProps>(
         {footer != null && (
           <div
             className={cn([
-              'mt-8 py-4 border-t',
+              'py-4 border-t',
               {
+                '-mt-[1px]': gap === 'none',
+                'mt-8': gap !== 'none',
                 '-m-4 px-4': gap === '4',
                 '-m-6 px-6': gap === '6'
               }

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -79,7 +79,6 @@ export const FooterNoGap: StoryFn<typeof Card> = (args) => (
   </Card>
 )
 FooterNoGap.args = {
-  overflow: 'visible',
   gap: 'none',
   footer: (
     <div className='text-center'>

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -2,6 +2,7 @@ import { Button } from '#ui/atoms/Button'
 import { Card } from '#ui/atoms/Card'
 import { Spacer } from '#ui/atoms/Spacer'
 import { StatusIcon } from '#ui/atoms/StatusIcon'
+import { Table, Td, Th, Tr } from '#ui/atoms/Table'
 import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
 import { Input } from '#ui/forms/Input'
@@ -36,6 +37,50 @@ export const Footer: StoryFn<typeof Card> = (args) => (
 )
 Footer.args = {
   overflow: 'visible',
+  footer: (
+    <div className='text-center'>
+      <Button variant='link'>
+        <StatusIcon gap='small' className='text-2xl mr-1' name='cloudArrowUp' />{' '}
+        <Text size='small'>Download file</Text>
+      </Button>
+    </div>
+  )
+}
+
+/**
+ * The `footer` can also be set when card has gap set as `none`.
+ * Example: we want to show a table with a footer, insider a rounded card
+ */
+export const FooterNoGap: StoryFn<typeof Card> = (args) => (
+  <Card {...args}>
+    <Table
+      thead={
+        <Tr>
+          <Th>NAME</Th>
+          <Th>EMAIL</Th>
+          <Th>STATUS</Th>
+        </Tr>
+      }
+      tbody={
+        <>
+          <Tr>
+            <Td>M. Jordan</Td>
+            <Td>mjordan@email.com</Td>
+            <Td>active</Td>
+          </Tr>
+          <Tr>
+            <Td>B. Wayne</Td>
+            <Td>bwayne@email.com</Td>
+            <Td>active</Td>
+          </Tr>
+        </>
+      }
+    />
+  </Card>
+)
+FooterNoGap.args = {
+  overflow: 'visible',
+  gap: 'none',
   footer: (
     <div className='text-center'>
       <Button variant='link'>


### PR DESCRIPTION
## What I did

I've added a no-gap option (`gap: 'none'`) to the Card, making sure it can still accept a footer.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
