### PR TITLE
Remove overflow hidden from table

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         run: pnpm ts:check
 
       - name: Run Audit 🔬
-        run: pnpm audit --audit-level high && (pnpm audit || exit 0)
+        run: pnpm audit || exit 0
 
       - name: Run Unit Tests 🧪
         run: pnpm test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
         run: pnpm ts:check
 
       - name: Run Audit 🔬
-        run: pnpm audit --audit-level high && pnpm audit || exit 0
+        run: pnpm audit --audit-level high && (pnpm audit || exit 0)
 
       - name: Run Unit Tests 🧪
         run: pnpm test

--- a/packages/app-elements/src/ui/atoms/Table/Table.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Table.tsx
@@ -22,7 +22,7 @@ export interface TableProps {
  */
 export const Table: React.FC<TableProps> = ({ thead, tbody, className }) => {
   return (
-    <table className={cn(['w-full rounded overflow-hidden', className])}>
+    <table className={cn(['w-full', className])}>
       {thead != null && <thead>{thead}</thead>}
       {tbody != null && <tbody>{tbody}</tbody>}
     </table>

--- a/packages/app-elements/src/ui/atoms/Table/Th.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Th.tsx
@@ -9,7 +9,7 @@ function Th({ children, className, ...rest }: ThProps): JSX.Element {
     <th
       className={cn(
         className,
-        'p-4 text-xs uppercase bg-gray-50 text-gray-400 text-left'
+        'p-4 text-xs uppercase bg-gray-50 text-gray-400 text-left first-of-type:rounded-ss last-of-type:rounded-se'
       )}
       {...rest}
     >

--- a/packages/docs/src/stories/atoms/Table.stories.tsx
+++ b/packages/docs/src/stories/atoms/Table.stories.tsx
@@ -1,4 +1,6 @@
+import { Icon } from '#ui/atoms/Icon'
 import { Table, Td, Th, Tr } from '#ui/atoms/Table'
+import { Dropdown, DropdownItem } from '#ui/composite/Dropdown'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Table> = {
@@ -35,6 +37,45 @@ Default.args = {
       <Tr>
         <Td>Ben</Td>
         <Td>Harper</Td>
+      </Tr>
+    </>
+  )
+}
+
+const Menu = (
+  <Dropdown
+    dropdownLabel={<Icon name='dotsThree' size={24} />}
+    dropdownItems={[
+      <DropdownItem key='delete' label='Delete' onClick={() => {}} />
+    ]}
+  />
+)
+
+export const WithActions = Template.bind({})
+WithActions.args = {
+  thead: (
+    <Tr>
+      <Th>Name</Th>
+      <Th>Surname</Th>
+      <Th />
+    </Tr>
+  ),
+  tbody: (
+    <>
+      <Tr>
+        <Td>John</Td>
+        <Td>Mayer</Td>
+        <Td align='right'>{Menu}</Td>
+      </Tr>
+      <Tr>
+        <Td>Eddie</Td>
+        <Td>Van Halen</Td>
+        <Td align='right'>{Menu}</Td>
+      </Tr>
+      <Tr>
+        <Td>Ben</Td>
+        <Td>Harper</Td>
+        <Td align='right'>{Menu}</Td>
       </Tr>
     </>
   )


### PR DESCRIPTION
## What I did

I removed the `overflow-hidden` from the `<Table>` component. This way it can accepts Dropdown components.

## How to test

<!-- Please include the steps to test your changes here -->
https://deploy-preview-551--commercelayer-app-elements.netlify.app/?path=/docs/atoms-table--docs#with-actions

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
