### PR TITLE
Add `ButtonImageSelect` component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -66,6 +66,10 @@ export { Badge, type BadgeProps } from '#ui/atoms/Badge'
 export { Button, type ButtonProps } from '#ui/atoms/Button'
 export { ButtonCard, type ButtonCardProps } from '#ui/atoms/ButtonCard'
 export { ButtonFilter, type ButtonFilterProps } from '#ui/atoms/ButtonFilter'
+export {
+  ButtonImageSelect,
+  type ButtonImageSelectProps
+} from '#ui/atoms/ButtonImageSelect'
 export { Card, type CardProps } from '#ui/atoms/Card'
 export { Container, type ContainerProps } from '#ui/atoms/Container'
 export {

--- a/packages/app-elements/src/ui/atoms/ButtonImageSelect.test.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonImageSelect.test.tsx
@@ -1,0 +1,31 @@
+import { render } from '@testing-library/react'
+import { ButtonImageSelect } from './ButtonImageSelect'
+
+describe('ButtonImageSelect', () => {
+  const mockedConsoleLog = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('Should be rendered', () => {
+    const { container } = render(<ButtonImageSelect />)
+    expect(container).toBeVisible()
+  })
+
+  test('Should render with image', () => {
+    const { getByTestId } = render(
+      <ButtonImageSelect
+        src='https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'
+        onClick={() => {
+          console.log('main-button-clicked')
+        }}
+      />
+    )
+    expect(getByTestId('ButtonImageSelect-main')).toContainElement(
+      getByTestId('ButtonImageSelect-image')
+    )
+    getByTestId('ButtonImageSelect-main').click()
+    expect(mockedConsoleLog).toHaveBeenCalledWith('main-button-clicked')
+  })
+})

--- a/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
@@ -1,0 +1,41 @@
+import cn from 'classnames'
+import { type AvatarProps } from './Avatar'
+import { Icon } from './Icon'
+
+export interface ButtonImageSelectProps
+  extends React.HTMLAttributes<HTMLButtonElement> {
+  /**
+   * Image URL
+   */
+  src?: AvatarProps['src']
+}
+
+/**
+ * This component renders as `<button>` showing an `Avatar` image, if given, or a camera icon to choose one.
+ */
+export function ButtonImageSelect({
+  src,
+  ...rest
+}: ButtonImageSelectProps): JSX.Element {
+  return (
+    <button
+      type='button'
+      data-testid='ButtonImageSelect-main'
+      className={cn(
+        'flex items-center justify-center rounded p-[2px] text-primary',
+        'min-w-[96px] min-h-[96px] w-[96px] h-[96px]',
+        'border border-gray-300 hover:border-primary hover:border-solid hover:ring-inset hover:ring-1 hover:ring-primary',
+        src != null ? 'border-solid' : 'border-dashed'
+      )}
+      {...rest}
+    >
+      {src != null ? (
+        <img src={src} data-testid='ButtonImageSelect-image' />
+      ) : (
+        <Icon name='camera' size={32} />
+      )}
+    </button>
+  )
+}
+
+ButtonImageSelect.displayName = 'ButtonImageSelect'

--- a/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
@@ -1,5 +1,4 @@
 import cn from 'classnames'
-import { type AvatarProps } from './Avatar'
 import { Icon } from './Icon'
 
 export interface ButtonImageSelectProps
@@ -7,7 +6,7 @@ export interface ButtonImageSelectProps
   /**
    * Image URL
    */
-  src?: AvatarProps['src']
+  src?: HTMLImageElement['src']
 }
 
 /**

--- a/packages/docs/src/stories/atoms/ButtonImageSelect.stories.tsx
+++ b/packages/docs/src/stories/atoms/ButtonImageSelect.stories.tsx
@@ -1,0 +1,26 @@
+import { ButtonImageSelect } from '#ui/atoms/ButtonImageSelect'
+import type { Meta, StoryFn } from '@storybook/react'
+
+const setup: Meta<typeof ButtonImageSelect> = {
+  title: 'Atoms/ButtonImageSelect',
+  parameters: {
+    layout: 'padded'
+  },
+  component: ButtonImageSelect
+}
+
+export default setup
+
+const Template: StoryFn<typeof ButtonImageSelect> = (args) => (
+  <div>
+    <ButtonImageSelect {...args} />
+  </div>
+)
+
+export const Primary = Template.bind({})
+Primary.args = {}
+
+export const WithImage = Template.bind({})
+WithImage.args = {
+  src: 'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'
+}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `ButtonImageSelect` component provide an image select `button` that is showing an image preview if a valid `src` prop is given. Otherwise the component shows a `camera` TW icon to invite a new image selection.

<img width="837" alt="Screenshot 2024-01-15 alle 23 38 14" src="https://github.com/commercelayer/app-elements/assets/105653649/6a410ba4-2134-4c02-8e0e-92132138388e">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
