### PR TITLE
Prevent failed transaction to be displayed as a success message

### DIFF
--- a/packages/app-elements/src/dictionaries/orders.ts
+++ b/packages/app-elements/src/dictionaries/orders.ts
@@ -178,17 +178,26 @@ export function getOrderDisplayStatus(order: Order): OrderDisplayStatus {
   }
 }
 
-export function getOrderTransactionPastTense(
+export function getOrderTransactionName(
   type: NonNullable<Order['transactions']>[number]['type']
-): string {
-  const dictionary: Record<typeof type, string> = {
+): { pastTense: string; singular: string } {
+  const pastTenseDictionary: Record<typeof type, string> = {
     authorizations: 'authorized',
     captures: 'captured',
     refunds: 'refunded',
     voids: 'voided'
   }
+  const singularDictionary: Record<typeof type, string> = {
+    authorizations: 'Payment authorization',
+    captures: 'Payment capture',
+    refunds: 'Refund',
+    voids: 'Void'
+  }
 
-  return dictionary[type]
+  return {
+    pastTense: pastTenseDictionary[type],
+    singular: singularDictionary[type]
+  }
 }
 
 export function getOrderStatusName(status: Order['status']): string {

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -318,7 +318,7 @@ export {
   getOrderFulfillmentStatusName,
   getOrderPaymentStatusName,
   getOrderStatusName,
-  getOrderTransactionPastTense,
+  getOrderTransactionName,
   getOrderTriggerAttributeName
 } from '#dictionaries/orders'
 export { getPromotionDisplayStatus } from '#dictionaries/promotions'


### PR DESCRIPTION
## What I did

In case a transaction fails, we now show the event in the timeline with the same message as it was succeded.
Example:  Payment of xxx was authorized, where `authorized` is the past tense of the transaction `type`.

In this PR I've added a check on the `succeeded` attribute to solve this issue.

Result:
<img width="638" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/334e7f1d-91c0-4402-8ac2-8f00a6b63223">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
