### PR TITLE
Add new date helper `getLastYearIsoRange`

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -1,4 +1,8 @@
 import {
+  getLastYearIsoRange,
+  removeMillisecondsFromIsoDate
+} from '#helpers/date'
+import {
   formatDate,
   formatDateRange,
   formatDateWithPredicate,
@@ -582,5 +586,47 @@ describe('formatDateRange should return the proper date format', () => {
         rangeTo: '2025-01-31T14:30:00.000Z'
       })
     ).toEqual('Dec 01, 2023 - Jan 31, 2025')
+  })
+})
+
+describe('getLastYearIsoRange', () => {
+  test('should return last year range with milliseconds', () => {
+    const now = new Date('2023-04-24T13:45:00.000Z')
+    const result = getLastYearIsoRange({ now, showMilliseconds: true })
+
+    expect(result).toEqual({
+      date_from: '2022-04-24T13:45:01.000Z',
+      date_to: '2023-04-24T13:45:00.000Z'
+    })
+  })
+
+  test('should return last year range without milliseconds', () => {
+    const now = new Date('2023-04-24T13:45:00.538Z')
+    const result = getLastYearIsoRange({ now, showMilliseconds: false })
+
+    expect(result).toEqual({
+      date_from: '2022-04-24T13:45:01Z',
+      date_to: '2023-04-24T13:45:00Z'
+    })
+  })
+})
+
+describe('removeMillisecondsFromIsoDate', () => {
+  test('should remove milliseconds from the date', () => {
+    expect(removeMillisecondsFromIsoDate('2023-04-24T13:45:00.538Z')).toBe(
+      '2023-04-24T13:45:00Z'
+    )
+  })
+
+  test('should accept partial date string', () => {
+    expect(removeMillisecondsFromIsoDate('2023-03-25')).toBe(
+      '2023-03-25T00:00:00Z'
+    )
+  })
+
+  test('should return same value if argument is invalid', () => {
+    expect(removeMillisecondsFromIsoDate('2023-broken-date')).toBe(
+      '2023-broken-date'
+    )
   })
 })

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -367,3 +367,60 @@ export function sortAndGroupByDate<T extends Event>(
     }).toUpperCase()
   )
 }
+
+/**
+ * Remove milliseconds from a date ISO string.
+ *
+ * Example:
+ * ```
+ * removeMilliseconds('2022-04-24T13:44:59.452Z') // '2022-04-24T13:44:59Z'
+ * ```
+ */
+export function removeMillisecondsFromIsoDate(isoDate: string): string {
+  try {
+    const validDate = new Date(isoDate)
+    return (validDate.toISOString().split('.')[0] ?? '') + 'Z'
+  } catch (e) {
+    return isoDate
+  }
+}
+
+/**
+ * Returns one year date range (minus 1 second) from the specified now date.
+ *
+ * If `showMilliseconds` is false will remove milliseconds from the Date ISO strings,
+ * ready to be used, for instance, in Metrics APIs requests.
+ *
+ * Example:
+ * ```
+ * // with showMilliseconds = true
+ * { date_from: '2022-04-24T13:44:59:452Z', date_to: '2023-04-24T13:45:452Z' }
+ * // with showMilliseconds = false
+ * { date_from: '2022-04-24T13:44:59Z', date_to: '2023-04-24T13:45Z' }
+ * ```
+ */
+export function getLastYearIsoRange({
+  now,
+  showMilliseconds = true
+}: {
+  now: Date
+  showMilliseconds: boolean
+}): {
+  date_from: string
+  date_to: string
+} {
+  const to = now.toISOString()
+
+  // same day, one year ago
+  const lastYearDate = new Date(
+    new Date(now).setFullYear(now.getFullYear() - 1)
+  )
+  // remove 1 second to avoid overlapping with the current year
+  lastYearDate.setSeconds(lastYearDate.getSeconds() + 1)
+  const from = lastYearDate.toISOString()
+
+  return {
+    date_from: showMilliseconds ? from : removeMillisecondsFromIsoDate(from),
+    date_to: showMilliseconds ? to : removeMillisecondsFromIsoDate(to)
+  }
+}

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -11,6 +11,8 @@ export {
   getEventDateInfo,
   getIsoDateAtDayEdge,
   getIsoDateAtDaysBefore,
+  getLastYearIsoRange,
+  removeMillisecondsFromIsoDate,
   sortAndGroupByDate,
   timeSeparator
 } from '#helpers/date'

--- a/packages/docs/src/components/CodeSample.tsx
+++ b/packages/docs/src/components/CodeSample.tsx
@@ -63,7 +63,11 @@ export function CodeSample({
   return (
     <>
       {description}
-      <Source dark language='js' code={`${sanitizedCode}//=  ${result}`} />
+      <Source
+        dark
+        language='js'
+        code={`${sanitizedCode}//=  ${typeof result === 'object' ? JSON.stringify(result) : result}`}
+      />
     </>
   )
 }

--- a/packages/docs/src/stories/utility/Date.stories.tsx
+++ b/packages/docs/src/stories/utility/Date.stories.tsx
@@ -1,4 +1,9 @@
-import { formatDate, formatDateRange, getEventDateInfo } from '#helpers/date'
+import {
+  formatDate,
+  formatDateRange,
+  getEventDateInfo,
+  getLastYearIsoRange
+} from '#helpers/date'
 import { Description, Stories, Subtitle, Title } from '@storybook/addon-docs'
 import { type Meta, type StoryFn } from '@storybook/react'
 import { CodeSample } from 'src/components/CodeSample'
@@ -249,6 +254,24 @@ export const GetEventDateInfo: StoryFn = () => {
           getEventDateInfo({
             startsAt: '3023-01-01T14:30:00.000Z',
             expiresAt: '3023-01-31T14:30:00.000Z'
+          })
+        }
+      />
+    </>
+  )
+}
+
+/**
+ *  Returns one year date range (minus 1 second) from the specified `now` date.
+ */
+export const GetLastYearIsoRange: StoryFn = () => {
+  return (
+    <>
+      <CodeSample
+        fn={() =>
+          getLastYearIsoRange({
+            now: new Date('2024-01-01T14:30:00.000Z'),
+            showMilliseconds: true
           })
         }
       />


### PR DESCRIPTION
## What I did

I've moved here the `getLastYearIsoRange` helper we are using in some apps to generate the 1-year date range to be used to get counters from Metrics API.

I've also fixed it to work with leap years.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
