### PR TITLE
Promotion is disabled when `disable_at` is set

### DIFF
--- a/packages/app-elements/src/dictionaries/promotions.ts
+++ b/packages/app-elements/src/dictionaries/promotions.ts
@@ -9,7 +9,7 @@ interface PromotionDisplayStatus extends DisplayStatus {
 export function getPromotionDisplayStatus(
   promotion: Omit<Promotion, 'type'>
 ): PromotionDisplayStatus {
-  if (promotion.active !== true) {
+  if (promotion.disabled_at != null) {
     return {
       status: 'disabled',
       label: 'Disabled',

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -348,6 +348,7 @@ export const presetResourceListItem = {
     updated_at: '2023-06-10T06:38:44.964Z',
     starts_at: '2024-01-01T06:38:44.964Z',
     expires_at: '2033-01-01T06:38:44.964Z',
+    disabled_at: '2023-01-01T06:38:44.964Z',
     name: 'Jan 50% off',
     percentage: 50,
     total_usage_limit: 3,
@@ -360,9 +361,21 @@ export const presetResourceListItem = {
     updated_at: '2023-06-10T06:38:44.964Z',
     starts_at: '2033-01-01T06:38:44.964Z',
     expires_at: '2043-01-01T06:38:44.964Z',
-    name: 'Free shipping',
+    name: 'Jan free shipping',
     total_usage_limit: 3,
-    active: true
+    active: false
+  },
+  promotionDisabledAndUpcoming: {
+    type: 'free_shipping_promotions',
+    id: '',
+    created_at: '',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    starts_at: '2033-01-01T06:38:44.964Z',
+    expires_at: '2043-01-01T06:38:44.964Z',
+    disabled_at: '2023-01-01T06:38:44.964Z',
+    name: 'Jan free shipping (alternative test)',
+    total_usage_limit: 3,
+    active: false
   },
   promotionExpired: {
     type: 'free_gift_promotions',
@@ -373,7 +386,7 @@ export const presetResourceListItem = {
     expires_at: '2023-12-01T06:38:44.964Z',
     name: 'Free gift',
     total_usage_limit: 3,
-    active: true
+    active: false
   },
   promotionWithCoupons: {
     type: 'percentage_discount_promotions',


### PR DESCRIPTION
## What I did

Updated the `disabled` check. Promotions are disabled when `disable_at` attribute is set. Looking to `active` is wrong because `active` indicates if the promotion is active (enabled and not expired).

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
