### PR TITLE
Add `className` to InputRadioGroup > OptionItem

### DIFF
--- a/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
@@ -17,6 +17,10 @@ interface OptionItem {
    * Item content to be displayed in the central section of the row
    */
   content: ReactNode
+  /**
+   * Optional CSS class name to be applied to the card item
+   */
+  className?: string
 }
 
 interface Props extends Pick<InputWrapperBaseProps, 'feedback' | 'hint'> {
@@ -82,14 +86,14 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
             'grid grid-cols-2': viewMode === 'grid'
           })}
         >
-          {options.map((optionItem, index) => {
+          {options.map((optionItem) => {
             const isSelected = optionItem.value === selectedValue
 
             return (
               <Card
                 key={optionItem.value}
                 overflow='hidden'
-                className={cn({
+                className={cn(optionItem.className, {
                   '!p-1': !isSelected,
                   'border-primary-500 border-2 !p-[calc(theme(space.1)-1px)]':
                     isSelected,

--- a/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
@@ -232,6 +232,27 @@ ViewModeGrid.args = {
   ]
 }
 
+/** It possible to specify a custom CSS class name for a single option item */
+export const ItemCustomClassName = Template.bind({})
+ItemCustomClassName.args = {
+  title: 'Choose a color',
+  name: 'package',
+  viewMode: 'grid',
+  showInput: false,
+  options: [
+    {
+      value: 'orange',
+      className: 'text-orange',
+      content: <div>orange</div>
+    },
+    {
+      value: 'red',
+      className: 'text-red',
+      content: <div>red</div>
+    }
+  ]
+}
+
 export const DefaultValue = Template.bind({})
 DefaultValue.args = {
   name: 'package',


### PR DESCRIPTION
## What I did

In `InputRadioGroup`, it's now possible to pass an optional `className` to each option item.


Example: 
```
options: [
    {
      value: 'item1',
      content: <div>Item #1</div>
    },
    {
      value: 'item2',
      className: 'w-full',
      content: <div>Item #2</div>
    }
  ]
```


## How to test


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
