### PR TITLE
Add ability to show additional Elements when checkbox is checked

### DIFF
--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
@@ -164,14 +164,14 @@ const SkeletonTemplate: SkeletonTemplateComponent<
 
           if (
             isSpecificReactComponent(child, [
-              'Avatar',
-              'AvatarLetter',
-              'Badge',
-              'Button',
-              'Icon',
-              'StatusIcon',
-              'RadialProgress',
-              'ButtonFilter'
+              /^Avatar$/,
+              /^AvatarLetter$/,
+              /^Badge$/,
+              /^Button$/,
+              /^Icon$/,
+              /^StatusIcon$/,
+              /^RadialProgress$/,
+              /^ButtonFilter$/
             ])
           ) {
             return cloneElement(child, {

--- a/packages/app-elements/src/ui/composite/ListDetailsItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListDetailsItem.tsx
@@ -44,7 +44,7 @@ export function ListDetailsItem({
 }: ListDetailsItemProps): JSX.Element {
   const childrenHaveInternalPadding = (
     Children.map(children, (child) =>
-      isSpecificReactComponent(child, ['CopyToClipboard'])
+      isSpecificReactComponent(child, [/^CopyToClipboard$/])
     ) ?? []
   ).some(Boolean)
 

--- a/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.tsx
@@ -4,7 +4,7 @@ import {
   type InputWrapperBaseProps
 } from '#ui/internals/InputWrapper'
 import cn from 'classnames'
-import { forwardRef } from 'react'
+import { forwardRef, useState } from 'react'
 
 export interface InputCheckboxProps
   extends Omit<InputWrapperBaseProps, 'label' | 'inline'>,
@@ -14,14 +14,22 @@ export interface InputCheckboxProps
    * Example: `<Avatar>`
    */
   icon?: JSX.Element
+  /**
+   * Additional `Element` to be rendered when the input is checked
+   */
+  checkedElement?: JSX.Element
   children?: JSX.Element | string
 }
 
 export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
   (
-    { className, hint, feedback, icon, children, ...rest },
+    { className, hint, feedback, icon, children, checkedElement, ...rest },
     ref
   ): JSX.Element => {
+    const [checked, setChecked] = useState<boolean>(
+      rest.defaultChecked ?? rest.checked ?? false
+    )
+
     return (
       <InputWrapper
         hint={hint}
@@ -40,6 +48,14 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
           >
             <input
               type='checkbox'
+              onChangeCapture={(event) => {
+                setChecked(event.currentTarget.checked)
+                rest.onChangeCapture?.(event)
+              }}
+              onChange={(event) => {
+                setChecked(event.currentTarget.checked)
+                rest.onChange?.(event)
+              }}
               data-testid='checkbox-input'
               className={cn(
                 'border border-gray-300 rounded w-[18px] h-[18px] text-primary focus:ring-primary',
@@ -58,6 +74,9 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
             ) : null}
           </label>
         </div>
+        {checkedElement != null && (rest.checked === true || checked) && (
+          <div className='my-2 ml-[18px] pl-4'>{checkedElement}</div>
+        )}
       </InputWrapper>
     )
   }

--- a/packages/app-elements/src/utils/array.ts
+++ b/packages/app-elements/src/utils/array.ts
@@ -1,5 +1,9 @@
 type Invalid<T> = Error & { __errorMessage: T }
 
+export function isDefined<T>(value: T | undefined | null): value is T {
+  return value != null
+}
+
 type AsUniqueArray<A extends readonly any[], B extends readonly any[]> = {
   [I in keyof A]: unknown extends {
     [J in keyof B]: J extends I ? never : B[J] extends A[I] ? unknown : never

--- a/packages/app-elements/src/utils/children.test.tsx
+++ b/packages/app-elements/src/utils/children.test.tsx
@@ -1,33 +1,65 @@
-import { getInnerText, isSpecificReactComponent } from './children'
+import {
+  filterByDisplayName,
+  getInnerText,
+  isSpecificReactComponent
+} from './children'
 
-function makeChildWithName(displayName: string): JSX.Element {
+function createElement(
+  displayName: string,
+  props?: Record<string, unknown>
+): JSX.Element {
   const SampleComponent = (): JSX.Element => <div />
   SampleComponent.displayName = displayName
 
-  return <SampleComponent />
+  return <SampleComponent {...props} />
 }
 
 describe('isSpecificReactComponent', () => {
   it('should return `true` for matched named component', () => {
     expect(
-      isSpecificReactComponent(makeChildWithName('Button'), ['Button'])
+      isSpecificReactComponent(createElement('Button'), [/^Button$/])
     ).toBe(true)
   })
 
   it('should return `false` for not matched named component', () => {
-    expect(
-      isSpecificReactComponent(makeChildWithName('Title'), ['Button'])
-    ).toBe(false)
+    expect(isSpecificReactComponent(createElement('Title'), [/^Button$/])).toBe(
+      false
+    )
   })
 
   it('should return `false` for null child', () => {
-    expect(isSpecificReactComponent(null, ['Button'])).toBe(false)
+    expect(isSpecificReactComponent(null, [/^Button$/])).toBe(false)
   })
 
   it('should return `false` for any other ReactNode element', () => {
     expect(
-      isSpecificReactComponent('string is a valid ReactNode', ['Button'])
+      isSpecificReactComponent('string is a valid ReactNode', [/^Button$/])
     ).toBe(false)
+  })
+})
+
+describe('filterByDisplayName', () => {
+  it('should return all children with the given displayName', () => {
+    const container = (
+      <div>
+        <div>{createElement('Input', { id: '1' })}</div>
+        <div>{createElement('HookedInput', { id: '2' })}</div>
+        <div>
+          <div>{createElement('HookedInput', { id: '3' })}</div>
+        </div>
+        {createElement('Button', { type: 'submit', children: 'Submit' })}
+      </div>
+    )
+    expect(filterByDisplayName(container, /^Hooked/)).toMatchInlineSnapshot(`
+      [
+        <HookedInput
+          id="2"
+        />,
+        <HookedInput
+          id="3"
+        />,
+      ]
+    `)
   })
 })
 

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputCheckbox.stories.tsx
@@ -2,8 +2,9 @@ import { Button } from '#ui/atoms/Button'
 import { Spacer } from '#ui/atoms/Spacer'
 import { HookedForm } from '#ui/forms/Form'
 import { HookedInputCheckbox } from '#ui/forms/InputCheckbox'
+import { HookedInputSelect } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
-import { useForm } from 'react-hook-form'
+import { useForm, type FieldErrors } from 'react-hook-form'
 
 const setup: Meta<typeof HookedInputCheckbox> = {
   title: 'Forms/react-hook-form/HookedInputCheckbox',
@@ -29,7 +30,7 @@ const Template: StoryFn<typeof HookedInputCheckbox> = (args) => {
   return (
     <HookedForm
       {...methods}
-      onSubmit={(values) => {
+      onSubmit={(values): void => {
         alert(JSON.stringify(values))
       }}
     >
@@ -44,4 +45,81 @@ const Template: StoryFn<typeof HookedInputCheckbox> = (args) => {
 export const Default = Template.bind({})
 Default.args = {
   name: 'myCheckboxField'
+}
+
+interface Fields {
+  color_selected: boolean
+  color: 'red' | 'green' | 'blue' | null
+  accept: boolean
+}
+
+export const WithCheckedElement: StoryFn = () => {
+  const methods = useForm<Fields>({
+    defaultValues: {
+      color_selected: true,
+      color: null,
+      accept: false
+    },
+    resolver: async (data) => {
+      const errors = new Map<string, FieldErrors<Fields>[keyof Fields]>()
+
+      if (data.color_selected && data.color == null) {
+        errors.set('color', {
+          type: 'required',
+          message: 'Color is required'
+        })
+      }
+
+      if (!data.accept) {
+        errors.set('accept', {
+          type: 'required',
+          message: 'You must accept'
+        })
+      }
+
+      return {
+        errors: Object.fromEntries(errors),
+        values: data
+      }
+    }
+  })
+
+  return (
+    <div style={{ minHeight: '200px' }}>
+      <HookedForm
+        {...methods}
+        onSubmit={(values): void => {
+          alert(JSON.stringify(values))
+        }}
+      >
+        <HookedInputCheckbox
+          name='color_selected'
+          checkedElement={
+            <div>
+              <HookedInputSelect
+                name='color'
+                hint={{ text: 'Select your preferred color.' }}
+                initialValues={[
+                  { label: 'Red', value: 'red' },
+                  { label: 'Green', value: 'green' },
+                  { label: 'Blue', value: 'blue' }
+                ]}
+              />
+              <Spacer top='2'>
+                <HookedInputCheckbox name='optional_check'>
+                  Optional check
+                </HookedInputCheckbox>
+              </Spacer>
+            </div>
+          }
+        >
+          Color preference
+        </HookedInputCheckbox>
+        <HookedInputCheckbox name='accept'>Accept</HookedInputCheckbox>
+        <Spacer top='4'>
+          <Button type='submit'>Submit</Button>
+        </Spacer>
+      </HookedForm>
+    </div>
+  )
 }

--- a/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
@@ -1,7 +1,9 @@
 import { Avatar } from '#ui/atoms/Avatar'
 import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
+import { Input } from '#ui/forms/Input'
 import { InputCheckbox } from '#ui/forms/InputCheckbox'
+import { InputSelect } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof InputCheckbox> = {
@@ -77,4 +79,31 @@ WithError.args = {
     variant: 'danger',
     message: 'Required field'
   }
+}
+
+export const WithCheckedElement: StoryFn<typeof InputCheckbox> = (args) => {
+  return (
+    <div style={{ height: '300px' }}>
+      <InputCheckbox>First checkbox</InputCheckbox>
+      <InputCheckbox defaultChecked checkedElement={<Input />}>
+        Set a name
+      </InputCheckbox>
+      <InputCheckbox
+        checkedElement={
+          <InputSelect
+            onSelect={() => {}}
+            hint={{ text: 'Select your preferred color.' }}
+            initialValues={[
+              { label: 'Red', value: 'red' },
+              { label: 'Green', value: 'green' },
+              { label: 'Blue', value: 'blue' }
+            ]}
+          />
+        }
+      >
+        Preferred color
+      </InputCheckbox>
+      <InputCheckbox>Last checkbox</InputCheckbox>
+    </div>
+  )
 }


### PR DESCRIPTION
## What I did

I added the ability to show additional `Element`s when the `InputCheckbox` component is checked.

```tsx
<HookedInputCheckbox
  name='color_selected'
  checkedElement={
    <div>
      <HookedInputSelect
        name='color'
        hint={{ text: 'Select your preferred color.' }}
        initialValues={[
          { label: 'Red', value: 'red' },
          { label: 'Green', value: 'green' },
          { label: 'Blue', value: 'blue' }
        ]}
      />
      <Spacer top='2'>
        <HookedInputCheckbox name='optional_check'>
          Optional check
        </HookedInputCheckbox>
      </Spacer>
    </div>
  }
>
  Color preference
</HookedInputCheckbox>
```

https://github.com/commercelayer/app-elements/assets/1681269/5e2427c3-1748-47fb-9e63-38ac6bdd7a77


## How to test

https://deploy-preview-533--commercelayer-app-elements.netlify.app/?path=/docs/forms-react-hook-form-hookedinputcheckbox--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
