### PR TITLE
Improve props definition of table related components

### DIFF
--- a/packages/app-elements/src/ui/atoms/Table/Td.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Td.tsx
@@ -1,8 +1,7 @@
 import { isJsonPrimitive } from '#utils/text'
 import cn from 'classnames'
 
-export interface TdProps {
-  className?: string
+export interface TdProps extends React.TdHTMLAttributes<HTMLElement> {
   children?: React.ReactNode
   textEllipsis?: number
 }
@@ -10,10 +9,14 @@ export interface TdProps {
 export const Td: React.FC<TdProps> = ({
   children,
   className,
-  textEllipsis
+  textEllipsis,
+  ...rest
 }) => {
   return (
-    <td className={cn('p-4 text-sm border-b border-gray-100', className)}>
+    <td
+      className={cn('p-4 text-sm border-b border-gray-100', className)}
+      {...rest}
+    >
       {textEllipsis !== undefined ? (
         <div
           title={

--- a/packages/app-elements/src/ui/atoms/Table/Th.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Th.tsx
@@ -1,11 +1,16 @@
+import cn from 'classnames'
+
 export interface ThProps extends React.ThHTMLAttributes<HTMLElement> {
   children?: React.ReactNode
 }
 
-function Th({ children, ...rest }: ThProps): JSX.Element {
+function Th({ children, className, ...rest }: ThProps): JSX.Element {
   return (
     <th
-      className='p-4 text-xs uppercase bg-gray-50 text-gray-400 text-left'
+      className={cn(
+        className,
+        'p-4 text-xs uppercase bg-gray-50 text-gray-400 text-left'
+      )}
       {...rest}
     >
       {children}


### PR DESCRIPTION
## What I did

- `<Td>` component now can accept other related `td` props such as `colSpan`
- `<Th>` now also accepts classname

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
