### PR TITLE
Add dashboard allowed app in token provider

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -38,7 +38,7 @@ export interface TokenProviderValue {
     action: TokenProviderRoleActions,
     resource: ListableResourceType
   ) => boolean
-  canAccess: (appSlug: TokenProviderAllowedApp) => boolean
+  canAccess: (appSlug: Exclude<TokenProviderAllowedApp, 'dashboard'>) => boolean
   emitInvalidAuth: (reason: string) => void
 }
 
@@ -207,9 +207,10 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
           return
         }
 
-        // fetching organization details if user has read permission
+        // fetching organization details if user has read permission and app is not dashboard
         const organization =
-          tokenInfo.permissions?.organizations?.read === true
+          tokenInfo.permissions?.organizations?.read === true &&
+          appSlug !== 'dashboard'
             ? await getOrganization({
                 accessToken,
                 domain,

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -17,6 +17,7 @@ export type TokenProviderAllowedApp =
   | 'subscriptions'
   | 'tags'
   | 'webhooks'
+  | 'dashboard'
 
 export type TokenProviderTokenApplicationKind =
   | 'integration'


### PR DESCRIPTION
## What I did

I've added `dashboard` to the allowed token provider apps.
When it is used, organization data won't be fetched.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
