### PR TITLE
Fix type of `app` props in `appsNavigation` helper

### DIFF
--- a/packages/app-elements/src/helpers/appsNavigation.ts
+++ b/packages/app-elements/src/helpers/appsNavigation.ts
@@ -1,4 +1,4 @@
-import { type ResourceTypeLock } from '@commercelayer/sdk/lib/cjs/api'
+import { type TokenProviderAllowedApp } from '#providers/TokenProvider/types'
 import isEmpty from 'lodash/isEmpty'
 
 const currentVersion = 0.2
@@ -133,7 +133,7 @@ interface NavigateToInternalParams {
     /**
      * app name to navigate to, it could be the current app (internal linking) or another app (cross linking)
      */
-    app: ResourceTypeLock
+    app: TokenProviderAllowedApp
     /**
      * resource id to open
      */
@@ -149,7 +149,7 @@ interface NavigateToExternalParams {
     /**
      * app name to navigate to, it could be the current app (internal linking) or another app (cross linking)
      */
-    app: ResourceTypeLock
+    app: TokenProviderAllowedApp
     /**
      * resource id to open
      */


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I set the type of `app` props defined in the `appsNavigation` helper methods to be of type `TokenProviderAllowedApp` instead of SDK's `ResourceTypeLock`. This change should be a refinement of a previous fix made to introduce this new type aimed to take care and control over our active apps.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
