### PR TITLE
Add `createRoute` and `createTypedRoute` helpers

### DIFF
--- a/packages/app-elements/src/helpers/route.test.ts
+++ b/packages/app-elements/src/helpers/route.test.ts
@@ -1,0 +1,59 @@
+import { createRoute, createTypedRoute } from './route'
+
+describe('createRoute', () => {
+  it('`makePath` should be without variables when `path` does not have variables', () => {
+    const home = createRoute('/')
+    expect(home.path).toEqual('/')
+    expect(home.makePath({})).toEqual('/')
+    expect(
+      home.makePath({ promotionId: '1234' }, 'firstname=John&lastname=Doe')
+    ).toEqual('/?firstname=John&lastname=Doe')
+
+    const list = createRoute('/orders/')
+    expect(list.path).toEqual('/orders')
+    expect(list.makePath({})).toEqual('/orders')
+    expect(
+      list.makePath({ promotionId: '1234' }, 'firstname=John&lastname=Doe')
+    ).toEqual('/orders?firstname=John&lastname=Doe')
+  })
+
+  it('`makePath` should accepts a list of variables based on the provided `path`', () => {
+    const route = createRoute('/list/:promotionId/edit/:name?/')
+    expect(route.path).toEqual('/list/:promotionId/edit/:name?')
+    expect(route.makePath({ promotionId: '1234', name: 'John' })).toEqual(
+      '/list/1234/edit/John'
+    )
+    expect(
+      route.makePath({ promotionId: '1234' }, 'firstname=John&lastname=Doe')
+    ).toEqual('/list/1234/edit?firstname=John&lastname=Doe')
+
+    const ordersRoute = createRoute('/orders/:orderId?/')
+    expect(ordersRoute.makePath({})).toEqual('/orders')
+    expect(ordersRoute.makePath({ orderId: '1234' })).toEqual('/orders/1234')
+  })
+})
+
+describe('createTypedRoute', () => {
+  it('`makePath` should accepts a list of variables with the defined types', () => {
+    const route = createTypedRoute<{
+      orderNumber: number
+      shipmentCode?: 'IT' | 'US'
+    }>()('/orders/:orderNumber/:shipmentCode?/')
+    expect(route.path).toEqual('/orders/:orderNumber/:shipmentCode?')
+    expect(
+      route.makePath({ orderNumber: 1234 }, 'firstname=John&lastname=Doe')
+    ).toEqual('/orders/1234?firstname=John&lastname=Doe')
+    expect(route.makePath({ orderNumber: 1234, shipmentCode: 'IT' })).toEqual(
+      '/orders/1234/IT'
+    )
+    expect(
+      route.makePath({ orderNumber: 1234 }, 'firstname=John&lastname=Doe')
+    ).toEqual('/orders/1234?firstname=John&lastname=Doe')
+    expect(
+      route.makePath(
+        { orderNumber: 1234, shipmentCode: 'US' },
+        'firstname=John&lastname=Doe'
+      )
+    ).toEqual('/orders/1234/US?firstname=John&lastname=Doe')
+  })
+})

--- a/packages/app-elements/src/helpers/route.ts
+++ b/packages/app-elements/src/helpers/route.ts
@@ -1,0 +1,144 @@
+import type { Simplify } from 'type-fest'
+
+/**
+ * Create a `Route` given a path. Route has the provided `path` and a `makePath` method that helps making a path.
+ * @param path it can be a simple string (e.g. `/` or `/home/`) or a more complex with variables (e.g. `/users/:name/` or `/orders/:id?/`)
+ * @returns
+ */
+export function createRoute<
+  Path extends `/${string}/` | `/`,
+  Parameters extends Record<string, unknown> = ExtractParameters<Path>
+>(path: ValidPath<Parameters, Path>): Route<Path, Parameters> {
+  return {
+    path: ('/' +
+      path
+        .replace(/\/+$/g, '')
+        .replace(/^\/+/g, '')) as Path extends `/${infer P}/` ? `/${P}` : '/',
+    makePath: (
+      parameters: Parameters,
+      searchParams?: string | URLSearchParams
+    ) => {
+      const placeholderRegex = /:(\w+)[?]?/g
+
+      const newPath =
+        '/' +
+        path
+          .replace(placeholderRegex, (match, placeholder) => {
+            const value =
+              placeholder in parameters
+                ? (parameters[placeholder as keyof typeof parameters] as string)
+                : null
+            return value ?? match
+          })
+          .replace(placeholderRegex, '')
+          .replace(/\/+$/g, '')
+          .replace(/^\/+/g, '')
+
+      return `${newPath}${
+        hasSearchParameters(searchParams) ? `?${searchParams.toString()}` : ''
+      }`
+    }
+  }
+}
+
+/**
+ * Create a typed `Route` given a path. Route has the provided `path` and a `makePath` method that helps making a path.
+ * @param path it can be a simple string (e.g. `/` or `/home/`) or a more complex with variables (e.g. `/users/:name/` or `/orders/:id?/`)
+ * @example
+ * ```ts
+ * const route = createTypedRoute<{
+ *   orderNumber: number
+ *   shipmentCode?: 'IT' | 'US'
+ * }>()('/orders/:orderNumber/:shipmentCode?/')
+ * ```
+ */
+export const createTypedRoute =
+  <Parameters extends Record<string, any>>() =>
+  <Path extends `/${string}/` | `/`>(path: ValidPath<Parameters, Path>) => {
+    return createRoute<Path, Parameters>(path)
+  }
+
+/**
+ * Get params from a `Route`.
+ *
+ * @example
+ * ```ts
+ * const route = createRoute('/orders/:id/:name?/')
+ *
+ * type Params = GetParams<typeof route>
+ *
+ * // equivalent to
+ *
+ * type Params = {
+ *   id: string;
+ *   name?: string | undefined;
+ * }
+ * ```
+ */
+export type GetParams<R extends { makePath: (...arg: any[]) => string }> = {
+  [K in keyof Parameters<R['makePath']>[0]]: string
+}
+
+interface Route<
+  Path extends `/${string}/` | `/`,
+  Parameters extends Record<string, unknown> = ExtractParameters<Path>
+> {
+  path: Path extends `/${infer P}/` ? `/${P}` : '/'
+  makePath: (
+    parameters: Parameters,
+    searchParams?: string | URLSearchParams
+  ) => string
+}
+
+function hasSearchParameters(
+  searchParams?: string | URLSearchParams
+): searchParams is string {
+  return Array.from(new URLSearchParams(searchParams)).length > 0
+}
+
+type ExtractParameters<Path extends string> =
+  Path extends `${string}:${infer Var}/${infer Rest}`
+    ? Simplify<
+        FixOptional<{ [key in Var]: string | number | boolean }> &
+          ExtractParameters<Rest>
+      >
+    : // eslint-disable-next-line @typescript-eslint/ban-types
+      {}
+
+type FixOptional<T extends Record<string, any>> = Omit<T, `${string}?`> & {
+  [K in keyof T as K extends `${infer VariableName}?`
+    ? VariableName
+    : never]?: T[K]
+}
+
+type ErrorParameters<
+  Parameters extends Record<string, any>,
+  Path extends string
+> = keyof ({
+  [key in keyof ExtractParameters<Path> as key extends keyof Parameters
+    ? never
+    : undefined extends ExtractParameters<Path>[key]
+      ? key extends string
+        ? `${key}?`
+        : key
+      : key]-?: 'Is not properly set.'
+} & {
+  [key in keyof Parameters as key extends string
+    ? Path extends `${string}/:${key}${undefined extends Parameters[key]
+        ? '?'
+        : ''}/${string}`
+      ? never
+      : undefined extends Parameters[key]
+        ? `${key}?`
+        : key
+    : never]-?: 'Is not properly set.'
+})
+
+type ValidPath<
+  Parameters extends Record<string, any>,
+  Path extends string
+> = ErrorParameters<Parameters, Path> extends never
+  ? Path
+  : `Missing variable '${ErrorParameters<Parameters, Path> extends string
+      ? ErrorParameters<Parameters, Path>
+      : 'unknown'}'`

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -17,6 +17,7 @@ export {
 export { downloadJsonAsFile } from '#helpers/downloadJsonAsFile'
 export { computeFullname, formatDisplayName } from '#helpers/name'
 export { formatResourceName, type TriggerAttribute } from '#helpers/resources'
+export { createRoute, createTypedRoute, type GetParams } from '#helpers/route'
 export {
   getAvatarSrcFromRate,
   getParcelTrackingDetail,

--- a/packages/docs/src/components/CodeSample.tsx
+++ b/packages/docs/src/components/CodeSample.tsx
@@ -1,18 +1,20 @@
 import { Source } from '@storybook/addon-docs'
-import * as prettierBabel from 'prettier/plugins/babel'
 import * as prettierEstree from 'prettier/plugins/estree'
+import * as prettierTypescript from 'prettier/plugins/typescript'
 import * as prettier from 'prettier/standalone'
 import { useEffect, useState } from 'react'
 
 export function CodeSample({
   fn,
+  code,
   description
 }: {
   fn: () => any
+  code?: string
   description?: string
 }): JSX.Element {
   const [sanitizedCode, setSanitizedCode] = useState<string>()
-  const code = fn.toString()
+  const [rawCode, setRawCode] = useState<string | undefined>(code)
 
   const result = fn()
 
@@ -20,32 +22,43 @@ export function CodeSample({
   // eslint-disable-next-line no-eval
   eval('')
 
+  useEffect(
+    function UpdateRawCode() {
+      if (rawCode === undefined) {
+        setRawCode(fn.toString())
+      }
+    },
+    [rawCode]
+  )
+
   useEffect(() => {
     void (async () => {
-      let tmpSanitizedCode = code
-        .replaceAll('\n', '')
-        .replace(/^\(\) => {(.*)}/, '$1')
-        .replace(/^\(\)=>{(.*)}$/, '$1')
-        .replaceAll('() =>', '')
-        .replaceAll('()=>', '')
-        .replaceAll('return ', '')
-        .replaceAll("eval('')", '')
-        .replaceAll('eval("")', '')
-        .replaceAll('/* @__PURE__ */ ', '')
+      if (rawCode !== undefined) {
+        let tmpSanitizedCode = rawCode
+          .replaceAll('\n', '')
+          .replace(/^\(\) => {(.*)}/, '$1')
+          .replace(/^\(\)=>{(.*)}$/, '$1')
+          .replaceAll('() =>', '')
+          .replaceAll('()=>', '')
+          .replaceAll('return ', '')
+          .replaceAll("eval('')", '')
+          .replaceAll('eval("")', '')
+          .replaceAll('/* @__PURE__ */ ', '')
 
-      tmpSanitizedCode = await prettier.format(tmpSanitizedCode, {
-        singleQuote: true,
-        trailingComma: 'none',
-        parser: 'babel',
-        printWidth: 60,
-        plugins: [prettierBabel, prettierEstree]
-      })
+        tmpSanitizedCode = await prettier.format(tmpSanitizedCode, {
+          singleQuote: true,
+          trailingComma: 'none',
+          parser: 'typescript',
+          printWidth: 60,
+          plugins: [prettierTypescript, prettierEstree]
+        })
 
-      tmpSanitizedCode = tmpSanitizedCode.replaceAll(';', ';\n')
+        tmpSanitizedCode = tmpSanitizedCode.replaceAll(';', ';\n')
 
-      setSanitizedCode(tmpSanitizedCode)
+        setSanitizedCode(tmpSanitizedCode)
+      }
     })()
-  }, [code])
+  }, [rawCode])
 
   return (
     <>

--- a/packages/docs/src/stories/utility/Route.stories.tsx
+++ b/packages/docs/src/stories/utility/Route.stories.tsx
@@ -1,0 +1,121 @@
+import { createRoute, createTypedRoute } from '#helpers/route'
+import { Description, Stories, Subtitle, Title } from '@storybook/addon-docs'
+import { type Meta, type StoryFn } from '@storybook/react'
+import { CodeSample } from 'src/components/CodeSample'
+
+/** This list of `route` utilities help to work with routes. */
+const setup: Meta = {
+  title: 'Utility/Route',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      source: {
+        code: null
+      },
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Stories />
+        </>
+      )
+    }
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true
+      }
+    }
+  }
+}
+export default setup
+
+/**
+ * Create a `Route` given a path. Route has the provided `path` and a `makePath` method that helps making a path.
+ */
+export const CreateRoute: StoryFn = () => {
+  return (
+    <>
+      <CodeSample
+        fn={() => {
+          // eslint-disable-next-line no-eval
+          eval('')
+
+          const route = createRoute('/orders/:id/:opt?/')
+
+          return route.path
+        }}
+      />
+      <CodeSample
+        fn={() => {
+          // eslint-disable-next-line no-eval
+          eval('')
+
+          const route = createRoute('/orders/:id/:opt?/')
+
+          return route.makePath({
+            id: 'ABC123'
+          })
+        }}
+      />
+      <CodeSample
+        fn={() => {
+          // eslint-disable-next-line no-eval
+          eval('')
+
+          const route = createRoute('/orders/:id/:opt?/')
+
+          return route.makePath({
+            id: 'ABC123',
+            opt: 'yes'
+          })
+        }}
+      />
+    </>
+  )
+}
+
+export const CreateTypedRoute: StoryFn = () => {
+  return (
+    <>
+      <CodeSample
+        code={`
+          const route = createTypedRoute<{ status: 'open' | 'close' }>()(
+            '/statues/:status/'
+          );
+
+          return route.path
+        `}
+        fn={() => {
+          const route = createTypedRoute<{ status: 'open' | 'close' }>()(
+            '/statues/:status/'
+          )
+
+          return route.path
+        }}
+      />
+      <CodeSample
+        code={`
+          const route = createTypedRoute<{ status: 'open' | 'close' }>()(
+            '/statues/:status/'
+          );
+
+          return route.makePath({
+            status: 'close'
+          })
+        `}
+        fn={() => {
+          const route = createTypedRoute<{ status: 'open' | 'close' }>()(
+            '/statues/:status/'
+          )
+
+          return route.makePath({
+            status: 'close'
+          })
+        }}
+      />
+    </>
+  )
+}


### PR DESCRIPTION
## What I did

I added a new `createRoute` and `createTypedRoute` helpers. Creating routes is now fully type-safe.

### Usage

```ts
const orderDetailsRoute = createRoute('/orders/:id/')

orderDetailsRoute.path //= '/orders/:id'

orderDetailsRoute.makePath({ id: 'abc' }) //= '/orders/abc'
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
