### PR TITLE
Reorganize props of `ButtonImageSelect` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/ButtonImageSelect.test.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonImageSelect.test.tsx
@@ -16,8 +16,10 @@ describe('ButtonImageSelect', () => {
   test('Should render with image', () => {
     const { getByTestId } = render(
       <ButtonImageSelect
-        src='https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'
-        alt=''
+        img={{
+          src: 'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png',
+          alt: ''
+        }}
         onClick={() => {
           console.log('main-button-clicked')
         }}

--- a/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
+++ b/packages/app-elements/src/ui/atoms/ButtonImageSelect.tsx
@@ -1,27 +1,21 @@
 import cn from 'classnames'
 import { Icon } from './Icon'
 
-interface WithImg {
+interface ButtonImage {
   src: string
   alt: string
 }
 
-interface WithoutImg {
-  src?: undefined
-  alt?: undefined
+export interface ButtonImageSelectProps
+  extends React.HTMLAttributes<HTMLButtonElement> {
+  img?: ButtonImage
 }
-
-type ImageProps = WithImg | WithoutImg
-
-export type ButtonImageSelectProps = React.HTMLAttributes<HTMLButtonElement> &
-  ImageProps
 
 /**
  * This component renders as `<button>` showing an `Avatar` image, if given, or a camera icon to choose one.
  */
 export function ButtonImageSelect({
-  src,
-  alt,
+  img,
   ...rest
 }: ButtonImageSelectProps): JSX.Element {
   return (
@@ -32,12 +26,17 @@ export function ButtonImageSelect({
         'flex items-center justify-center rounded p-[2px] text-primary',
         'min-w-[96px] min-h-[96px] w-[96px] h-[96px]',
         'border border-gray-200 hover:border-primary hover:border-solid hover:ring-inset hover:ring-1 hover:ring-primary',
-        src != null ? 'border-solid' : 'border-dashed'
+        img != null ? 'border-solid' : 'border-dashed'
       )}
       {...rest}
     >
-      {src != null ? (
-        <img src={src} alt={alt} data-testid='ButtonImageSelect-image' />
+      {img != null ? (
+        <img
+          src={img.src}
+          alt={img.alt}
+          data-testid='ButtonImageSelect-image'
+          className='max-w-full max-h-full'
+        />
       ) : (
         <Icon name='camera' size={32} />
       )}

--- a/packages/docs/src/stories/atoms/ButtonImageSelect.stories.tsx
+++ b/packages/docs/src/stories/atoms/ButtonImageSelect.stories.tsx
@@ -22,6 +22,8 @@ Primary.args = {}
 
 export const WithImage = Template.bind({})
 WithImage.args = {
-  src: 'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png',
-  alt: ''
+  img: {
+    src: 'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png',
+    alt: ''
+  }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Moved spare `src` and `alt` props of `ButtonImageSelect` to be grouped inside option `img` object prop to simplify the conditional logic of component's prop.
- Added some TW classnames constraints to the preview img of the component.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
