### PR TITLE
Make `useOverlay` reactive on `queryParam` changes

### DIFF
--- a/packages/app-elements/src/hooks/useOverlay.tsx
+++ b/packages/app-elements/src/hooks/useOverlay.tsx
@@ -131,7 +131,7 @@ export function useOverlay(options?: OverlayOptions): OverlayHook {
     } else {
       setShow(true)
     }
-  }, [isInQueryParamMode])
+  }, [isInQueryParamMode, options?.queryParam])
 
   // when component is mounted and `queryParam` exists in current url, overlay will automatically opened
   useEffect(


### PR DESCRIPTION
## What I did

I've fixed a behavior where `useOverlay` was not reacting to option changes.

Example:
```ts
// `isFoo` changes dinamically during data fetchiing
const { open } = useOverlay({ queryParam:  isFoo ? 'foo' : 'bar'   })
```

when `isFoo` changes now the `open` method appends the right query param to the URL.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
