### PR TITLE
Fix `lockSimple` icon key name

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -44,7 +44,7 @@ export const iconMapping = {
   linkSimple: phosphor.LinkSimple,
   list: phosphor.List,
   lockSimpleOpen: phosphor.LockSimpleOpen,
-  LockSimple: phosphor.LockSimple,
+  lockSimple: phosphor.LockSimple,
   magnifyingGlass: phosphor.MagnifyingGlass,
   megaphoneSimple: phosphor.MegaphoneSimple,
   minus: phosphor.Minus,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed `lockSimple` icon key name. I wrongly set the key with capital first letter.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
