### PR TITLE
Add `Tooltip` component

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -52,6 +52,7 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.50.1",
     "react-select": "^5.8.0",
+    "react-tooltip": "^5.26.2",
     "swr": "^2.2.4",
     "ts-invariant": "^0.10.3",
     "type-fest": "^4.10.2",

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -121,6 +121,11 @@ export {
 export { Tab, Tabs, type TabProps, type TabsProps } from '#ui/atoms/Tabs'
 export { Tag, type TagProps } from '#ui/atoms/Tag'
 export { Text, type TextProps } from '#ui/atoms/Text'
+export {
+  Tooltip,
+  type TooltipProps,
+  type TooltipRefProps
+} from '#ui/atoms/Tooltip'
 // Composite
 export {
   ActionButtons,

--- a/packages/app-elements/src/ui/atoms/Tooltip.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.test.tsx
@@ -1,0 +1,41 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react'
+import { Tooltip } from './Tooltip'
+
+describe('Tooltip', () => {
+  const originalResizeObserver = global.ResizeObserver
+  beforeAll(() => {
+    global.ResizeObserver = class ResizeObserver {
+      observe(): void {}
+      unobserve(): void {}
+      disconnect(): void {}
+    }
+  })
+  afterAll(() => {
+    global.ResizeObserver = originalResizeObserver
+  })
+
+  test('render a tooltip', async () => {
+    const { getByText } = render(
+      <Tooltip id='my-tooltip' label='discover more' content='content...' />
+    )
+    expect(getByText('discover more')).toBeInTheDocument()
+  })
+
+  test('should open tooltip on mouse hover', async () => {
+    const { getByText } = render(
+      <Tooltip
+        id='my-tooltip'
+        label='Hover me'
+        content={<div>This is a tooltip.</div>}
+      />
+    )
+
+    act(() => {
+      fireEvent.mouseEnter(getByText('Hover me'))
+    })
+
+    await waitFor(() => {
+      expect(getByText('This is a tooltip.')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/app-elements/src/ui/atoms/Tooltip.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.tsx
@@ -1,0 +1,67 @@
+import cn from 'classnames'
+import { forwardRef, type ReactNode } from 'react'
+import {
+  Tooltip as ReactTooltip,
+  type PlacesType,
+  type TooltipRefProps
+} from 'react-tooltip'
+
+export { type TooltipRefProps } from 'react-tooltip'
+
+export interface TooltipProps {
+  /** Tooltip unique identifier  */
+  id: string
+  /** Label that triggers the opening of the tooltip  */
+  label: ReactNode
+  /** Content to be rendered inside the tooltip box */
+  content: ReactNode
+  /**
+   * Desired direction where the tooltip content will be opened in relation to the label.
+   * If the tooltip is too close to the edge of the screen, it will be repositioned automatically.
+   * @default 'top'
+   */
+  direction?: Extract<
+    PlacesType,
+    'top' | 'top-start' | 'top-end' | 'bottom' | 'bottom-start' | 'bottom-end'
+  >
+}
+
+/**
+ * Render a label that will open a tooltip box when hovered/focused.
+ * Both label and content can be any ReactNode.
+ *
+ * This component is a wrapper around react-tooltip.
+ */
+export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
+  ({ id, label, content, direction = 'top' }, ref): JSX.Element => {
+    return (
+      <>
+        <span
+          aria-describedby={id}
+          data-tooltip-id={id}
+          className='cursor-pointer'
+        >
+          {label}
+        </span>
+        <ReactTooltip
+          id={id}
+          ref={ref}
+          place={direction}
+          clickable
+          imperativeModeOnly={ref != null}
+          // We are using our own styles, by applying tailwind classes
+          // https://react-tooltip.com/docs/examples/styling#base-styles
+          disableStyleInjection
+          className='rounded bg-black text-white px-4 py-3 text-sm font-semibold w-max'
+          classNameArrow={cn('w-2 h-2', {
+            'rotate-[45deg]': direction.includes('top'),
+            'rotate-[225deg]': direction.includes('bottom')
+          })}
+        >
+          {content}
+        </ReactTooltip>
+      </>
+    )
+  }
+)
+Tooltip.displayName = 'Tooltip'

--- a/packages/docs/src/stories/atoms/Tooltip.stories.tsx
+++ b/packages/docs/src/stories/atoms/Tooltip.stories.tsx
@@ -1,0 +1,97 @@
+import { Icon } from '#ui/atoms/Icon'
+import { Text } from '#ui/atoms/Text'
+import { Tooltip, type TooltipRefProps } from '#ui/atoms/Tooltip'
+import { type Meta, type StoryFn } from '@storybook/react'
+import { useRef } from 'react'
+
+const setup: Meta<typeof Tooltip> = {
+  title: 'Atoms/Tooltip',
+  component: Tooltip,
+  parameters: {
+    layout: 'padded'
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          padding: '50px'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
+}
+export default setup
+
+const Template: StoryFn<typeof Tooltip> = (args) => <Tooltip {...args} />
+
+export const Default = Template.bind({})
+Default.args = {
+  id: 'my-tooltip',
+  label: 'Hover me',
+  content: 'This is a tooltip.'
+}
+
+/**
+ * Both label and content can be any ReactNode.
+ **/
+export const WithCustomElements = Template.bind({})
+WithCustomElements.args = {
+  id: 'my-tooltip2',
+  label: <Icon name='info' className='inline' weight='bold' size={20} />,
+  content: (
+    <div>
+      <Text variant='warning' tag='div' weight='bold'>
+        <Icon
+          name='folderOpen'
+          style={{
+            display: 'inline-block'
+          }}
+        />{' '}
+        I am a JSX element
+      </Text>
+    </div>
+  )
+}
+
+/**
+ * Tooltip works by default as inline element, so it can be part of a sentence.
+ **/
+export const Inline: StoryFn<typeof Tooltip> = (args) => (
+  <div>
+    We can have an{' '}
+    <Tooltip
+      id='inline-tooltip'
+      label={<a>inline tooltip</a>}
+      content='Lorem ipsum is a placeholder text commonly used.'
+      direction='top'
+    />{' '}
+    as part of a sentence.
+  </div>
+)
+
+/**
+ * Tooltip can be also controller by passing a React ref and using its custom `open` and `close` method.
+ *
+ * In this example we are controlling the opening/closing when hovering the parent element.
+ * */
+export const ControlledRef: StoryFn<typeof Tooltip> = () => {
+  const ref = useRef<TooltipRefProps>(null)
+  const open = (): void => ref.current?.open()
+  const close = (): void => ref.current?.close()
+
+  return (
+    <div onMouseEnter={open} onMouseLeave={close}>
+      Hover me{' '}
+      <Tooltip
+        id='controlled-tooltip'
+        label={<Icon name='info' className='inline' weight='bold' size={20} />}
+        content='Tooltip arrow centered on the icon, but triggered from the entire parent div.'
+        direction='bottom-start'
+        ref={ref}
+      />{' '}
+      to discover more.
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       react-select:
         specifier: ^5.8.0
         version: 5.8.0(@types/react@18.2.55)(react-dom@18.2.0)(react@18.2.0)
+      react-tooltip:
+        specifier: ^5.26.2
+        version: 5.26.2(react-dom@18.2.0)(react@18.2.0)
       swr:
         specifier: ^2.2.4
         version: 2.2.4(react@18.2.0)
@@ -2453,25 +2456,25 @@ packages:
     resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
     dependencies:
       '@floating-ui/utils': 0.1.2
+    dev: false
 
   /@floating-ui/core@1.6.0:
     resolution: {integrity: sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==}
     dependencies:
       '@floating-ui/utils': 0.2.1
-    dev: false
 
   /@floating-ui/dom@1.5.2:
     resolution: {integrity: sha512-6ArmenS6qJEWmwzczWyhvrXRdI/rI78poBcW0h/456+onlabit+2G+QxHx5xTOX60NBJQXjsCLFbW2CmsXpUog==}
     dependencies:
       '@floating-ui/core': 1.4.1
       '@floating-ui/utils': 0.1.2
+    dev: false
 
   /@floating-ui/dom@1.6.1:
     resolution: {integrity: sha512-iA8qE43/H5iGozC3W0YSnVSW42Vh522yyM1gj+BqRwVsTNOyr231PsXDaV04yT39PsO0QL2QpbI/M0ZaLUQgRQ==}
     dependencies:
       '@floating-ui/core': 1.6.0
       '@floating-ui/utils': 0.2.1
-    dev: false
 
   /@floating-ui/react-dom@2.0.2(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==}
@@ -2479,7 +2482,7 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/dom': 1.5.2
+      '@floating-ui/dom': 1.6.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: true
@@ -2510,10 +2513,10 @@ packages:
 
   /@floating-ui/utils@0.1.2:
     resolution: {integrity: sha512-ou3elfqG/hZsbmF4bxeJhPHIf3G2pm0ujc39hYEZrfVqt7Vk/Zji6CXc3W0pmYM8BW1g40U+akTl9DKZhFhInQ==}
+    dev: false
 
   /@floating-ui/utils@0.2.1:
     resolution: {integrity: sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q==}
-    dev: false
 
   /@gar/promisify@1.1.3:
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
@@ -13387,6 +13390,18 @@ packages:
       react: 18.2.0
       tslib: 2.6.2
     dev: true
+
+  /react-tooltip@5.26.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-C1qHiqWYn6l5c98kL/NKFyJSw5G11vUVJkgOPcKgn306c5iL5317LxMNn5Qg1GSSM7Qvtsd6KA5MvwfgxFF7Dg==}
+    peerDependencies:
+      react: '>=16.14.0'
+      react-dom: '>=16.14.0'
+    dependencies:
+      '@floating-ui/dom': 1.6.1
+      classnames: 2.5.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
 
   /react-transition-group@4.4.5(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}


### PR DESCRIPTION
## What I did

I've added a Tooltip component wrapping the `react-tooltip` library.

Examples and documentation [here](https://deploy-preview-553--commercelayer-app-elements.netlify.app/?path=/docs/atoms-tooltip--docs)


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
