### PR TITLE
Grouped button filter is now correctly rendered when multiple relationship-resources are selected as filter value

### DIFF
--- a/packages/app-elements/src/mocks/handlers.ts
+++ b/packages/app-elements/src/mocks/handlers.ts
@@ -102,6 +102,25 @@ export const handlers = [
     )
   }),
 
+  http.get(`https://*/api/markets/AlRevhXQga`, async ({ request }) => {
+    return HttpResponse.json({
+      data: {
+        id: 'AlRevhXQga',
+        type: 'markets',
+        links: {
+          self: 'https://alessani.commercelayer.co/api/markets/AlRevhXQga'
+        },
+        attributes: {
+          name: 'Europe'
+        },
+        meta: {
+          mode: 'test',
+          organization_id: 'WXlEOFrjnr'
+        }
+      }
+    })
+  }),
+
   ...customers,
   ...countries
 ]

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FilterNav.test.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FilterNav.test.tsx
@@ -1,0 +1,103 @@
+import { CoreSdkProvider } from '#providers/CoreSdkProvider'
+import { MockTokenProvider as TokenProvider } from '#providers/TokenProvider/MockTokenProvider'
+import { fireEvent, render, waitFor } from '@testing-library/react'
+import { FiltersNav } from './FiltersNav'
+import { instructions } from './mockedInstructions'
+
+describe('FiltersNav', () => {
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('should render filter nav buttons', () => {
+    const { container, getByText } = render(
+      <FiltersNav
+        instructions={instructions}
+        onFilterClick={() => {}}
+        onUpdate={() => {}}
+        queryString='?status_in=placed&status_in=approved&payment_status_in=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
+      />
+    )
+    expect(container).toBeVisible()
+
+    // grouped by status_in
+    expect(getByText('Order status · 2')).toBeVisible()
+    // payment_status_in is only one, so it should not be grouped
+    expect(getByText('Authorized')).toBeVisible()
+    // grouped by market_in, we have 3 markets
+    expect(getByText('Markets · 3')).toBeVisible()
+  })
+
+  test('should render single resource name (relationship) when there is only 1 filter for relationship selected (InputResourceGroup component)', async () => {
+    const { container, getByText } = render(
+      <TokenProvider kind='integration' appSlug='orders' devMode>
+        <CoreSdkProvider>
+          <FiltersNav
+            instructions={instructions}
+            onFilterClick={() => {}}
+            onUpdate={() => {}}
+            queryString='?market_id_in=AlRevhXQga' // mocked in msw as Europe
+          />
+        </CoreSdkProvider>
+      </TokenProvider>
+    )
+    expect(container).toBeVisible()
+
+    // grouped by status_in
+    await waitFor(() => {
+      expect(getByText('Europe')).toBeVisible()
+    })
+  })
+
+  test('should handle onFilterClick callback, returning current query string and clicked filter id', () => {
+    const onFilterClick = vi.fn()
+
+    const { getByText } = render(
+      <FiltersNav
+        instructions={instructions}
+        onFilterClick={onFilterClick}
+        onUpdate={() => {}}
+        queryString='?status_in=placed&status_in=approved&payment_status_in=authorized'
+      />
+    )
+
+    fireEvent.click(getByText('Authorized'))
+    expect(onFilterClick).toHaveBeenCalledWith(
+      'payment_status_in=authorized&status_in=placed&status_in=approved',
+      'payment_status_in'
+    )
+  })
+
+  test('should handle onUpdate callback, returning current query string and clicked filter id', () => {
+    const onUpdate = vi.fn()
+
+    const { getAllByTestId } = render(
+      <FiltersNav
+        instructions={instructions}
+        onFilterClick={() => {}}
+        onUpdate={onUpdate}
+        queryString='?status_in=placed&payment_status_in=authorized'
+      />
+    )
+
+    // expecting to find 3 remove buttons (all + status_in + payment_status_in)
+    const removeAllFiltersButton = getAllByTestId('ButtonFilter-remove')[0]
+    const removeStatusButton = getAllByTestId('ButtonFilter-remove')[1]
+    const removeAuthorizedButton = getAllByTestId('ButtonFilter-remove')[2]
+    expect(removeAllFiltersButton).toBeVisible()
+    expect(removeStatusButton).toBeVisible()
+    expect(removeAuthorizedButton).toBeVisible()
+    assertToBeDefined(removeAllFiltersButton)
+    assertToBeDefined(removeStatusButton)
+
+    // remove status_in filter, expecting that new query string only contains payment_status_in
+    fireEvent.click(removeStatusButton)
+    expect(onUpdate).toHaveBeenCalledWith('payment_status_in=authorized')
+
+    onUpdate.mockReset()
+
+    // remove all filters by clicking on remove all filters button
+    fireEvent.click(removeAllFiltersButton)
+    expect(onUpdate).toHaveBeenCalledWith('') // new query string is empty
+  })
+})

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
@@ -253,7 +253,8 @@ export function FiltersNav({
 
         if (
           instructionItem.render.component === 'inputResourceGroup' &&
-          arrValue[0] !== undefined
+          arrValue[0] !== undefined &&
+          arrValue.length === 1
         ) {
           return (
             <ButtonFilterFetchResource


### PR DESCRIPTION
## What I did

We discovered a broken behavior when using a filter item with the `InputResourceGroup` component and more resources were selected as active filters.
Instead of showing the grouped label (es: `Markets · 3`) we were displaying the name for the first resource only (fetching the resource name asynchronously).

This behavior should only happen when we only have 1 resource (relationship) as active filter.

I've now fixed the issue and handled new test cases.
 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
