### PR TITLE
Add `SkeletonTemplate` support for `CopyToClipboard`

### DIFF
--- a/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
+++ b/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
@@ -83,7 +83,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
       {...rest}
     >
       {showValue && (
-        <p className='overflow-x-auto py-2'>
+        <div className='overflow-x-auto py-2'>
           {isJsonString(value) ? (
             <div className='whitespace-pre max-h-[200px] font-mono font-medium'>
               {JSON.stringify(JSON.parse(value), null, 2)}
@@ -91,7 +91,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
           ) : (
             value
           )}
-        </p>
+        </div>
       )}
       <div className='pt-2'>
         <button

--- a/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
+++ b/packages/app-elements/src/ui/atoms/SkeletonTemplate.tsx
@@ -177,7 +177,8 @@ const SkeletonTemplate: SkeletonTemplateComponent<
               /^Icon$/,
               /^StatusIcon$/,
               /^RadialProgress$/,
-              /^ButtonFilter$/
+              /^ButtonFilter$/,
+              /^CopyToClipboard$/
             ])
           ) {
             return cloneElement(child, {

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -1,6 +1,7 @@
 import { Avatar } from '#ui/atoms/Avatar'
 import { Badge } from '#ui/atoms/Badge'
 import { Button } from '#ui/atoms/Button'
+import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
 import { RadialProgress } from '#ui/atoms/RadialProgress'
 import {
   SkeletonTemplate,
@@ -109,6 +110,9 @@ const children = (
         quis ultricies nisl sollicitudin tempus. Ut ut tempus nisi. Proin
         fermentum consectetur lacus id condimentum.
       </Text>
+    </Spacer>
+    <Spacer top='8'>
+      <CopyToClipboard value='Copy this to clipboard!' />
     </Spacer>
   </>
 )


### PR DESCRIPTION
## What I did

SkeletonTemplate was not applying the loading style on CopyToClipboard.
I've also changed a `p` tag with `div` since the first can't have a block-level tag as children.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
