### PR TITLE
Add an `API` badge when promotion is created from outside the app

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -14,6 +14,7 @@ import type {
   StockLocation,
   StockTransfer
 } from '@commercelayer/sdk'
+import { referenceOrigins } from './transformers/promotions'
 
 const market = {
   type: 'markets',
@@ -331,6 +332,7 @@ export const presetResourceListItem = {
   },
   promotionActive: {
     type: 'percentage_discount_promotions',
+    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -343,6 +345,7 @@ export const presetResourceListItem = {
   },
   promotionDisabled: {
     type: 'percentage_discount_promotions',
+    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -356,6 +359,7 @@ export const presetResourceListItem = {
   },
   promotionUpcoming: {
     type: 'free_shipping_promotions',
+    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -367,6 +371,7 @@ export const presetResourceListItem = {
   },
   promotionDisabledAndUpcoming: {
     type: 'free_shipping_promotions',
+    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -379,6 +384,7 @@ export const presetResourceListItem = {
   },
   promotionExpired: {
     type: 'free_gift_promotions',
+    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -389,6 +395,22 @@ export const presetResourceListItem = {
     active: false
   },
   promotionWithCoupons: {
+    type: 'percentage_discount_promotions',
+    reference_origin: referenceOrigins.appPromotions,
+    id: '',
+    created_at: '',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    starts_at: '2024-01-01T06:38:44.964Z',
+    expires_at: '3033-01-01T06:38:44.964Z',
+    name: '50% off',
+    percentage: 23,
+    total_usage_limit: 3,
+    active: true,
+    coupons: [
+      { code: '1234', created_at: '', id: '', type: 'coupons', updated_at: '' }
+    ]
+  },
+  promotionFromApi: {
     type: 'percentage_discount_promotions',
     id: '',
     created_at: '',

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
@@ -9,17 +9,28 @@ import {
 import type { Promotion } from '@commercelayer/sdk'
 import { type ResourceToProps } from '../types'
 
+export const referenceOrigins = {
+  appPromotions: 'app-promotions'
+} as const
+
 export const promotionToProps: ResourceToProps<Omit<Promotion, 'type'>> = ({
   resource,
   user
 }) => {
   const displayStatus = getPromotionDisplayStatus(resource)
   const hasCoupons = (resource.coupons ?? []).length > 0
+  const createdFromApi =
+    resource.reference_origin !== referenceOrigins.appPromotions
 
   return {
     name: (
       <>
         {resource.name}{' '}
+        {createdFromApi && (
+          <Badge className='ml-1' variant='warning'>
+            API
+          </Badge>
+        )}
         {hasCoupons && (
           <Badge className='ml-1' variant='teal'>
             coupons


### PR DESCRIPTION
## What I did

I added an `API` badge when promotion is created from outside the app.

<img width="661" alt="Screenshot 2024-01-30 alle 14 58 45" src="https://github.com/commercelayer/app-elements/assets/1681269/35d4975f-2b82-4872-a34e-282c90ad4eea">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
