### PR TITLE
Add `time` to the InputDate and HookedInputDate components

### DIFF
--- a/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.css
+++ b/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.css
@@ -1,10 +1,14 @@
+:root {
+  --var-border-color: #e6e7e7;
+}
+
 .react-datepicker-wrapper {
   width: 100%;
 }
 
 .react-datepicker {
   font-family: inherit;
-  border-color: #e6e7e7;
+  border-color: var(--var-border-color);
   padding: 1px;
   box-shadow: 2px 2px 0 #f8f8f8;
 }
@@ -15,7 +19,11 @@
 
 .react-datepicker__header {
   background-color: #f8f8f8;
-  border-color: #e6e7e7;
+  border-color: var(--var-border-color);
+}
+
+.react-datepicker__time-container {
+  border-color: var(--var-border-color);
 }
 
 .react-datepicker__navigation {
@@ -63,7 +71,12 @@
   border: 1px solid #f8f8f8;
 }
 
-.react-datepicker__day--selected {
+.react-datepicker__day--selected,
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected {
   background-color: #404141;
   color: #fff;
 }
@@ -92,6 +105,11 @@
 .react-datepicker__quarter-text--in-range:hover,
 .react-datepicker__year-text--selected:hover,
 .react-datepicker__year-text--in-selecting-range:hover,
-.react-datepicker__year-text--in-range:hover {
+.react-datepicker__year-text--in-range:hover,
+.react-datepicker__time-container
+  .react-datepicker__time
+  .react-datepicker__time-box
+  ul.react-datepicker__time-list
+  li.react-datepicker__time-list-item--selected:hover {
   background-color: #404141;
 }

--- a/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.tsx
@@ -33,6 +33,10 @@ export interface InputDateProps extends InputWrapperBaseProps {
    */
   placeholder?: string
   /**
+   * Show the time selector
+   */
+  showTimeSelect?: boolean | undefined
+  /**
    * String to be parsed as formatter (eg. MM/dd/yyyy, dd-MM-yy, ect...).
    * When undefined, will autodetect format from user's browser
    */
@@ -64,6 +68,7 @@ export const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
       value,
       wrapperClassName,
       inputClassName,
+      showTimeSelect = false,
       format,
       placeholder,
       minDate,
@@ -77,7 +82,7 @@ export const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
     },
     ref
   ): JSX.Element => {
-    const dateFormat = format ?? detectDateFormat()
+    const dateFormat = format ?? detectDateTimeFormat(showTimeSelect)
     return (
       <InputWrapper
         {...rest}
@@ -92,6 +97,7 @@ export const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
             selected={value}
             onChange={onChange}
             dateFormat={dateFormat}
+            showTimeSelect={showTimeSelect}
             placeholderText={
               autoPlaceholder === true ? dateFormat.toLowerCase() : placeholder
             }
@@ -127,11 +133,16 @@ export const InputDateComponent = forwardRef<DatePicker, InputDateProps>(
 
 InputDateComponent.displayName = 'InputDateComponent'
 
-function detectDateFormat(): string {
+function detectDateTimeFormat(showTime: boolean): string {
   const date = new Date(2023, 11, 15) //  15th of December
-  let format = date.toLocaleDateString()
-  format = format.replace('15', 'dd')
-  format = format.replace('12', 'MM')
-  format = format.replace('2023', 'yyyy')
-  return format
+
+  const dateFormat = date
+    .toLocaleDateString()
+    .replace('15', 'dd')
+    .replace('12', 'MM')
+    .replace('2023', 'yyyy')
+
+  const timeFormat = ', h:mm aa'
+
+  return `${dateFormat}${showTime ? timeFormat : ''}`
 }

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputDate.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputDate.stories.tsx
@@ -15,7 +15,18 @@ const setup: Meta<typeof HookedInputDate> = {
         type: 'code'
       }
     }
-  }
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          paddingBottom: '300px'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
 }
 export default setup
 

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputDateRange.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputDateRange.stories.tsx
@@ -15,7 +15,18 @@ const setup: Meta<typeof HookedInputDateRange> = {
         type: 'code'
       }
     }
-  }
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          paddingBottom: '300px'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
 }
 export default setup
 

--- a/packages/docs/src/stories/forms/ui/InputDate.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputDate.stories.tsx
@@ -7,7 +7,18 @@ const setup: Meta<typeof InputDate> = {
   component: InputDate,
   parameters: {
     layout: 'padded'
-  }
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          paddingBottom: '300px'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
 }
 export default setup
 
@@ -24,7 +35,8 @@ Default.args = {
 export const WithMinValue = Template.bind({})
 WithMinValue.args = {
   placeholder: 'select a future date',
-  minDate: new Date()
+  minDate: new Date(),
+  showTimeSelect: true
 }
 
 export const AutoPlaceholder = Template.bind({})
@@ -36,6 +48,12 @@ export const WithHint = Template.bind({})
 WithHint.args = {
   label: 'Shipping date',
   hint: { text: 'Please enter a valid date ' }
+}
+
+export const WithTimeSelect = Template.bind({})
+WithTimeSelect.args = {
+  label: 'Starts on',
+  showTimeSelect: true
 }
 
 export const WithError = Template.bind({})

--- a/packages/docs/src/stories/forms/ui/InputDateRange.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputDateRange.stories.tsx
@@ -7,7 +7,18 @@ const setup: Meta<typeof InputDateRange> = {
   component: InputDateRange,
   parameters: {
     layout: 'padded'
-  }
+  },
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          paddingBottom: '300px'
+        }}
+      >
+        <Story />
+      </div>
+    )
+  ]
 }
 export default setup
 


### PR DESCRIPTION
## What I did

I added `time` to the InputDate and HookedInputDate components.

<img width="689" alt="Screenshot 2024-02-16 alle 21 27 32" src="https://github.com/commercelayer/app-elements/assets/1681269/6022d0b6-35d0-4540-8d52-ccec2a733385">

## How to test

https://deploy-preview-556--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputdate--docs#with-time-select

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
