### PR TITLE
Prevent children of ListDetailsItem to break its layout

### DIFF
--- a/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
+++ b/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
@@ -82,7 +82,17 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
       )}
       {...rest}
     >
-      {showValue && <p className='overflow-x-auto py-2'>{value}</p>}
+      {showValue && (
+        <p className='overflow-x-auto py-2'>
+          {isJsonString(value) ? (
+            <div className='whitespace-pre max-h-[200px] font-mono font-medium'>
+              {JSON.stringify(JSON.parse(value), null, 2)}
+            </div>
+          ) : (
+            value
+          )}
+        </p>
+      )}
       <div className='pt-2'>
         <button
           type='button'
@@ -137,6 +147,16 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
       </div>
     </div>
   )
+}
+
+/** check if a string can be considered as stringified JSON object */
+function isJsonString(str: string): boolean {
+  try {
+    JSON.parse(str)
+  } catch (e) {
+    return false
+  }
+  return true
 }
 
 CopyToClipboard.displayName = 'CopyToClipboard'

--- a/packages/app-elements/src/ui/composite/ListDetailsItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListDetailsItem.tsx
@@ -52,7 +52,7 @@ export function ListDetailsItem({
     <div
       data-testid={`list-details-item-${label}`}
       className={classNames(
-        'border-gray-100 flex flex-col md:!flex-row md:!gap-4 py-2 md:py-0',
+        'border-gray-100 md:!gap-4 py-2 md:py-0 grid md:!grid-cols-[1fr,1.4fr]',
         {
           'px-4': gutter !== 'none',
           'border-b py-4 md:!py-2': border !== 'none'
@@ -60,14 +60,16 @@ export function ListDetailsItem({
       )}
       {...rest}
     >
-      <div className='text-gray-500 font-medium flex-none w-5/12 md:!py-2'>
+      <div className='text-gray-500 font-medium flex-none w-full md:!py-2 min-w-0'>
         {label}
       </div>
       <div
         data-testid={`list-details-item-${label}-value`}
-        className={classNames('w-full font-semibold', {
+        // keep `min-w-0` to avoid grid overflow when grid-item content is too long
+        className={classNames('font-semibold min-w-0', {
           'py-2': !childrenHaveInternalPadding,
-          'md:text-right': childrenAlign === 'right'
+          'md:text-right': childrenAlign === 'right',
+          truncate: typeof children === 'string'
         })}
       >
         {isLoading === true ? (

--- a/packages/docs/src/stories/atoms/CopyToClipboard.stories.tsx
+++ b/packages/docs/src/stories/atoms/CopyToClipboard.stories.tsx
@@ -41,3 +41,13 @@ export const Empty = TemplateEmpty.bind({})
 Empty.args = {
   value: ''
 }
+
+/** When content is identified as JSON string it will be rendered accordinling with a max-height and scrollable overflow */
+export const WithJsonContent: StoryFn<typeof CopyToClipboard> = (args) => (
+  <>
+    <CopyToClipboard value={'{"issuer_type":"cards"}'} />
+    <CopyToClipboard
+      value={`{"web-app":{"servlet":[{"servlet-name":"cofaxEmail","servlet-class":"org.cofax.cds.EmailServlet","init-param":{"mailHost":"mail1","mailHostOverride":"mail2"}},{"servlet-name":"cofaxAdmin","servlet-class":"org.cofax.cds.AdminServlet"},{"servlet-name":"fileServlet","servlet-class":"org.cofax.cds.FileServlet"},{"servlet-name":"cofaxTools","servlet-class":"org.cofax.cms.CofaxToolsServlet","init-param":{"templatePath":"toolstemplates/","log":1,"logLocation":"/usr/local/tomcat/logs/CofaxTools.log","logMaxSize":"","dataLog":1,"dataLogLocation":"/usr/local/tomcat/logs/dataLog.log","dataLogMaxSize":"","removePageCache":"/content/admin/remove?cache=pages&id=","removeTemplateCache":"/content/admin/remove?cache=templates&id=","fileTransferFolder":"/usr/local/tomcat/webapps/content/fileTransferFolder","lookInContext":1,"adminGroupID":4,"betaServer":true}}],"servlet-mapping":{"cofaxCDS":"/","cofaxEmail":"/cofaxutil/aemail/*","cofaxAdmin":"/admin/*","fileServlet":"/static/*","cofaxTools":"/tools/*"},"taglib":{"taglib-uri":"cofax.tld","taglib-location":"/WEB-INF/tlds/cofax.tld"}}}`}
+    />
+  </>
+)

--- a/packages/docs/src/stories/composite/ListDetailsItem.stories.tsx
+++ b/packages/docs/src/stories/composite/ListDetailsItem.stories.tsx
@@ -1,5 +1,6 @@
 import { A } from '#ui/atoms/A'
 import { Button } from '#ui/atoms/Button'
+import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
 import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { Text } from '#ui/atoms/Text'
@@ -108,3 +109,45 @@ export const ListWithActions: StoryFn<typeof ListDetailsItem> = (_args) => {
     </Section>
   )
 }
+
+/**
+ * ListDetailsItem allow to render long content without breaking the layout.
+ *
+ * Just be sure that the long children passed to the component can automatically handle the overflow, or content will be truncated by css.
+ */
+export const ListWithCopyToClipboardAndLongContent: StoryFn<
+  typeof ListDetailsItem
+> = (_args) => (
+  <>
+    <ListDetailsItem label='Status'>
+      <Button variant='link'>In transit</Button>
+    </ListDetailsItem>
+    <ListDetailsItem label='Tracking'>42314321ASD4545</ListDetailsItem>
+    <ListDetailsItem label='Payment instrument:'>
+      <CopyToClipboard value='{"issuer_type":"cards"}' />
+    </ListDetailsItem>
+    <ListDetailsItem label='Payment request data:'>
+      <CopyToClipboard
+        value={`{"web-app":{"servlet":[{"servlet-name":"cofaxEmail","servlet-class":"org.cofax.cds.EmailServlet","init-param":{"mailHost":"mail1","mailHostOverride":"mail2"}},{"servlet-name":"cofaxAdmin","servlet-class":"org.cofax.cds.AdminServlet"},{"servlet-name":"fileServlet","servlet-class":"org.cofax.cds.FileServlet"},{"servlet-name":"cofaxTools","servlet-class":"org.cofax.cms.CofaxToolsServlet","init-param":{"templatePath":"toolstemplates/","log":1,"logLocation":"/usr/local/tomcat/logs/CofaxTools.log","logMaxSize":"","dataLog":1,"dataLogLocation":"/usr/local/tomcat/logs/dataLog.log","dataLogMaxSize":"","removePageCache":"/content/admin/remove?cache=pages&id=","removeTemplateCache":"/content/admin/remove?cache=templates&id=","fileTransferFolder":"/usr/local/tomcat/webapps/content/fileTransferFolder","lookInContext":1,"adminGroupID":4,"betaServer":true}}],"servlet-mapping":{"cofaxCDS":"/","cofaxEmail":"/cofaxutil/aemail/*","cofaxAdmin":"/admin/*","fileServlet":"/static/*","cofaxTools":"/tools/*"},"taglib":{"taglib-uri":"cofax.tld","taglib-location":"/WEB-INF/tlds/cofax.tld"}}}`}
+      />
+    </ListDetailsItem>
+    <ListDetailsItem label='Description:'>
+      <CopyToClipboard value='Body-hugging crop top that will become the centerpiece of any summer outfit! 82% polyester, 18% spandex. Made with a smooth and comfortable microfiber yarn.' />
+    </ListDetailsItem>
+
+    <ListDetailsItem label='Long string (no whitespaces):'>
+      <CopyToClipboard value='eyJ2ZXJzaW9uIjoiMS4wLjAiLCJkZXZpY2VGaW5nZXJwcmludCI6IjFCMk0yWdsdsadsdsAwMDAwSHhaMmZZNHUwN3J6c2VLR1FKOWw6NDAiLCJwZXJzaXN0ZW50Q29va2llIjpbXSwiY29tcG9uZW50cyI6edsdsdsdxNmUzNdsdsdsdsdsdsdsdsdsdsdwMDAwMDAwMDAwMCJ9fQ' />
+    </ListDetailsItem>
+    <ListDetailsItem label='String child that do not handle overflow:'>
+      eyJ2ZXJzaW9uIjoiMS4wLjAiLCJkZXZpY2VGaW5nZXJwcmludCI6IjFCMk0yWdsdsadsdsAwMDAwSHhaMmZZNHUwN3J6c2VLR1FKOWw6NDAiLCJwZXJzaXN0ZW50Q29va2llIjpbXSwiY29tcG9uZW50cyI6edsdsdsdxNmUzNdsdsdsdsdsdsdsdsdsdsdwMDAwMDAwMDAwMCJ9fQ
+    </ListDetailsItem>
+    <ListDetailsItem label='Long content in <Text>:' childrenAlign='right'>
+      <Text>
+        customer, shipping_address, billing_address,
+        payment_method.payment_gateway, line_items.item, shipments.parcels,
+        line_items.stock_line_items.stock_item.sku.prices,
+        shipments.shipping_method
+      </Text>
+    </ListDetailsItem>
+  </>
+)


### PR DESCRIPTION
## What I did

I've switched the `<ListDetailsItem>` from flex to grid layout.
In this way is easier to handle the fact that children should not break the layout and grow too much, consuming label (left column) spacing.

Example of broken layout:
<img width="594" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/ac7b0de8-86d4-4775-baa5-1a3627ddc21b">


In this way we do not need to use custom props if children are instructed to use `overlfow: scroll` like `<CopyToClipboard>`  does.

When a long string is passed as children and it's recognized as plain string, it will be trimmed `...` if too long.

This won't happen if the child is a different JSX element.
Layout won't break, but the overflowing rule is demanded to the child (eg: <Text> will take multiple lines since it handle break-words itself)

I've also did a small change to the `CopyToClipboard` component: now if it finds a string that is JSON (eg: json string from the API) it will be rendered as code.

Preview:

- [ListDetailsItem](https://deploy-preview-546--commercelayer-app-elements.netlify.app/?path=/docs/composite-listdetailsitem--docs#list-with-copy-to-clipboard-and-long-content)
- [CopyToClipboard](https://deploy-preview-546--commercelayer-app-elements.netlify.app/?path=/docs/atoms-copytoclipboard--docs#with-json-content)


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
