### PR TITLE
The `HookedInputCheckbox` component will set all Hooked children to undefined when unchecked

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
@@ -24,7 +24,7 @@ export function HookedInputCheckbox({
   name,
   ...props
 }: HookedInputCheckboxProps): JSX.Element {
-  const { register, getValues, watch, resetField } = useFormContext()
+  const { register, getValues, watch, resetField, setValue } = useFormContext()
   const feedback = useValidationFeedback(name)
   const isChecked = Boolean(watch(name))
 
@@ -39,9 +39,13 @@ export function HookedInputCheckbox({
   }, [props.checkedElement])
 
   useEffect(() => {
-    if (!isChecked && childrenFieldNames.length > 0) {
+    if (childrenFieldNames.length > 0) {
       childrenFieldNames.forEach((fieldName) => {
-        resetField(fieldName)
+        if (isChecked) {
+          resetField(fieldName)
+        } else {
+          setValue(fieldName, undefined)
+        }
       })
     }
   }, [isChecked])

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputCheckbox.stories.tsx
@@ -57,7 +57,7 @@ export const WithCheckedElement: StoryFn = () => {
   const methods = useForm<Fields>({
     defaultValues: {
       color_selected: true,
-      color: null,
+      color: 'green',
       accept: false
     },
     resolver: async (data) => {


### PR DESCRIPTION
## What I did

The `HookedInputCheckbox` component will set all Hooked children to undefined when unchecked

https://github.com/commercelayer/app-elements/assets/1681269/0c761f83-917a-4788-861e-0cde4bd2047d


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
