### PR TITLE
Enforce `domain` when production URL is matched

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -1,4 +1,5 @@
 import { type TokenProviderTokenApplicationKind } from '#providers/TokenProvider'
+import { isProductionHostname } from '#providers/TokenProvider/url'
 import { PageError } from '#ui/composite/PageError'
 import { type Organization } from '@commercelayer/sdk'
 import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
@@ -125,6 +126,8 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
 }) => {
   const [_state, dispatch] = useReducer(reducer, initialTokenProviderState)
   const isSelfHosted = organizationSlug != null
+
+  domain = isProductionHostname() ? 'commercelayer.io' : domain
 
   const accessToken =
     accessTokenFromProp ??

--- a/packages/app-elements/src/providers/TokenProvider/url.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/url.test.ts
@@ -1,5 +1,6 @@
 import {
   getOrgSlugFromCurrentUrl,
+  isProductionHostname,
   makeDashboardUrl,
   makeReAuthenticationUrl
 } from './url'
@@ -83,5 +84,49 @@ describe('makeReAuthenticationUrl', () => {
     window.location.pathname = '/exports/new'
 
     expect(makeReAuthenticationUrl(dashboardUrl, '')).toBe(dashboardUrl)
+  })
+})
+
+describe('isProductionHostname', () => {
+  const { location } = window
+  beforeAll(function clearLocation() {
+    delete (window as any).location
+    ;(window as any).location = {
+      ...location,
+      hostname: ''
+    }
+  })
+  afterAll(function resetLocation() {
+    window.location = location
+  })
+
+  test('should return true for production hostnames', () => {
+    ;[
+      'org.commercelayer.app',
+      'org-123.commercelayer.app',
+      '123-456.commercelayer.app',
+      'dashboard.commercelayer.io',
+      '_org.commercelayer.app',
+      'org_.commercelayer.app',
+      'org-_.commercelayer.app',
+      'org_-.commercelayer.app',
+      '123.commercelayer.app',
+      'org123.commercelayer.app'
+    ].forEach((hostname) => {
+      window.location.hostname = hostname
+      expect(isProductionHostname()).toBe(true)
+    })
+  })
+
+  test('should return false for non-production hostnames', () => {
+    ;[
+      'demo-store.stg.commercelayer.app',
+      'demo-store.stg.commercelayer.app.test',
+      'org.dashboard.commercelayer.io',
+      'dashboard.commercelayer.io.test'
+    ].forEach((hostname) => {
+      window.location.hostname = hostname
+      expect(isProductionHostname()).toBe(false)
+    })
   })
 })

--- a/packages/app-elements/src/providers/TokenProvider/url.ts
+++ b/packages/app-elements/src/providers/TokenProvider/url.ts
@@ -40,3 +40,13 @@ export function makeReAuthenticationUrl(
     return dashboardUrl
   }
 }
+
+export function isProductionHostname(): boolean {
+  if (typeof window !== 'undefined') {
+    return /^[\w-]+\.commercelayer\.app$|^dashboard\.commercelayer\.io$/.test(
+      window.location.hostname
+    )
+  }
+
+  return false
+}


### PR DESCRIPTION
## What I did

To prevent the wrong configuration from being set, we now check if `window.location.hostname` matches one of the production subsets.
In that case `commercelayer.io` is used


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
