### PR TITLE
Few improvements for the `InputSelect` component

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.test.tsx
@@ -46,8 +46,12 @@ describe('InputSelect', () => {
         onSelect={mockedOnSelect}
         initialValues={[
           {
-            value: 'ABC123',
-            label: 'Cap with Black Logo'
+            value: 'paris',
+            label: 'Paris'
+          },
+          {
+            value: 'london',
+            label: 'London'
           }
         ]}
         placeholder='Please select an option'
@@ -55,17 +59,58 @@ describe('InputSelect', () => {
     )
     expect(container).toBeVisible()
     expect(queryByText('Please select an option')).toBeVisible()
-    expect(queryByText('Cap with Black Logo')).toBeNull()
+    expect(queryByText('London')).toBeNull()
 
     // open select dropdown
     fireEvent.keyDown(getByText('Please select an option'), {
       key: 'ArrowDown'
     })
-    await waitFor(() => queryByText('Cap with Black Logo'))
-    fireEvent.click(getByText('Cap with Black Logo'))
+    await waitFor(() => queryByText('London'))
+    expect(queryByText('Paris')).toBeVisible()
+    expect(queryByText('London')).toBeVisible()
+    fireEvent.click(getByText('London'))
     expect(mockedOnSelect).toHaveBeenCalledTimes(1)
 
     expect(queryByText('Please select an option')).toBeNull()
-    expect(queryByText('Cap with Black Logo')).toBeVisible()
+    expect(queryByText('Paris')).toBeNull()
+    expect(queryByText('London')).toBeVisible()
+  })
+
+  test('should not select the value when the option is disabled', async () => {
+    const mockedOnSelect = vi.fn()
+    const { container, queryByText, getByText } = render(
+      <InputSelect
+        onSelect={mockedOnSelect}
+        initialValues={[
+          {
+            value: 'paris',
+            label: 'Paris'
+          },
+          {
+            value: 'london',
+            label: 'London',
+            isDisabled: true
+          }
+        ]}
+        placeholder='Please select an option'
+      />
+    )
+    expect(container).toBeVisible()
+    expect(queryByText('Please select an option')).toBeVisible()
+    expect(queryByText('London')).toBeNull()
+
+    // open select dropdown
+    fireEvent.keyDown(getByText('Please select an option'), {
+      key: 'ArrowDown'
+    })
+    await waitFor(() => queryByText('London'))
+    expect(queryByText('Paris')).toBeVisible()
+    expect(queryByText('London')).toBeVisible()
+    fireEvent.click(getByText('London'))
+    expect(mockedOnSelect).not.toHaveBeenCalledTimes(1)
+
+    expect(queryByText('Please select an option')).toBeVisible()
+    expect(queryByText('Paris')).toBeVisible()
+    expect(queryByText('London')).toBeVisible()
   })
 })

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -40,6 +40,10 @@ export interface InputSelectProps extends InputWrapperBaseProps {
    */
   defaultValue?: InputSelectValue | InputSelectValue[]
   /**
+   * Selected value or values, in case of `isMulti`
+   */
+  value?: InputSelectValue | InputSelectValue[]
+  /**
    * Placeholder text to display when no value is selected
    */
   placeholder?: string
@@ -134,6 +138,7 @@ export const InputSelect = forwardRef<
       menuIsOpen,
       initialValues,
       defaultValue,
+      value,
       isClearable,
       isLoading,
       loadingText = 'Loading...',
@@ -168,6 +173,7 @@ export const InputSelect = forwardRef<
             menuIsOpen={menuIsOpen}
             initialValues={initialValues}
             defaultValue={defaultValue}
+            value={value}
             isClearable={isClearable}
             placeholder={isLoading === true ? loadingText : placeholder}
             isDisabled={isLoading === true || isDisabled === true}
@@ -187,6 +193,7 @@ export const InputSelect = forwardRef<
             menuIsOpen={menuIsOpen}
             initialValues={initialValues}
             defaultValue={defaultValue}
+            value={value}
             isClearable={isClearable}
             placeholder={isLoading === true ? loadingText : placeholder}
             isDisabled={isLoading === true || isDisabled === true}

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -2,8 +2,14 @@ import {
   InputWrapper,
   type InputWrapperBaseProps
 } from '#ui/internals/InputWrapper'
-import { type FocusEventHandler } from 'react'
-import { type MultiValue, type Options, type SingleValue } from 'react-select'
+import { forwardRef, type FocusEventHandler } from 'react'
+import {
+  type GroupBase,
+  type MultiValue,
+  type Options,
+  type SelectInstance,
+  type SingleValue
+} from 'react-select'
 import { AsyncSelectComponent } from './AsyncComponent'
 import { SelectComponent } from './SelectComponent'
 import { getSelectStyles } from './styles'
@@ -116,76 +122,86 @@ export interface InputSelectProps extends InputWrapperBaseProps {
  * On both standard and async mode it can be set to select a single single value or multiple values.
  *
  */
-export const InputSelect: React.FC<InputSelectProps> = ({
-  label,
-  hint,
-  feedback,
-  menuIsOpen,
-  initialValues,
-  defaultValue,
-  isClearable,
-  isLoading,
-  loadingText = 'Loading...',
-  placeholder,
-  isDisabled,
-  isOptionDisabled,
-  isSearchable,
-  onSelect,
-  isMulti,
-  onBlur,
-  name,
-  className,
-  loadAsyncValues,
-  debounceMs,
-  noOptionsMessage = 'No results found',
-  ...rest
-}) => {
-  return (
-    <InputWrapper
-      className={className}
-      label={label}
-      hint={hint}
-      feedback={feedback}
-      name={name}
-      {...rest}
-    >
-      {loadAsyncValues != null ? (
-        <AsyncSelectComponent
-          menuIsOpen={menuIsOpen}
-          initialValues={initialValues}
-          defaultValue={defaultValue}
-          isClearable={isClearable}
-          placeholder={isLoading === true ? loadingText : placeholder}
-          isDisabled={isLoading === true || isDisabled === true}
-          onSelect={onSelect}
-          isMulti={isMulti}
-          onBlur={onBlur}
-          name={name}
-          noOptionsMessage={noOptionsMessage}
-          loadAsyncValues={loadAsyncValues}
-          styles={getSelectStyles(feedback?.variant)}
-          debounceMs={debounceMs}
-          isOptionDisabled={isOptionDisabled}
-        />
-      ) : (
-        <SelectComponent
-          menuIsOpen={menuIsOpen}
-          initialValues={initialValues}
-          defaultValue={defaultValue}
-          isClearable={isClearable}
-          placeholder={isLoading === true ? loadingText : placeholder}
-          isDisabled={isLoading === true || isDisabled === true}
-          isSearchable={isSearchable}
-          onSelect={onSelect}
-          isMulti={isMulti}
-          isOptionDisabled={isOptionDisabled}
-          onBlur={onBlur}
-          name={name}
-          styles={getSelectStyles(feedback?.variant)}
-        />
-      )}
-    </InputWrapper>
-  )
-}
+export const InputSelect = forwardRef<
+  SelectInstance<InputSelectValue, boolean, GroupBase<InputSelectValue>>,
+  InputSelectProps
+>(
+  (
+    {
+      label,
+      hint,
+      feedback,
+      menuIsOpen,
+      initialValues,
+      defaultValue,
+      isClearable,
+      isLoading,
+      loadingText = 'Loading...',
+      placeholder,
+      isDisabled,
+      isOptionDisabled,
+      isSearchable,
+      onSelect,
+      isMulti,
+      onBlur,
+      name,
+      className,
+      loadAsyncValues,
+      debounceMs,
+      noOptionsMessage = 'No results found',
+      ...rest
+    },
+    ref
+  ) => {
+    return (
+      <InputWrapper
+        className={className}
+        label={label}
+        hint={hint}
+        feedback={feedback}
+        name={name}
+        {...rest}
+      >
+        {loadAsyncValues != null ? (
+          <AsyncSelectComponent
+            ref={ref}
+            menuIsOpen={menuIsOpen}
+            initialValues={initialValues}
+            defaultValue={defaultValue}
+            isClearable={isClearable}
+            placeholder={isLoading === true ? loadingText : placeholder}
+            isDisabled={isLoading === true || isDisabled === true}
+            onSelect={onSelect}
+            isMulti={isMulti}
+            onBlur={onBlur}
+            name={name}
+            noOptionsMessage={noOptionsMessage}
+            loadAsyncValues={loadAsyncValues}
+            styles={getSelectStyles(feedback?.variant)}
+            debounceMs={debounceMs}
+            isOptionDisabled={isOptionDisabled}
+          />
+        ) : (
+          <SelectComponent
+            ref={ref}
+            menuIsOpen={menuIsOpen}
+            initialValues={initialValues}
+            defaultValue={defaultValue}
+            isClearable={isClearable}
+            placeholder={isLoading === true ? loadingText : placeholder}
+            isDisabled={isLoading === true || isDisabled === true}
+            isSearchable={isSearchable}
+            onSelect={onSelect}
+            isMulti={isMulti}
+            isOptionDisabled={isOptionDisabled}
+            onBlur={onBlur}
+            name={name}
+            styles={getSelectStyles(feedback?.variant)}
+          />
+        )}
+      </InputWrapper>
+    )
+  }
+)
 
 InputSelect.displayName = 'InputSelect'

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -17,6 +17,7 @@ export interface InputSelectValue {
   value: string | number
   label: string
   meta?: Record<string, any>
+  isDisabled?: boolean
 }
 
 export type PossibleSelectValue =

--- a/packages/app-elements/src/ui/forms/InputSelect/SelectComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/SelectComponent.tsx
@@ -1,4 +1,9 @@
-import Select, { type StylesConfig } from 'react-select'
+import { forwardRef } from 'react'
+import Select, {
+  type GroupBase,
+  type SelectInstance,
+  type StylesConfig
+} from 'react-select'
 import { type InputSelectProps, type InputSelectValue } from './InputSelect'
 import components from './overrides'
 
@@ -7,23 +12,27 @@ interface SelectComponentProps
   styles: StylesConfig<InputSelectValue>
 }
 
-export const SelectComponent: React.FC<SelectComponentProps> = ({
-  onSelect,
-  noOptionsMessage,
-  isOptionDisabled,
-  initialValues,
-  ...rest
-}) => {
-  return (
-    <Select
-      {...rest}
-      isOptionDisabled={isOptionDisabled}
-      options={initialValues}
-      onChange={onSelect}
-      noOptionsMessage={() => noOptionsMessage}
-      components={components}
-    />
-  )
-}
+export const SelectComponent = forwardRef<
+  SelectInstance<InputSelectValue, boolean, GroupBase<InputSelectValue>>,
+  SelectComponentProps
+>(
+  (
+    { onSelect, noOptionsMessage, isOptionDisabled, initialValues, ...rest },
+    ref
+  ) => {
+    return (
+      <Select
+        {...rest}
+        ref={ref}
+        isOptionDisabled={isOptionDisabled}
+        options={initialValues}
+        onChange={onSelect}
+        closeMenuOnSelect={rest.isMulti !== true}
+        noOptionsMessage={() => noOptionsMessage}
+        components={components}
+      />
+    )
+  }
+)
 
 SelectComponent.displayName = 'SelectComponent'

--- a/packages/app-elements/src/ui/forms/InputSelect/styles.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/styles.ts
@@ -18,7 +18,7 @@ export const getSelectStyles = (
     ...style,
     padding: '0'
   }),
-  option: (style, { isSelected, isFocused }) => ({
+  option: (style, { isSelected, isFocused, isDisabled }) => ({
     ...style,
     padding: '0.625rem 1rem',
     backgroundColor: isSelected
@@ -26,7 +26,7 @@ export const getSelectStyles = (
       : isFocused
         ? '#F8F8F8'
         : 'transparent',
-    color: isSelected ? '#fff' : 'rgb(40 41 41)',
+    color: isSelected ? '#fff' : isDisabled ? '#BBBEBE' : 'rgb(40 41 41)',
     fontSize: 16,
     fontWeight: 500,
     cursor: 'pointer',

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
@@ -15,17 +15,37 @@ const setup: Meta<typeof HookedInputSelect> = {
 export default setup
 
 const Template: StoryFn<typeof HookedInputSelect> = (args) => {
-  const methods = useForm()
+  const methods = useForm({
+    resolver: async (data, context) => {
+      return {
+        errors:
+          data.city == null || data.city.length === 0
+            ? { city: { type: 'required', message: 'City is required' } }
+            : {},
+        values: data
+      }
+    }
+  })
 
   return (
     <HookedForm
       {...methods}
-      onSubmit={(values) => {
+      onSubmit={(values): void => {
         alert(JSON.stringify(values))
       }}
     >
       <HookedInputSelect {...args} />
       <Spacer top='4'>
+        <Button
+          type='reset'
+          variant='secondary'
+          onClick={() => {
+            methods.reset()
+          }}
+        >
+          Reset
+        </Button>
+        &nbsp;&nbsp;&nbsp;
         <Button type='submit'>Submit</Button>
       </Spacer>
     </HookedForm>
@@ -95,4 +115,40 @@ MultiSelect.args = {
       }
     }
   ]
+}
+
+export const Clear: StoryFn<typeof HookedInputSelect> = () => {
+  const methods = useForm({
+    defaultValues: { city: ['paris'] }
+  })
+
+  return (
+    <HookedForm
+      {...methods}
+      onSubmit={(values) => {
+        alert(JSON.stringify(values))
+      }}
+    >
+      <HookedInputSelect
+        name='city'
+        isMulti
+        label='Search resource'
+        initialValues={MultiSelect.args?.initialValues ?? []}
+        placeholder='Type to filter list...'
+      />
+      <Spacer top='4'>
+        <Button
+          type='reset'
+          variant='secondary'
+          onClick={() => {
+            methods.reset()
+          }}
+        >
+          Reset
+        </Button>
+        &nbsp;&nbsp;&nbsp;
+        <Button type='submit'>Submit</Button>
+      </Spacer>
+    </HookedForm>
+  )
 }

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
@@ -54,7 +54,8 @@ Default.args = {
     },
     {
       value: 'london',
-      label: 'London'
+      label: 'London',
+      isDisabled: true
     }
   ]
 }
@@ -83,7 +84,8 @@ MultiSelect.args = {
       label: 'Rome',
       meta: {
         cityCode: 'EU_ROME'
-      }
+      },
+      isDisabled: true
     },
     {
       value: 'new york',

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -1,7 +1,7 @@
 import { InputSelect, type InputSelectValue } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 
-const fullList = [
+const fullList: InputSelectValue[] = [
   { value: 'customers', label: 'Customers' },
   { value: 'customer_subscriptions', label: 'Customer subscriptions' },
   { value: 'skus', label: 'SKUs' },
@@ -56,7 +56,7 @@ Default.args = {
 }
 
 /**
- * <span type='info'>Default mode with ability to search within the provided `initialValues`</span>
+ * Default mode with ability to search within the provided `initialValues`
  */
 export const Simple = Template.bind({})
 Simple.args = {
@@ -69,7 +69,24 @@ Simple.args = {
 }
 
 /**
- * <span type='info'>With the `loadAsyncValues` prop, it's possible to return options asynchronously while typing. </span>
+ * Use `isDisabled` option property to disable the option. In the list below `Customers` will be disabled.
+ */
+export const DisabledOptions = Template.bind({})
+DisabledOptions.args = {
+  label: 'Search resource',
+  initialValues: [
+    { value: 'customer_subscriptions', label: 'Customer subscriptions' },
+    { value: 'customers', label: 'Customers', isDisabled: true },
+    { value: 'skus', label: 'SKUs' }
+  ],
+  placeholder: 'Type to filter list...',
+  isSearchable: true,
+  isClearable: false,
+  onBlur: () => {}
+}
+
+/**
+ * With the `loadAsyncValues` prop, it's possible to return options asynchronously while typing.
  */
 export const Async = Template.bind({})
 Async.args = {
@@ -92,7 +109,7 @@ Async.args = {
 }
 
 /**
- * <span type='info'>`isMulti` allows to select more than one value</span>
+ * `isMulti` allows to select more than one value
  */
 export const Multi = Template.bind({})
 Multi.args = {
@@ -105,7 +122,7 @@ Multi.args = {
 }
 
 /**
- * <span type='info'>Options can be grouped by passing an array of objects with `label` and `options` properties.</span>
+ * Options can be grouped by passing an array of objects with `label` and `options` properties.
  */
 export const GroupedOptions = Template.bind({})
 GroupedOptions.args = {
@@ -115,7 +132,7 @@ GroupedOptions.args = {
       label: 'Europe',
       options: [
         { label: 'France', value: 'fr' },
-        { label: 'Italy', value: 'it' },
+        { label: 'Italy', value: 'it', isDisabled: true },
         { label: 'Spain', value: 'es' },
         { label: 'Germany', value: 'de' }
       ]


### PR DESCRIPTION
## What I did

- add `isDisabled` option with the proper css style.
- add the `ref` attribute to access inner functionality from outer component.
- when `isMulti` the menu will stay open after selecting an option (AsyncComponent is still closing the menu).
- add ability to reset the `HookedInputSelect`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
