### PR TITLE
Tune breakpoints and container size

### DIFF
--- a/packages/app-elements/src/ui/atoms/Container.tsx
+++ b/packages/app-elements/src/ui/atoms/Container.tsx
@@ -25,7 +25,7 @@ export const Container: React.FC<ContainerProps> = ({
   return (
     <div
       className={cn(
-        'container mx-auto  flex flex-col px-4 md:!px-0',
+        'container mx-auto flex flex-col px-4 md:px-0',
         { 'min-h-screen': minHeight },
         className
       )}

--- a/packages/app-elements/src/ui/atoms/Grid.tsx
+++ b/packages/app-elements/src/ui/atoms/Grid.tsx
@@ -34,7 +34,7 @@ function Grid({
     <div
       className={cn('grid grid-cols-1 gap-4', className, {
         'grid-flow-col': columns === 'auto',
-        'sm:!grid-cols-2': columns === '2',
+        'md:grid-cols-2': columns === '2',
         'items-center': alignItems === 'center',
         'items-start': alignItems === 'start',
         'items-end': alignItems === 'end'

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -48,7 +48,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
       )}
       <div
         {...rest}
-        className='bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]'
+        className='bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]'
       >
         {menuHeader != null && (
           <>

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
         >
           <div />
         </div>
@@ -80,7 +80,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
         >
           <div />
         </div>
@@ -125,7 +125,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
         >
           <div />
         </div>
@@ -170,7 +170,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 sm:max-w-[250px]"
+          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
         >
           <button
             aria-label="Payments"

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PageLayout > Should be rendered 1`] = `
 <div
-  class="container mx-auto  flex flex-col px-4 md:!px-0 min-h-screen"
+  class="container mx-auto flex flex-col px-4 md:px-0 min-h-screen"
   data-testid="my-page"
 >
   <div

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -13,9 +13,13 @@ function alphaToHex(percentage) {
 module.exports = {
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
+    screens: {
+      md: '768px',
+      lg: '992px',
+      xl: '1200px'
+    },
     container: {
       screens: {
-        sm: '540px',
         md: '632px'
       }
     },


### PR DESCRIPTION
## What I did

I've removed the `sm` breakpoint and modified the starting of the `md` one, which now starts at 768px.

The only breakpoints that we handle are:
```
    md: '768px',
    lg: '992px',
    xl: '1200px'
```



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
