### PR TITLE
`id` is now optional for the `Tooltip` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tooltip.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.test.tsx
@@ -23,11 +23,7 @@ describe('Tooltip', () => {
 
   test('should open tooltip on mouse hover', async () => {
     const { getByText } = render(
-      <Tooltip
-        id='my-tooltip'
-        label='Hover me'
-        content={<div>This is a tooltip.</div>}
-      />
+      <Tooltip label='Hover me' content='This is a tooltip.' />
     )
 
     act(() => {
@@ -36,6 +32,10 @@ describe('Tooltip', () => {
 
     await waitFor(() => {
       expect(getByText('This is a tooltip.')).toBeInTheDocument()
+      expect(getByText('This is a tooltip.')).toHaveAttribute(
+        'id',
+        'hoverme-thisisatooltip-top'
+      )
     })
   })
 })

--- a/packages/app-elements/src/ui/atoms/Tooltip.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.tsx
@@ -1,3 +1,4 @@
+import { getInnerText } from '#utils/children'
 import cn from 'classnames'
 import { forwardRef, type ReactNode } from 'react'
 import {
@@ -10,7 +11,7 @@ export { type TooltipRefProps } from 'react-tooltip'
 
 export interface TooltipProps {
   /** Tooltip unique identifier  */
-  id: string
+  id?: string
   /** Label that triggers the opening of the tooltip  */
   label: ReactNode
   /** Content to be rendered inside the tooltip box */
@@ -33,11 +34,19 @@ export interface TooltipProps {
  * This component is a wrapper around react-tooltip.
  */
 export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
-  ({ id, label, content, direction = 'top' }, ref): JSX.Element => {
+  (
+    {
+      label,
+      content,
+      direction = 'top',
+      id = `${getSanitizedInnerText(label)}-${getSanitizedInnerText(content)}-${direction}`
+    },
+    ref
+  ): JSX.Element => {
     return (
       <>
         <span
-          aria-describedby={id}
+          aria-description={getInnerText(content)}
           data-tooltip-id={id}
           className='cursor-pointer'
         >
@@ -64,4 +73,9 @@ export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
     )
   }
 )
+
 Tooltip.displayName = 'Tooltip'
+
+function getSanitizedInnerText(node: ReactNode): string {
+  return getInnerText(node).replace(/\W+/g, '').toLowerCase()
+}

--- a/packages/docs/src/stories/atoms/Tooltip.stories.tsx
+++ b/packages/docs/src/stories/atoms/Tooltip.stories.tsx
@@ -28,7 +28,6 @@ const Template: StoryFn<typeof Tooltip> = (args) => <Tooltip {...args} />
 
 export const Default = Template.bind({})
 Default.args = {
-  id: 'my-tooltip',
   label: 'Hover me',
   content: 'This is a tooltip.'
 }
@@ -38,7 +37,6 @@ Default.args = {
  **/
 export const WithCustomElements = Template.bind({})
 WithCustomElements.args = {
-  id: 'my-tooltip2',
   label: <Icon name='info' className='inline' weight='bold' size={20} />,
   content: (
     <div>
@@ -49,7 +47,7 @@ WithCustomElements.args = {
             display: 'inline-block'
           }}
         />{' '}
-        I am a JSX element
+        I'm a JSX element
       </Text>
     </div>
   )
@@ -62,7 +60,6 @@ export const Inline: StoryFn<typeof Tooltip> = (args) => (
   <div>
     We can have an{' '}
     <Tooltip
-      id='inline-tooltip'
       label={<a>inline tooltip</a>}
       content='Lorem ipsum is a placeholder text commonly used.'
       direction='top'
@@ -85,9 +82,8 @@ export const ControlledRef: StoryFn<typeof Tooltip> = () => {
     <div onMouseEnter={open} onMouseLeave={close}>
       Hover me{' '}
       <Tooltip
-        id='controlled-tooltip'
         label={<Icon name='info' className='inline' weight='bold' size={20} />}
-        content='Tooltip arrow centered on the icon, but triggered from the entire parent div.'
+        content='Tooltip arrow centered on the icon, but triggered from the entire parent "div".'
         direction='bottom-start'
         ref={ref}
       />{' '}


### PR DESCRIPTION
## What I did

I made `id` optional for the `Tooltip` component.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
