### PR TITLE
`distanceToNow` option on `formatDate` now consider also future dates

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -158,7 +158,7 @@ describe('formatDate', () => {
   test('Should return the distance to now', () => {
     expect(
       formatDate({
-        isoDate: '2023-12-25T14:30:00.000Z',
+        isoDate: '2023-12-25T14:29:40.000Z',
         timezone: 'Australia/Sydney',
         format: 'distanceToNow'
       })
@@ -166,11 +166,19 @@ describe('formatDate', () => {
 
     expect(
       formatDate({
-        isoDate: '2023-12-25T14:30:00.000Z',
+        isoDate: '2023-12-25T14:29:40.000Z',
         timezone: 'Europe/Rome',
         format: 'distanceToNow'
       })
     ).toBe('less than a minute ago')
+
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T14:30:10.000Z',
+        timezone: 'Europe/Rome',
+        format: 'distanceToNow'
+      })
+    ).toBe('in less than a minute')
 
     expect(
       formatDate({
@@ -182,10 +190,25 @@ describe('formatDate', () => {
 
     expect(
       formatDate({
+        isoDate: '2023-12-25T14:37:00.000Z',
+        timezone: 'Europe/Rome',
+        format: 'distanceToNow'
+      })
+    ).toBe('in 7 minutes')
+
+    expect(
+      formatDate({
         isoDate: '2023-02-27T16:00:00.000Z',
         format: 'distanceToNow'
       })
     ).toBe('10 months ago')
+
+    expect(
+      formatDate({
+        isoDate: '2024-10-27T16:00:00.000Z',
+        format: 'distanceToNow'
+      })
+    ).toBe('in 10 months')
   })
 })
 
@@ -261,11 +284,20 @@ describe('formatDateWithPredicate', () => {
     expect(
       formatDateWithPredicate({
         predicate: 'Updated',
-        isoDate: '2023-12-25T14:30:00.000Z',
+        isoDate: '2023-12-25T14:29:50.000Z',
         timezone: 'Australia/Sydney',
         format: 'distanceToNow'
       })
     ).toBe('Updated less than a minute ago')
+
+    expect(
+      formatDateWithPredicate({
+        predicate: 'Expires',
+        isoDate: '2023-12-25T14:30:10.000Z',
+        timezone: 'Australia/Sydney',
+        format: 'distanceToNow'
+      })
+    ).toBe('Expires in less than a minute')
   })
 })
 

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -3,7 +3,7 @@ import zonedTimeToUtc from 'date-fns-tz/zonedTimeToUtc'
 import endOfDay from 'date-fns/endOfDay'
 import format from 'date-fns/format'
 import formatDistance from 'date-fns/formatDistance'
-import isAfter from 'date-fns/isAfter'
+import isBefore from 'date-fns/isBefore'
 import isFuture from 'date-fns/isFuture'
 import isPast from 'date-fns/isPast'
 import isSameMonth from 'date-fns/isSameMonth'
@@ -163,8 +163,9 @@ function getPresetFormatTemplate(
     case 'distanceToNow':
       return `'${formatDistance(
         zonedDate,
-        utcToZonedTime(new Date(), timezone)
-      )} ago'`
+        utcToZonedTime(new Date(), timezone),
+        { addSuffix: true }
+      )}'`
   }
 }
 
@@ -267,7 +268,7 @@ export function getEventDateInfo({
   const zonedStartsAt = utcToZonedTime(new Date(startsAt), timezone)
   const zonedExpiresAt = utcToZonedTime(new Date(expiresAt), timezone)
 
-  if (isAfter(zonedStartsAt, zonedExpiresAt)) {
+  if (isBefore(zonedExpiresAt, zonedStartsAt)) {
     throw new Error(
       'The expiration date/time of the event must be after the activation (startsAt).'
     )

--- a/packages/docs/src/stories/utility/Date.stories.tsx
+++ b/packages/docs/src/stories/utility/Date.stories.tsx
@@ -117,6 +117,15 @@ export const FormatDate: StoryFn = () => {
           })
         }}
       />
+      <CodeSample
+        fn={() => {
+          return formatDate({
+            isoDate: '2033-12-25T14:30:00.000Z',
+            timezone: 'Europe/Rome',
+            format: 'distanceToNow'
+          })
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION

## What I did

`distanceToNow` option on `formatDate` now consider also future dates.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
