### PR TITLE
Add `defaultTab` to `Tabs` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tabs.tsx
+++ b/packages/app-elements/src/ui/atoms/Tabs.tsx
@@ -37,7 +37,7 @@ export interface TabsProps {
    */
   keepAlive?: boolean
   /**
-   * Optional tab index to activate a particular tab at component mount. First tab has index 0.
+   * Optional prop to define which tab needs to be activated at component mount by providing its numerical index. First tab has index 0.
    */
   defaultTab?: number
 }
@@ -92,7 +92,11 @@ function Tabs({
   }, [activeIndex, onTabSwitch])
 
   useEffect(() => {
-    if (defaultTab != null && defaultTab !== firstActiveIndex) {
+    if (
+      defaultTab != null &&
+      defaultTab !== firstActiveIndex &&
+      defaultTab < Children.count(children)
+    ) {
       setActiveIndex(defaultTab)
     }
   }, [defaultTab, setActiveIndex])

--- a/packages/app-elements/src/ui/atoms/Tabs.tsx
+++ b/packages/app-elements/src/ui/atoms/Tabs.tsx
@@ -59,7 +59,9 @@ function Tabs({
       ),
     [children]
   )
-  const [activeIndex, setActiveIndex] = useState(firstActiveIndex ?? 0)
+  const [activeIndex, setActiveIndex] = useState(
+    defaultTab ?? firstActiveIndex ?? 0
+  )
 
   useEffect(
     function validateChildren() {
@@ -90,16 +92,6 @@ function Tabs({
       onTabSwitch(activeIndex)
     }
   }, [activeIndex, onTabSwitch])
-
-  useEffect(() => {
-    if (
-      defaultTab != null &&
-      defaultTab !== firstActiveIndex &&
-      defaultTab < Children.count(children)
-    ) {
-      setActiveIndex(defaultTab)
-    }
-  }, [defaultTab, setActiveIndex])
 
   return (
     <div id={id} role='tablist' className={className} {...rest}>

--- a/packages/app-elements/src/ui/atoms/Tabs.tsx
+++ b/packages/app-elements/src/ui/atoms/Tabs.tsx
@@ -18,7 +18,7 @@ export interface TabsProps {
    */
   className?: string
   /**
-   * Event the fires every time a tab is activated. Note that this also fires on first render.
+   * Event that fires every time a tab is activated. Note that this also fires on first render.
    */
   onTabSwitch?: (tabIndex: number) => void
   /**
@@ -33,9 +33,13 @@ export interface TabsProps {
    */
   children: Array<React.ReactElement<TabProps, typeof Tab> | null>
   /**
-   * This controls whether the content of inactive panels should be un-mounted or kept mounted but hidden.
+   * This controls whether the content of inactive tabs should be un-mounted or kept mounted but hidden.
    */
   keepAlive?: boolean
+  /**
+   * Optional tab index to activate a particular tab at component mount. First tab has index 0.
+   */
+  defaultTab?: number
 }
 
 function Tabs({
@@ -44,6 +48,7 @@ function Tabs({
   onTabSwitch,
   className,
   keepAlive,
+  defaultTab,
   ...rest
 }: TabsProps): JSX.Element {
   // since we allow `null` child (conditional rendering of <Tab>), we need to understand the first not null child to set as initial active
@@ -85,6 +90,12 @@ function Tabs({
       onTabSwitch(activeIndex)
     }
   }, [activeIndex, onTabSwitch])
+
+  useEffect(() => {
+    if (defaultTab != null && defaultTab !== firstActiveIndex) {
+      setActiveIndex(defaultTab)
+    }
+  }, [defaultTab, setActiveIndex])
 
   return (
     <div id={id} role='tablist' className={className} {...rest}>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added a numerical `defaultTab` prop to `Tabs` component to provide a way to define if a particular tab needs to be activated at component mount, instead of the first one available.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
