### PR TITLE
Enforce `TokenProvider` allowed apps

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -1,12 +1,29 @@
 import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
 
+export type TokenProviderAllowedApp =
+  | 'bundles'
+  | 'customers'
+  | 'exports'
+  | 'gift_cards'
+  | 'imports'
+  | 'inventory'
+  | 'orders'
+  | 'price_lists'
+  | 'promotions'
+  | 'returns'
+  | 'shipments'
+  | 'skus'
+  | 'stock_transfers'
+  | 'subscriptions'
+  | 'tags'
+  | 'webhooks'
+
 export type TokenProviderTokenApplicationKind =
   | 'integration'
   | 'sales_channel'
   | 'webapp'
-  | ListableResourceType
-
-export type TokenProviderAllowedApp = ListableResourceType | 'resources'
+  | 'resources'
+  | TokenProviderAllowedApp
 
 export type TokenProviderRoleActions = 'create' | 'destroy' | 'read' | 'update'
 
@@ -47,7 +64,7 @@ export interface TokenProviderTokenInfo {
     /**
      * Token application kind.
      */
-    kind: 'integration' | 'sales_channel' | 'webapp' | ListableResourceType
+    kind: TokenProviderTokenApplicationKind
     /**
      * The name of the application.
      * When token is generated from the dashboard hub it could be 'Imports', 'Orders', etc...
@@ -80,7 +97,7 @@ export interface TokenProviderTokenInfo {
    */
   accessible_apps?: Array<{
     name: string
-    kind: ListableResourceType
+    kind: TokenProviderAllowedApp
     core: boolean
   }>
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

We enforced the list of allowed apps in `TokenProvider` by defining a custom union type containing all of our active apps.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
