### PR TITLE
Add `lightGray` to the StatusIcon background

### DIFF
--- a/packages/app-elements/src/dictionaries/promotions.ts
+++ b/packages/app-elements/src/dictionaries/promotions.ts
@@ -14,7 +14,7 @@ export function getPromotionDisplayStatus(
       status: 'disabled',
       label: 'Disabled',
       icon: 'minus',
-      color: 'gray'
+      color: 'lightGray'
     }
   }
 

--- a/packages/app-elements/src/ui/atoms/StatusIcon.tsx
+++ b/packages/app-elements/src/ui/atoms/StatusIcon.tsx
@@ -15,6 +15,7 @@ export interface StatusIconProps extends React.HTMLAttributes<HTMLDivElement> {
     | 'orange'
     | 'red'
     | 'gray'
+    | 'lightGray'
     | 'teal'
     | 'white'
     | 'black'
@@ -46,6 +47,9 @@ export const StatusIcon: React.FC<StatusIconProps> = ({
         { 'bg-green border-green text-white': background === 'green' },
         { 'bg-red border-red text-white': background === 'red' },
         { 'bg-gray-300 border-gray-300 text-white': background === 'gray' },
+        {
+          'bg-gray-200 border-gray-200 text-white': background === 'lightGray'
+        },
         { 'bg-orange border-orange text-white': background === 'orange' },
         { 'bg-teal border-teal text-white': background === 'teal' },
         { 'bg-white border-gray-200': background === 'white' },

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
@@ -52,11 +52,7 @@ export const promotionToProps: ResourceToProps<Omit<Promotion, 'type'>> = ({
       displayStatus.status === 'upcoming' ? (
         <RadialProgress icon='calendarBlank' />
       ) : (
-        <div
-          className={displayStatus.status === 'disabled' ? 'opacity-50' : ''}
-        >
-          <ListItemIcon icon={displayStatus.icon} color={displayStatus.color} />
-        </div>
+        <ListItemIcon icon={displayStatus.icon} color={displayStatus.color} />
       )
   }
 }

--- a/packages/docs/src/stories/atoms/StatusIcon.stories.tsx
+++ b/packages/docs/src/stories/atoms/StatusIcon.stories.tsx
@@ -58,6 +58,7 @@ export const AvailableBackgrounds: StoryFn = () => {
     ...(
       Object.keys({
         black: null,
+        lightGray: null,
         gray: null,
         green: null,
         none: null,


### PR DESCRIPTION

## What I did

I added the `lightGray` value to the StatusIcon background.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
