### PR TITLE
Add `variant` and `disabled` to `ListItem` component

### DIFF
--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -4,6 +4,8 @@ import cn from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import { useMemo, type FC } from 'react'
 
+type ListItemVariant = 'list' | 'card'
+
 type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
   /**
    * Icon component
@@ -31,6 +33,16 @@ type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
    * @default 'solid'
    */
   borderStyle?: 'dashed' | 'solid' | 'none'
+  /**
+   * ListItem variant: 'list' or 'card' with rounded borders
+   * @default 'list'
+   */
+  variant?: ListItemVariant
+  /**
+   * Disabled effect
+   * @default undefined
+   */
+  disabled?: boolean
 }
 
 export type ListItemProps = Props &
@@ -58,6 +70,8 @@ export const ListItem: FC<ListItemProps> = ({
   alignItems = 'center',
   alignIcon = 'top',
   borderStyle = 'solid',
+  variant = 'list',
+  disabled = false,
   ...rest
 }) => {
   const JsxTag = useMemo(
@@ -70,7 +84,8 @@ export const ListItem: FC<ListItemProps> = ({
     [rest.tag]
   )
   const hasHover =
-    rest.onClick != null || (rest.tag === 'a' && !isEmpty(rest.href))
+    !disabled &&
+    (rest.onClick != null || (rest.tag === 'a' && !isEmpty(rest.href)))
 
   const pySize = cn({
     'py-4': paddingSize === '4',
@@ -92,7 +107,9 @@ export const ListItem: FC<ListItemProps> = ({
           [pxSize]: padding !== 'none' && padding !== 'y',
           'border-dashed': borderStyle === 'dashed',
           'border-b': borderStyle !== 'none',
-          'cursor-pointer hover:bg-gray-50': hasHover
+          'cursor-pointer hover:bg-gray-50': hasHover,
+          'border rounded': variant === 'card',
+          'border-gray-200 bg-gray-100': disabled
         },
         className
       )}

--- a/packages/docs/src/stories/composite/ListItem.stories.tsx
+++ b/packages/docs/src/stories/composite/ListItem.stories.tsx
@@ -56,6 +56,23 @@ WithIcon.args = {
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />
 }
 
+export const Card = WithIconTemplate.bind({})
+Card.args = {
+  tag: 'div',
+  icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
+  onClick: () => {},
+  variant: 'card'
+}
+
+export const Disabled = WithIconTemplate.bind({})
+Disabled.args = {
+  tag: 'div',
+  icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
+  onClick: () => {},
+  variant: 'card',
+  disabled: true
+}
+
 export const WithCenteredIcon = WithIconTemplate.bind({})
 WithCenteredIcon.args = {
   tag: 'div',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Added `variant` prop to `ListItem` component defining `list` (default) and `card` options to give rounded border to the item in case of `card` setup
- Added `disabled` prop to `ListItem` component to enable a different UI for disabled-like usage of a single `ListItem`

<img width="700" alt="Screenshot 2024-02-08 alle 10 23 31" src="https://github.com/commercelayer/app-elements/assets/105653649/c545d22f-2a1c-49c1-b530-1e7ca91e05c2">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
