### PR TITLE
Enhance the `useResourceFilters` hook

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldOptions.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldOptions.tsx
@@ -1,24 +1,17 @@
 import { HookedInputResourceGroup } from '#ui/forms/InputResourceGroup'
 import { HookedInputToggleButton } from '#ui/forms/InputToggleButton'
 import { useFormContext } from 'react-hook-form'
-import { type FilterItemOptions, type FilterItemTextSearch } from './types'
+import { type FilterItemOptions } from './types'
 import { computeFilterLabel } from './utils'
 
 interface FieldProps {
-  item: FilterItemOptions | FilterItemTextSearch
+  item: FilterItemOptions
 }
 
-export function FieldItem({ item }: FieldProps): JSX.Element | null {
+export function FieldOptions({ item }: FieldProps): JSX.Element | null {
   const { watch } = useFormContext()
 
-  if (item.hidden === true) {
-    return null
-  }
-
   switch (item.render.component) {
-    case 'searchBar':
-      return null
-
     case 'inputToggleButton':
       return (
         <HookedInputToggleButton

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldTextSearch.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldTextSearch.tsx
@@ -1,0 +1,16 @@
+import { HookedInput } from '#ui/forms/Input'
+import { type FilterItemTextSearch } from './types'
+
+interface FieldProps {
+  item: FilterItemTextSearch
+}
+
+export function FieldTextSearch({ item }: FieldProps): JSX.Element | null {
+  switch (item.render.component) {
+    case 'searchBar':
+      return null
+
+    case 'input':
+      return <HookedInput label={item.label} name={item.sdk.predicate} />
+  }
+}

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersForm.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersForm.tsx
@@ -20,15 +20,30 @@ export interface FiltersFormProps {
    * New queryString generated on submit to be used to navigate to the listing page
    */
   onSubmit: (queryString: string) => void
+  /**
+   * By default, we strip out all filters that are not part of the `instructions` array.
+   * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
+   *
+   * @example
+   * ```jsx
+   * useResourceFilters({
+   *   instructions,
+   *   predicateWhitelist: [ 'starts_at_lteq', 'expires_at_gteq', 'starts_at_gt', 'expires_at_lt' ]
+   * })
+   * ```
+   */
+  predicateWhitelist: string[]
 }
 
 function FiltersForm({
   instructions,
+  predicateWhitelist,
   onSubmit
 }: FiltersFormProps): JSX.Element {
   const { adaptUrlQueryToFormValues, adaptFormValuesToUrlQuery } =
     makeFilterAdapters({
-      instructions
+      instructions,
+      predicateWhitelist
     })
 
   const hasTimeRangeFilter = instructions.some(

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersForm.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersForm.tsx
@@ -4,12 +4,12 @@ import { HookedForm } from '#ui/forms/Form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
 import { FieldCurrencyRange } from './FieldCurrencyRange'
-import { FieldItem } from './FieldItem'
+import { FieldOptions } from './FieldOptions'
+import { FieldTextSearch } from './FieldTextSearch'
 import { FieldTimeRange } from './FieldTimeRange'
 import { makeFilterAdapters } from './adapters'
 import { timeRangeValidationSchema } from './timeUtils'
 import type { FiltersInstructions } from './types'
-import { isItemOptions } from './types'
 
 export interface FiltersFormProps {
   /**
@@ -54,10 +54,22 @@ function FiltersForm({
       }}
     >
       {instructions.map((item) => {
-        if (isItemOptions(item) && item.hidden !== true) {
+        if (item.hidden === true) {
+          return null
+        }
+
+        if (item.type === 'textSearch') {
           return (
             <Spacer bottom='10' key={item.label}>
-              <FieldItem item={item} />
+              <FieldTextSearch item={item} />
+            </Spacer>
+          )
+        }
+
+        if (item.type === 'options') {
+          return (
+            <Spacer bottom='10' key={item.label}>
+              <FieldOptions item={item} />
             </Spacer>
           )
         }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
@@ -16,6 +16,7 @@ describe('FiltersNav', () => {
         onFilterClick={() => {}}
         onUpdate={() => {}}
         queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
+        predicateWhitelist={[]}
       />
     )
     expect(container).toBeVisible()
@@ -37,6 +38,7 @@ describe('FiltersNav', () => {
             onFilterClick={() => {}}
             onUpdate={() => {}}
             queryString='?market_id_in=AlRevhXQga' // mocked in msw as Europe
+            predicateWhitelist={[]}
           />
         </CoreSdkProvider>
       </TokenProvider>
@@ -58,6 +60,7 @@ describe('FiltersNav', () => {
         onFilterClick={onFilterClick}
         onUpdate={() => {}}
         queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized'
+        predicateWhitelist={[]}
       />
     )
 
@@ -77,6 +80,7 @@ describe('FiltersNav', () => {
         onFilterClick={() => {}}
         onUpdate={onUpdate}
         queryString='?status_in=placed&payment_status_eq=authorized'
+        predicateWhitelist={[]}
       />
     )
 

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
@@ -50,13 +50,27 @@ export interface FiltersNavProps {
    * Implemented function should open the filters form.
    */
   onFilterClick: (queryString: string, filterPredicate?: string) => void
+  /**
+   * By default, we strip out all filters that are not part of the `instructions` array.
+   * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
+   *
+   * @example
+   * ```jsx
+   * useResourceFilters({
+   *   instructions,
+   *   predicateWhitelist: [ 'starts_at_lteq', 'expires_at_gteq', 'starts_at_gt', 'expires_at_lt' ]
+   * })
+   * ```
+   */
+  predicateWhitelist: string[]
 }
 
 export function FiltersNav({
   instructions,
   onFilterClick: onBtnLabelClick,
   onUpdate,
-  queryString
+  queryString,
+  predicateWhitelist
 }: FiltersNavProps): JSX.Element {
   const { user } = useTokenProvider()
 
@@ -65,7 +79,8 @@ export function FiltersNav({
     adaptFormValuesToUrlQuery,
     adaptUrlQueryToUrlQuery
   } = makeFilterAdapters({
-    instructions
+    instructions,
+    predicateWhitelist
   })
 
   const filters = useMemo(

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
@@ -19,7 +19,6 @@ import {
   isTimeRangeFilterUiName
 } from './timeUtils'
 import {
-  isItemOptions,
   isTextSearch,
   type CurrencyRangeFieldValue,
   type FiltersInstructionItem,
@@ -245,7 +244,11 @@ export function FiltersNav({
           filterPredicate
         })
 
-        if (instructionItem == null || instructionItem.type === 'textSearch') {
+        if (
+          instructionItem == null ||
+          (instructionItem.type === 'textSearch' &&
+            instructionItem.render.component === 'searchBar')
+        ) {
           return null
         }
 
@@ -403,21 +406,24 @@ function getButtonFilterLabel({
 }): string {
   const isSingleElementArray = Array.isArray(values) && values.length === 1
   const isString = typeof values === 'string'
+  const optionValue = Array.isArray(values) ? values[0] : values
 
   if (
-    isItemOptions(instructionItem) &&
+    instructionItem.type === 'options' &&
     'options' in instructionItem.render.props &&
     instructionItem.render.props.options != null &&
     instructionItem.render.props.options.length > 0 &&
     (isSingleElementArray || isString)
   ) {
-    const optionValue = Array.isArray(values) ? values[0] : values
-
     return (
       instructionItem.render.props.options.find(
         ({ value }) => value === optionValue
       )?.label ?? instructionItem.label
     )
+  }
+
+  if (instructionItem.type === 'textSearch') {
+    return `${instructionItem.label} · ${optionValue}`
   }
 
   return `${instructionItem.label} · ${values.length}`

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
@@ -24,17 +24,32 @@ export interface FilterSearchBarProps {
    * Input placeholder
    */
   placeholder?: string
+  /**
+   * By default, we strip out all filters that are not part of the `instructions` array.
+   * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
+   *
+   * @example
+   * ```jsx
+   * useResourceFilters({
+   *   instructions,
+   *   predicateWhitelist: [ 'starts_at_lteq', 'expires_at_gteq', 'starts_at_gt', 'expires_at_lt' ]
+   * })
+   * ```
+   */
+  predicateWhitelist: string[]
 }
 
 function FiltersSearchBar({
   instructions,
   placeholder,
   onUpdate,
-  queryString
+  queryString,
+  predicateWhitelist
 }: FilterSearchBarProps): JSX.Element {
   const { adaptUrlQueryToFormValues, adaptFormValuesToUrlQuery } =
     makeFilterAdapters({
-      instructions
+      instructions,
+      predicateWhitelist
     })
 
   const textPredicate = instructions.find(

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
@@ -37,8 +37,10 @@ function FiltersSearchBar({
       instructions
     })
 
-  const textPredicate = instructions.find((item) => item.type === 'textSearch')
-    ?.sdk.predicate
+  const textPredicate = instructions.find(
+    (item) =>
+      item.type === 'textSearch' && item.render.component === 'searchBar'
+  )?.sdk.predicate
 
   const updateTextFilter = (hint?: string): void => {
     if (textPredicate == null) {

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToSdk.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToSdk.test.ts
@@ -184,6 +184,7 @@ describe('adaptFormValuesToSdk', () => {
       adaptFormValuesToSdk({
         formValues: {
           status_in: ['approved'],
+          lastname_eq: 'doe',
           total_amount_cents: {
             currencyCode: 'USD'
           }
@@ -192,6 +193,23 @@ describe('adaptFormValuesToSdk', () => {
       })
     ).toStrictEqual({
       status_in: 'approved',
+      archived_at_null: true
+    })
+  })
+
+  test('should generate `lastname_eq` when whitelisted', () => {
+    expect(
+      adaptFormValuesToSdk({
+        formValues: {
+          status_in: ['approved'],
+          lastname_eq: 'doe'
+        },
+        instructions,
+        predicateWhitelist: ['lastname_eq']
+      })
+    ).toStrictEqual({
+      status_in: 'approved',
+      lastname_eq: 'doe',
       archived_at_null: true
     })
   })

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToUrlQuery.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptFormValuesToUrlQuery.test.ts
@@ -10,12 +10,13 @@ describe('adaptFormValuesToUrlQuery', () => {
           market_id_in: ['dFDdasdgAN', 'KToVGDooQp'],
           payment_status_in: [],
           fulfillment_status_in: [],
-          archived_at_null: 'hide'
+          archived_at_null: 'hide',
+          lastname_eq: 'doe'
         },
         instructions
       })
     ).toBe(
-      'archived_at_null=hide&market_id_in=dFDdasdgAN&market_id_in=KToVGDooQp&status_in=cancelled'
+      'archived_at_null=hide&lastname_eq=doe&market_id_in=dFDdasdgAN&market_id_in=KToVGDooQp&status_in=cancelled'
     )
   })
 

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
@@ -29,6 +29,60 @@ describe('adaptUrlQueryToFormValues', () => {
     })
   })
 
+  test('should strip out params from query string when not defined in the instructions', () => {
+    expect(
+      adaptUrlQueryToFormValues({
+        queryString: 'lastname_eq=doe',
+        instructions
+      })
+    ).toStrictEqual({
+      market_id_in: [],
+      status_in: [],
+      payment_status_eq: undefined,
+      fulfillment_status_in: [],
+      archived_at_null: undefined,
+      timePreset: undefined,
+      timeFrom: undefined,
+      timeTo: undefined,
+      name_eq: undefined,
+      number_or_email_cont: undefined,
+      viewTitle: undefined,
+      total_amount_cents: {
+        from: undefined,
+        to: undefined,
+        currencyCode: undefined
+      }
+    })
+  })
+
+  test('should include whitelisted predicates', () => {
+    expect(
+      adaptUrlQueryToFormValues({
+        queryString: 'lastname_eq=doe',
+        instructions,
+        predicateWhitelist: ['lastname_eq']
+      })
+    ).toStrictEqual({
+      lastname_eq: 'doe',
+      market_id_in: [],
+      status_in: [],
+      payment_status_eq: undefined,
+      fulfillment_status_in: [],
+      archived_at_null: undefined,
+      timePreset: undefined,
+      timeFrom: undefined,
+      timeTo: undefined,
+      name_eq: undefined,
+      number_or_email_cont: undefined,
+      viewTitle: undefined,
+      total_amount_cents: {
+        from: undefined,
+        to: undefined,
+        currencyCode: undefined
+      }
+    })
+  })
+
   test('should build proper form value object when partially empty', () => {
     expect(
       adaptUrlQueryToFormValues({

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.test.ts
@@ -18,6 +18,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: 'foobar',
       viewTitle: 'Awaiting Approval',
       total_amount_cents: {
@@ -43,6 +44,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: undefined,
       viewTitle: undefined,
       total_amount_cents: {
@@ -68,6 +70,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: undefined,
       viewTitle: undefined,
       total_amount_cents: {
@@ -94,6 +97,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: undefined,
       viewTitle: undefined,
       total_amount_cents: {
@@ -120,6 +124,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: undefined,
       viewTitle: undefined,
       total_amount_cents: {
@@ -146,6 +151,7 @@ describe('adaptUrlQueryToFormValues', () => {
       timePreset: undefined,
       timeFrom: undefined,
       timeTo: undefined,
+      name_eq: undefined,
       number_or_email_cont: undefined,
       viewTitle: undefined,
       total_amount_cents: {

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToFormValues.ts
@@ -14,6 +14,7 @@ import { getAllowedValuesFromItemOptions } from './utils'
 export interface AdaptUrlQueryToFormValuesParams {
   queryString: string
   instructions: FiltersInstructions
+  predicateWhitelist?: string[]
 }
 
 /**
@@ -25,14 +26,16 @@ export function adaptUrlQueryToFormValues<
   FilterFormValues extends Record<UiFilterName, UiFilterValue>
 >({
   queryString,
-  instructions
+  instructions,
+  predicateWhitelist = []
 }: AdaptUrlQueryToFormValuesParams): FilterFormValues & FormFullValues {
   const parsedQuery = qs.parse(queryString)
 
   const allowedQueryParams = [
     ...instructions
       .filter((item) => !isCurrencyRange(item))
-      .map((item) => item.sdk.predicate)
+      .map((item) => item.sdk.predicate),
+    ...predicateWhitelist
     // ...currencyRangeFieldKeys
   ]
 
@@ -102,6 +105,13 @@ export function adaptUrlQueryToFormValues<
       )
 
       if (instructionItem == null) {
+        if (predicateWhitelist.includes(key)) {
+          return {
+            ...formValues,
+            [key]: parsedQuery[key]
+          }
+        }
+
         return formValues
       }
 

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.test.ts
@@ -57,11 +57,26 @@ describe('adaptUrlQueryToSdk', () => {
     expect(
       adaptUrlQueryToSdk({
         queryString:
-          'status_in=approved&payment_status_eq=not-existing&status_in=draft',
+          'status_in=approved&payment_status_eq=not-existing&status_in=draft&lastname_eq=doe',
         instructions
       })
     ).toStrictEqual({
       status_in: 'approved',
+      archived_at_null: true
+    })
+  })
+
+  test('should consider the query string whitelist', () => {
+    expect(
+      adaptUrlQueryToSdk({
+        queryString:
+          'status_in=approved&payment_status_eq=not-existing&status_in=draft&lastname_eq=doe',
+        predicateWhitelist: ['lastname_eq'],
+        instructions
+      })
+    ).toStrictEqual({
+      status_in: 'approved',
+      lastname_eq: 'doe',
       archived_at_null: true
     })
   })

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToSdk.ts
@@ -6,6 +6,7 @@ import { type FiltersInstructions } from './types'
 export interface AdaptUrlQueryToSdkParams {
   queryString: string
   instructions: FiltersInstructions
+  predicateWhitelist?: string[]
   timezone?: string
 }
 
@@ -18,16 +19,19 @@ export interface AdaptUrlQueryToSdkParams {
 export function adaptUrlQueryToSdk({
   queryString,
   instructions,
+  predicateWhitelist = [],
   timezone
 }: AdaptUrlQueryToSdkParams): QueryFilter {
   const formValues = adaptUrlQueryToFormValues({
     queryString,
+    predicateWhitelist,
     instructions
   })
 
   return adaptFormValuesToSdk({
     formValues,
     instructions,
+    predicateWhitelist,
     timezone
   })
 }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToUrlQuery.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToUrlQuery.test.ts
@@ -14,6 +14,31 @@ describe('adaptUrlQueryToUrlQuery', () => {
     )
   })
 
+  test('should strip out params from query string when not defined in the instructions', () => {
+    expect(
+      adaptUrlQueryToUrlQuery({
+        queryString:
+          'lastname_eq=doe&market_id_in=abc123&status_in=approved&status_in=cancelled&viewTitle=Awaiting%20Approval',
+        instructions
+      })
+    ).toBe(
+      'market_id_in=abc123&status_in=approved&status_in=cancelled&viewTitle=Awaiting%20Approval'
+    )
+  })
+
+  test('should include whitelisted predicates', () => {
+    expect(
+      adaptUrlQueryToUrlQuery({
+        queryString:
+          'lastname_eq=doe&market_id_in=abc123&status_in=approved&status_in=cancelled&viewTitle=Awaiting%20Approval',
+        instructions,
+        predicateWhitelist: ['lastname_eq']
+      })
+    ).toBe(
+      'lastname_eq=doe&market_id_in=abc123&status_in=approved&status_in=cancelled&viewTitle=Awaiting%20Approval'
+    )
+  })
+
   test('should re-sort query params alphabetically same string', () => {
     expect(
       adaptUrlQueryToUrlQuery({

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToUrlQuery.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptUrlQueryToUrlQuery.ts
@@ -5,6 +5,7 @@ import { type FiltersInstructions } from './types'
 export interface AdaptUrlQueryToUrlQueryParams {
   queryString: string
   instructions: FiltersInstructions
+  predicateWhitelist?: string[]
 }
 
 /**
@@ -14,11 +15,16 @@ export interface AdaptUrlQueryToUrlQueryParams {
  */
 export function adaptUrlQueryToUrlQuery({
   queryString,
-  instructions
+  instructions,
+  predicateWhitelist = []
 }: AdaptUrlQueryToUrlQueryParams): string {
   const formValues = adaptUrlQueryToFormValues({
     queryString,
+    instructions,
+    predicateWhitelist
+  })
+  return adaptFormValuesToUrlQuery({
+    formValues,
     instructions
   })
-  return adaptFormValuesToUrlQuery({ formValues, instructions })
 }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
@@ -53,7 +53,10 @@ export const makeFilterAdapters: MakeFiltersAdapters = ({ instructions }) => {
  */
 function isValidInstructions(instructions: FiltersInstructions): boolean {
   const hasMultipleText =
-    instructions.filter((item) => item.type === 'textSearch')?.length > 1
+    instructions.filter(
+      (item) =>
+        item.type === 'textSearch' && item.render.component === 'searchBar'
+    )?.length > 1
 
   const hasMultipleTimePreset =
     instructions.filter((item) => item.type === 'timeRange')?.length > 1

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
@@ -6,7 +6,10 @@ import { adaptUrlQueryToUrlQuery as adaptUrlQueryToUrlQueryFn } from './adaptUrl
 import type { MakeFiltersAdapters } from './adapters.types'
 import { type FiltersInstructions } from './types'
 
-export const makeFilterAdapters: MakeFiltersAdapters = ({ instructions }) => {
+export const makeFilterAdapters: MakeFiltersAdapters = ({
+  instructions,
+  predicateWhitelist
+}) => {
   const validInstructions = isValidInstructions(instructions)
     ? instructions
     : []
@@ -21,25 +24,29 @@ export const makeFilterAdapters: MakeFiltersAdapters = ({ instructions }) => {
     adaptFormValuesToSdk: (params) =>
       adaptFormValuesToSdkFn({
         ...params,
-        instructions: validInstructions
+        instructions: validInstructions,
+        predicateWhitelist
       }),
 
     adaptUrlQueryToFormValues: (params) =>
       adaptUrlQueryToFormValuesFn({
         ...params,
-        instructions: validInstructions
+        instructions: validInstructions,
+        predicateWhitelist
       }),
 
     adaptUrlQueryToSdk: (params) =>
       adaptUrlQueryToSdkFn({
         ...params,
-        instructions: validInstructions
+        instructions: validInstructions,
+        predicateWhitelist
       }),
 
     adaptUrlQueryToUrlQuery: (params) =>
       adaptUrlQueryToUrlQueryFn({
         ...params,
-        instructions: validInstructions
+        instructions: validInstructions,
+        predicateWhitelist
       }),
 
     validInstructions

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.types.ts
@@ -15,6 +15,7 @@ import {
 
 interface MakeFilterAdaptersParams {
   instructions: FiltersInstructions
+  predicateWhitelist: string[]
 }
 
 interface MakeFilterAdaptersReturn<FilterFormValues extends FormFullValues> {
@@ -47,5 +48,6 @@ interface MakeFilterAdaptersReturn<FilterFormValues extends FormFullValues> {
 export type MakeFiltersAdapters = <
   FilterFormValues extends Record<UiFilterName, UiFilterValue>
 >({
-  instructions
+  instructions,
+  predicateWhitelist
 }: MakeFilterAdaptersParams) => MakeFilterAdaptersReturn<FilterFormValues>

--- a/packages/app-elements/src/ui/resources/useResourceFilters/mockedInstructions.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/mockedInstructions.ts
@@ -121,6 +121,16 @@ export const instructions: FiltersInstructions = [
     }
   },
   {
+    label: 'Name',
+    type: 'textSearch',
+    sdk: {
+      predicate: 'name_eq'
+    },
+    render: {
+      component: 'input'
+    }
+  },
+  {
     label: 'Amount',
     type: 'currencyRange',
     sdk: {

--- a/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
@@ -110,9 +110,11 @@ export interface FilterItemTextSearch extends Omit<BaseFilterItem, 'sdk'> {
   type: 'textSearch'
   render: {
     /**
-     * UI component to render
+     * UI component to render.
+     *
+     * ⚠️ You can have only one `searchBar` component.
      */
-    component: 'searchBar'
+    component: 'searchBar' | 'input'
   }
   sdk: Pick<BaseFilterItem['sdk'], 'predicate'>
 }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
@@ -24,6 +24,19 @@ interface UseResourceFiltersConfig {
    * Array of instruction items to build the filters behaviors
    */
   instructions: FiltersInstructions
+  /**
+   * By default, we strip out all filters that are not part of the `instructions` array.
+   * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
+   *
+   * @example
+   * ```jsx
+   * useResourceFilters({
+   *   instructions,
+   *   predicateWhitelist: [ 'starts_at_lteq', 'expires_at_gteq', 'starts_at_gt', 'expires_at_lt' ]
+   * })
+   * ```
+   */
+  predicateWhitelist?: string[]
 }
 
 interface UseResourceFiltersHook {
@@ -81,14 +94,16 @@ interface UseResourceFiltersHook {
 }
 
 export function useResourceFilters({
-  instructions
+  instructions,
+  predicateWhitelist = []
 }: UseResourceFiltersConfig): UseResourceFiltersHook {
   const { user } = useTokenProvider()
   const [sdkFilters, setSdkFilters] = useState<QueryFilter>()
   const queryString = window.location.search
 
   const adapters = makeFilterAdapters({
-    instructions
+    instructions,
+    predicateWhitelist
   })
   const { validInstructions } = adapters
 
@@ -164,6 +179,7 @@ export function useResourceFilters({
                 instructions={validInstructions}
                 onUpdate={onUpdate}
                 queryString={queryStringProp}
+                predicateWhitelist={predicateWhitelist}
               />
             </Spacer>
           )}
@@ -174,6 +190,7 @@ export function useResourceFilters({
               onFilterClick={onFilterClick}
               onUpdate={onUpdate}
               queryString={queryStringProp}
+              predicateWhitelist={predicateWhitelist}
             />
           )}
         </Spacer>
@@ -187,6 +204,7 @@ export function useResourceFilters({
       return (
         <FiltersFormComponent
           instructions={validInstructions}
+          predicateWhitelist={predicateWhitelist}
           onSubmit={onSubmit}
         />
       )

--- a/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
+++ b/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
@@ -192,7 +192,7 @@ export const SearchWithNav: StoryFn = () => {
             navigate(`?${qs}`)
           }}
           searchBarPlaceholder='Type to search...'
-          queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized&fulfillment_status_in=unfulfilled&timeFrom=2023-09-03T22%3A00%3A00.000Z&timePreset=custom&timeTo=2023-09-05T22%3A00%3A00.000Z'
+          queryString='?name_eq=Ehi there&status_in=placed&status_in=approved&payment_status_eq=authorized&fulfillment_status_in=unfulfilled&timeFrom=2023-09-03T22%3A00%3A00.000Z&timePreset=custom&timeTo=2023-09-05T22%3A00%3A00.000Z'
         />
       </CoreSdkProvider>
     </TokenProvider>


### PR DESCRIPTION
## What I did

### Add `input` as render option for filters

```js
const instructions = [
  {
    hidden: true,
    label: 'Name',
    type: 'textSearch',
    sdk: {
      predicate: 'name_eq'
    },
    render: {
      component: 'input'
    }
  }
]
```
<img src="https://github.com/commercelayer/app-elements/assets/1681269/3c264a6f-0ad7-4154-be85-50b83f506fce" width="400" />

### Add `predicateWhitelist` to the `useResourceFilters`

By default, we strip out all filters that are not part of the `instructions` array.

The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.

```jsx
useResourceFilters({
  instructions,
  predicateWhitelist: [
    'disabled_at_null',
    'starts_at_lteq',
    'expires_at_gteq',
    'starts_at_gt',
    'expires_at_lt'
  ]
})
```

This way you can redirect to `/list?disabled_at_null=true&expires_at_gteq=2024-02-28T14%3A45%3A10.186Z&starts_at_lteq=2024-02-28T14%3A45%3A10.186Z&viewTitle=Active` without the need of specifying fake or hidden instructions.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
