### PR TITLE
Reduce  to `72pz` `large` size of `Avatar` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Avatar.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.tsx
@@ -24,7 +24,7 @@ export interface AvatarProps {
   shape?: 'rounded' | 'circle'
   /**
    * Image size
-   * (x-small: 32px, small: 48px, normal: 58px, large: 96px)
+   * (x-small: 32px, small: 48px, normal: 58px, large: 72px)
    * @default "normal"
    */
   size?: 'x-small' | 'small' | 'normal' | 'large'
@@ -61,7 +61,7 @@ export function Avatar({
         'border object-contain object-center',
         {
           // size
-          'min-w-[96px] min-h-[96px] w-[96px] h-[96px]': size === 'large',
+          'min-w-[72px] min-h-[72px] w-[72px] h-[72px]': size === 'large',
           'min-w-[58px] min-h-[58px] w-[58px] h-[58px]': size === 'normal',
           'min-w-[42px] min-h-[42px] w-[42px] h-[42px]': size === 'small',
           'min-w-8 min-h-8 w-8 h-8': size === 'x-small',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The `large` size of `Avatar` component has been uniformed by design to `72px` across all apps.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
