### PR TITLE
Aallow TokenProvider to persist token using custom `organizationSlug`

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -132,7 +132,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
   const accessToken =
     accessTokenFromProp ??
     getAccessTokenFromUrl() ??
-    getPersistentAccessToken({ appSlug })
+    getPersistentAccessToken({ appSlug, organizationSlug })
 
   const dashboardUrl = makeDashboardUrl({
     domain,
@@ -219,7 +219,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
             : null
 
         // all good
-        savePersistentAccessToken({ appSlug, accessToken })
+        savePersistentAccessToken({ appSlug, accessToken, organizationSlug })
         removeAuthParamsFromUrl()
 
         dispatch({

--- a/packages/app-elements/src/providers/TokenProvider/storage.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/storage.test.ts
@@ -1,4 +1,5 @@
-import { makeStorageKey } from './storage'
+import { getPersistentAccessToken } from '#providers/TokenProvider/storage'
+import { makeStorageKey, savePersistentAccessToken } from './storage'
 
 describe('makeStorageKey', () => {
   const { location } = window
@@ -14,12 +15,86 @@ describe('makeStorageKey', () => {
   })
 
   test('should return the storage key for clientId', () => {
-    window.location.hostname = 'myorg.commercelayer.app'
     const key = makeStorageKey({
       appSlug: 'imports',
-      item: 'accessToken'
+      organizationSlug: 'myorg'
     })
 
     expect(key).to.equal('imports:myorg:accessToken')
+  })
+})
+
+describe('getPersistentAccessToken', () => {
+  const { location } = window
+  beforeAll(function clearLocation() {
+    delete (window as any).location
+    ;(window as any).location = {
+      ...location,
+      hostname: ''
+    }
+  })
+  afterAll(function resetLocation() {
+    window.location = location
+    localStorage.clear()
+  })
+
+  test('should retrieve the access token by inferring organization slug from URL', () => {
+    window.location.hostname = 'demo-store.commercelayer.app'
+    localStorage.setItem('orders:demo-store:accessToken', 'pre-saved-token')
+    expect(
+      getPersistentAccessToken({
+        appSlug: 'orders'
+      })
+    ).toBe('pre-saved-token')
+  })
+
+  test('should retrieve the access token by using specific organization slug, ignoring URL', () => {
+    window.location.hostname = 'demo-store.commercelayer.app'
+    localStorage.setItem('orders:the-red-store:accessToken', 'pre-saved-token2')
+    expect(
+      getPersistentAccessToken({
+        appSlug: 'orders',
+        organizationSlug: 'the-red-store'
+      })
+    ).toBe('pre-saved-token2')
+  })
+})
+
+describe('savePersistentAccessToken', () => {
+  const { location } = window
+  beforeAll(function clearLocation() {
+    delete (window as any).location
+    ;(window as any).location = {
+      ...location,
+      hostname: ''
+    }
+  })
+  afterAll(function resetLocation() {
+    window.location = location
+    localStorage.clear()
+  })
+
+  test('should save the access token by inferring organization slug from URL', () => {
+    window.location.hostname = 'demo-store.commercelayer.app'
+    savePersistentAccessToken({
+      accessToken: 'myAccessToken',
+      appSlug: 'orders'
+    })
+    expect(localStorage.getItem('orders:demo-store:accessToken')).toBe(
+      'myAccessToken'
+    )
+  })
+
+  test('should save the access token by using specific organization slug, ignoring URL', () => {
+    window.location.hostname = 'demo-store.commercelayer.app'
+    savePersistentAccessToken({
+      accessToken: 'myAccessToken2',
+      appSlug: 'shipments',
+      organizationSlug: 'blue-store'
+    })
+    expect(localStorage.getItem('shipments:demo-store:accessToken')).toBe(null)
+    expect(localStorage.getItem('shipments:blue-store:accessToken')).toBe(
+      'myAccessToken2'
+    )
   })
 })

--- a/packages/app-elements/src/providers/TokenProvider/storage.ts
+++ b/packages/app-elements/src/providers/TokenProvider/storage.ts
@@ -1,46 +1,63 @@
 import { type TokenProviderAllowedApp } from './types'
 import { getOrgSlugFromCurrentUrl } from './url'
 
-type PersistentItem = 'accessToken'
-
 export function makeStorageKey({
   appSlug,
-  item
+  organizationSlug
 }: {
   appSlug: TokenProviderAllowedApp
-  item: PersistentItem
+  organizationSlug: string
 }): string {
-  return `${appSlug}:${getOrgSlugFromCurrentUrl()}:${item}`
+  return `${appSlug}:${
+    organizationSlug ?? getOrgSlugFromCurrentUrl()
+  }:accessToken`
 }
 
 export function getPersistentAccessToken({
-  appSlug
+  appSlug,
+  organizationSlug
 }: {
+  /** The app for which to get the token. */
   appSlug: TokenProviderAllowedApp
+  /** Try to infer it from the current URL when not explicitly provided. */
+  organizationSlug?: string
 }): string | null {
   if (typeof window === 'undefined') {
     return null
   }
 
   const storedAccessToken = window.localStorage.getItem(
-    makeStorageKey({ appSlug, item: 'accessToken' })
+    makeStorageKey({
+      appSlug,
+      organizationSlug:
+        organizationSlug ?? getOrgSlugFromCurrentUrl() ?? 'commercelayer'
+    })
   )
   return storedAccessToken
 }
 
 export function savePersistentAccessToken({
   appSlug,
-  accessToken
+  accessToken,
+  organizationSlug
 }: {
+  /** The app for which to get the token. */
   appSlug: TokenProviderAllowedApp
+  /** The token to save. */
   accessToken: string
+  /** Try to infer it from the current URL when not explicitly provided. */
+  organizationSlug?: string
 }): void {
   if (typeof window === 'undefined') {
     return
   }
 
   window.localStorage.setItem(
-    makeStorageKey({ appSlug, item: 'accessToken' }),
+    makeStorageKey({
+      appSlug,
+      organizationSlug:
+        organizationSlug ?? getOrgSlugFromCurrentUrl() ?? 'commercelayer'
+    }),
     accessToken
   )
 }


### PR DESCRIPTION
## What I did

`TokenProvider` saves and loads the token from `localStorage` by inferring the organization slug from the current URL.
With this PR I've extended this behavior and when `organizationSlug` is defined it will be used to build the local storage key, instead of inferring it from the URL


This will only impact self-hosted applications, since in all dashboard `app-*`s we are not using `organizationSlug` and the organization slug will be still inferred from the current URL.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
