### PR TITLE
`GetParams` type better works with `createTypedRoute`

### DIFF
--- a/packages/app-elements/src/helpers/route.ts
+++ b/packages/app-elements/src/helpers/route.ts
@@ -74,10 +74,42 @@ export const createTypedRoute =
  *   name?: string | undefined;
  * }
  * ```
+ *
+ * @example
+ * ```ts
+ * const route = createTypedRoute<{ type: 'A' | 42; enabled?: boolean }>()(
+ *   '/orders/:type/:enabled?/'
+ * )
+ *
+ * type Params = GetParams<typeof route>
+ *
+ * // equivalent to
+ *
+ * type Params = {
+ *   type: 'A' | '42';
+ *   enabled?: "false" | "true" | undefined;
+ * }
+ * ```
  */
 export type GetParams<R extends { makePath: (...arg: any[]) => string }> = {
-  [K in keyof Parameters<R['makePath']>[0]]: string
+  [K in keyof Parameters<R['makePath']>[0]]: Exclude<
+    ToLiteral<Parameters<R['makePath']>[0][K]>,
+    'undefined' | 'null'
+  >
 }
+
+/**
+ * Cast a valid `string | number | bigint | boolean | null | undefined` to literal.
+ *
+ * @example
+ * ```ts
+ * type N = ToLiteral<42> //= '42'
+ * type B = ToLiteral<boolean> //= 'false' | 'true'
+ * ```
+ */
+type ToLiteral<
+  V extends string | number | bigint | boolean | null | undefined
+> = `${V}`
 
 interface Route<
   Path extends `/${string}/` | `/`,


### PR DESCRIPTION

## What I did

I updated the `GetParams` type.

Before this PR:
```ts
const route = createTypedRoute<{ type: 'A' | 42; enabled?: boolean }>()(
  '/orders/:type/:enabled?/'
)

type Params = GetParams<typeof route>

// equivalent to

type Params = {
  type: string;
  enabled?: string | undefined;
}
```

After this PR:
```ts
const route = createTypedRoute<{ type: 'A' | 42; enabled?: boolean }>()(
  '/orders/:type/:enabled?/'
)

type Params = GetParams<typeof route>

// equivalent to

type Params = {
  type: 'A' | '42';
  enabled?: "false" | "true" | undefined;
}
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
