### PR TITLE
Show the option label when selected value is a string

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
@@ -15,14 +15,14 @@ describe('FiltersNav', () => {
         instructions={instructions}
         onFilterClick={() => {}}
         onUpdate={() => {}}
-        queryString='?status_in=placed&status_in=approved&payment_status_in=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
+        queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
       />
     )
     expect(container).toBeVisible()
 
     // grouped by status_in
     expect(getByText('Order status · 2')).toBeVisible()
-    // payment_status_in is only one, so it should not be grouped
+    // payment_status_eq is only one, so it should not be grouped
     expect(getByText('Authorized')).toBeVisible()
     // grouped by market_in, we have 3 markets
     expect(getByText('Markets · 3')).toBeVisible()
@@ -57,14 +57,14 @@ describe('FiltersNav', () => {
         instructions={instructions}
         onFilterClick={onFilterClick}
         onUpdate={() => {}}
-        queryString='?status_in=placed&status_in=approved&payment_status_in=authorized'
+        queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized'
       />
     )
 
     fireEvent.click(getByText('Authorized'))
     expect(onFilterClick).toHaveBeenCalledWith(
-      'payment_status_in=authorized&status_in=placed&status_in=approved',
-      'payment_status_in'
+      'payment_status_eq=authorized&status_in=placed&status_in=approved',
+      'payment_status_eq'
     )
   })
 
@@ -76,11 +76,11 @@ describe('FiltersNav', () => {
         instructions={instructions}
         onFilterClick={() => {}}
         onUpdate={onUpdate}
-        queryString='?status_in=placed&payment_status_in=authorized'
+        queryString='?status_in=placed&payment_status_eq=authorized'
       />
     )
 
-    // expecting to find 3 remove buttons (all + status_in + payment_status_in)
+    // expecting to find 3 remove buttons (all + status_in + payment_status_eq)
     const removeAllFiltersButton = getAllByTestId('ButtonFilter-remove')[0]
     const removeStatusButton = getAllByTestId('ButtonFilter-remove')[1]
     const removeAuthorizedButton = getAllByTestId('ButtonFilter-remove')[2]
@@ -90,9 +90,9 @@ describe('FiltersNav', () => {
     assertToBeDefined(removeAllFiltersButton)
     assertToBeDefined(removeStatusButton)
 
-    // remove status_in filter, expecting that new query string only contains payment_status_in
+    // remove status_in filter, expecting that new query string only contains payment_status_eq
     fireEvent.click(removeStatusButton)
-    expect(onUpdate).toHaveBeenCalledWith('payment_status_in=authorized')
+    expect(onUpdate).toHaveBeenCalledWith('payment_status_eq=authorized')
 
     onUpdate.mockReset()
 

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
@@ -401,16 +401,21 @@ function getButtonFilterLabel({
   values: string | string[]
   instructionItem: FiltersInstructionItem
 }): string {
+  const isSingleElementArray = Array.isArray(values) && values.length === 1
+  const isString = typeof values === 'string'
+
   if (
     isItemOptions(instructionItem) &&
     'options' in instructionItem.render.props &&
     instructionItem.render.props.options != null &&
     instructionItem.render.props.options.length > 0 &&
-    values.length === 1
+    (isSingleElementArray || isString)
   ) {
+    const optionValue = Array.isArray(values) ? values[0] : values
+
     return (
       instructionItem.render.props.options.find(
-        ({ value }) => value === values[0]
+        ({ value }) => value === optionValue
       )?.label ?? instructionItem.label
     )
   }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToSdk.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToSdk.test.ts
@@ -18,16 +18,16 @@ describe('adaptFormValuesToSdk', () => {
       adaptFormValuesToSdk({
         formValues: {
           market_id_in: ['dFDdasdgAN', 'KToVGDooQp'],
-          status_in: ['cancelled'],
-          payment_status_in: ['paid', 'refunded'],
+          status_in: ['cancelled', 'approved'],
+          payment_status_eq: ['paid'],
           fulfillment_status_in: ['fulfilled']
         },
         instructions
       })
     ).toStrictEqual({
       market_id_in: 'dFDdasdgAN,KToVGDooQp',
-      status_in: 'cancelled',
-      payment_status_in: 'paid,refunded',
+      status_in: 'cancelled,approved',
+      payment_status_eq: 'paid',
       fulfillment_status_in: 'fulfilled',
       archived_at_null: true
     })
@@ -39,7 +39,7 @@ describe('adaptFormValuesToSdk', () => {
         formValues: {
           market_id_in: [],
           status_in: [],
-          payment_status_in: [],
+          payment_status_eq: [],
           fulfillment_status_in: [],
           archived_at_null: 'only'
         },
@@ -57,7 +57,7 @@ describe('adaptFormValuesToSdk', () => {
         formValues: {
           market_id_in: [],
           status_in: [],
-          payment_status_in: [],
+          payment_status_eq: [],
           fulfillment_status_in: [],
           archived_at_null: undefined
         },
@@ -75,7 +75,7 @@ describe('adaptFormValuesToSdk', () => {
         formValues: {
           market_id_in: [],
           status_in: [],
-          payment_status_in: [],
+          payment_status_eq: [],
           fulfillment_status_in: [],
           archived_at_null: undefined,
           timePreset: 'today',
@@ -97,7 +97,7 @@ describe('adaptFormValuesToSdk', () => {
         formValues: {
           market_id_in: [],
           status_in: [],
-          payment_status_in: [],
+          payment_status_eq: [],
           fulfillment_status_in: [],
           archived_at_null: undefined,
           timePreset: 'today'
@@ -118,7 +118,7 @@ describe('adaptFormValuesToSdk', () => {
         formValues: {
           market_id_in: [],
           status_in: [],
-          payment_status_in: [],
+          payment_status_eq: [],
           fulfillment_status_in: [],
           archived_at_null: undefined,
           timePreset: 'custom',

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
@@ -12,7 +12,7 @@ describe('adaptUrlQueryToFormValues', () => {
     ).toStrictEqual({
       market_id_in: ['dFDdasdgAN', 'KToVGDooQp'],
       status_in: ['cancelled'],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,
@@ -37,7 +37,7 @@ describe('adaptUrlQueryToFormValues', () => {
     ).toStrictEqual({
       market_id_in: [],
       status_in: ['approved'],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,
@@ -62,7 +62,7 @@ describe('adaptUrlQueryToFormValues', () => {
     ).toStrictEqual({
       market_id_in: [],
       status_in: [],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,
@@ -82,13 +82,13 @@ describe('adaptUrlQueryToFormValues', () => {
     expect(
       adaptUrlQueryToFormValues({
         queryString:
-          'payment_status_in=invalid-value&status_in=draft&status_in=placed',
+          'payment_status_eq=invalid-value&status_in=draft&status_in=placed',
         instructions
       })
     ).toStrictEqual({
       market_id_in: [],
       status_in: ['placed'],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,
@@ -114,7 +114,7 @@ describe('adaptUrlQueryToFormValues', () => {
     ).toStrictEqual({
       market_id_in: [],
       status_in: ['placed'],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,
@@ -140,7 +140,7 @@ describe('adaptUrlQueryToFormValues', () => {
     ).toStrictEqual({
       market_id_in: [],
       status_in: ['placed'],
-      payment_status_in: [],
+      payment_status_eq: undefined,
       fulfillment_status_in: [],
       archived_at_null: undefined,
       timePreset: undefined,

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.test.ts
@@ -31,12 +31,12 @@ describe('adaptUrlQueryToSdk', () => {
   test('should return invalid status preset if not in url ', () => {
     expect(
       adaptUrlQueryToSdk({
-        queryString: 'payment_status_in=authorized',
+        queryString: 'payment_status_eq=authorized',
         instructions
       })
     ).toStrictEqual({
       status_in: 'placed,approved,cancelled',
-      payment_status_in: 'authorized',
+      payment_status_eq: 'authorized',
       archived_at_null: true
     })
   })
@@ -57,7 +57,7 @@ describe('adaptUrlQueryToSdk', () => {
     expect(
       adaptUrlQueryToSdk({
         queryString:
-          'status_in=approved&payment_status_in=not-existing&status_in=draft',
+          'status_in=approved&payment_status_eq=not-existing&status_in=draft',
         instructions
       })
     ).toStrictEqual({

--- a/packages/app-elements/src/ui/resources/useResourceFilters/mockedInstructions.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/mockedInstructions.ts
@@ -43,12 +43,12 @@ export const instructions: FiltersInstructions = [
     label: 'Payment Status',
     type: 'options',
     sdk: {
-      predicate: 'payment_status_in'
+      predicate: 'payment_status_eq'
     },
     render: {
       component: 'inputToggleButton',
       props: {
-        mode: 'multi',
+        mode: 'single',
         options: [
           { value: 'authorized', label: 'Authorized' },
           { value: 'paid', label: 'Paid' },

--- a/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
+++ b/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
@@ -192,7 +192,7 @@ export const SearchWithNav: StoryFn = () => {
             navigate(`?${qs}`)
           }}
           searchBarPlaceholder='Type to search...'
-          queryString='?status_in=placed&status_in=approved&timeFrom=2023-09-03T22%3A00%3A00.000Z&timePreset=custom&timeTo=2023-09-05T22%3A00%3A00.000Z'
+          queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized&fulfillment_status_in=unfulfilled&timeFrom=2023-09-03T22%3A00%3A00.000Z&timePreset=custom&timeTo=2023-09-05T22%3A00%3A00.000Z'
         />
       </CoreSdkProvider>
     </TokenProvider>


### PR DESCRIPTION
## What I did

When you have an Option instruction with `mode="single"`, the selected value is displayed with the option label.

```js
// instructions

[
  {
    label: 'Payment Status',
    type: 'options',
    sdk: {
      predicate: 'payment_status_eq'
    },
    render: {
      component: 'inputToggleButton',
      props: {
        mode: 'single',
        options: [
          { value: 'authorized', label: 'Authorized' },
          { value: 'paid', label: 'Paid' },
          { value: 'voided', label: 'Voided' },
          { value: 'refunded', label: 'Refunded' },
          { value: 'free', label: 'Free' },
          { value: 'unpaid', label: 'Unpaid' }
        ]
      }
    }
  }
]
```

```js
queryString='?payment_status_eq=authorized'
```
Before this change:
<img width="368" alt="Screenshot 2024-02-27 alle 21 42 40" src="https://github.com/commercelayer/app-elements/assets/1681269/669b1a4f-523b-41cd-bdb9-bbdd42080f93">

After this change:
<img width="325" alt="Screenshot 2024-02-27 alle 21 41 49" src="https://github.com/commercelayer/app-elements/assets/1681269/283f5a55-7681-48cb-8b48-a1efe0d03dc8">

## How to test

https://deploy-preview-570--commercelayer-app-elements.netlify.app/?path=/docs/resources-useresourcefilters--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
