### PR TITLE
Enhance the `InputRadioGroup` component

### DIFF
--- a/packages/app-elements/src/ui/forms/InputRadioGroup/HookedInputRadioGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputRadioGroup/HookedInputRadioGroup.tsx
@@ -1,4 +1,7 @@
 import { useValidationFeedback } from '#ui/forms/ReactHookForm'
+import { isDefined } from '#utils/array'
+import { filterByDisplayName } from '#utils/children'
+import { useEffect } from 'react'
 import { Controller, useFormContext } from 'react-hook-form'
 import { InputRadioGroup, type InputRadioGroupProps } from './InputRadioGroup'
 
@@ -18,8 +21,32 @@ export const HookedInputRadioGroup: React.FC<HookedInputRadioGroupProps> = ({
   name,
   ...props
 }) => {
-  const { control } = useFormContext()
+  const { control, watch, resetField, setValue } = useFormContext()
   const feedback = useValidationFeedback(name)
+  const selectedValue = watch(name)
+
+  useEffect(() => {
+    const options = props.options.flatMap((option) =>
+      filterByDisplayName(option.checkedElement ?? <></>, /^Hooked/)
+        .map((child) =>
+          typeof child.props.name === 'string'
+            ? {
+                isChecked: option.value === selectedValue,
+                fieldName: child.props.name as string
+              }
+            : undefined
+        )
+        .filter(isDefined)
+    )
+
+    options.forEach(({ fieldName, isChecked }) => {
+      if (isChecked) {
+        resetField(fieldName)
+      } else {
+        setValue(fieldName, undefined)
+      }
+    })
+  }, [selectedValue])
 
   return (
     <Controller

--- a/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
@@ -6,7 +6,13 @@ import {
   type InputWrapperBaseProps
 } from '#ui/internals/InputWrapper'
 import cn from 'classnames'
-import { useEffect, useState, type ComponentProps, type ReactNode } from 'react'
+import {
+  Fragment,
+  useEffect,
+  useState,
+  type ComponentProps,
+  type ReactNode
+} from 'react'
 
 interface OptionItem {
   /**
@@ -17,6 +23,10 @@ interface OptionItem {
    * Item content to be displayed in the central section of the row
    */
   content: ReactNode
+  /**
+   * Additional `Element` to be rendered when the input is checked
+   */
+  checkedElement?: JSX.Element
   /**
    * Optional CSS class name to be applied to the card item
    */
@@ -90,34 +100,41 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
             const isSelected = optionItem.value === selectedValue
 
             const option = (
-              <label
-                className={cn('flex gap-4 cursor-pointer h-full', {
-                  'rounded-md px-4 py-4 hover:bg-gray-50':
-                    viewMode !== 'simple',
-                  'items-center': ['list', 'simple'].includes(viewMode)
-                })}
-                data-testid='InputRadioGroup-item'
-              >
-                <input
-                  type='radio'
-                  checked={isSelected}
-                  name={name}
-                  value={optionItem.value}
-                  onChange={(event) => {
-                    setSelectedValue(event.currentTarget.value)
-                  }}
-                  className={cn(
-                    'border border-gray-300 rounded-full w-[18px] h-[18px] text-primary focus:ring-primary',
-                    { hidden: !showInput }
-                  )}
-                />
+              <div>
+                <label
+                  className={cn('flex gap-4 cursor-pointer h-full', {
+                    'rounded-md px-4 py-4 hover:bg-gray-50':
+                      viewMode !== 'simple',
+                    'items-center': ['list', 'simple'].includes(viewMode)
+                  })}
+                  data-testid='InputRadioGroup-item'
+                >
+                  <input
+                    type='radio'
+                    checked={isSelected}
+                    name={name}
+                    value={optionItem.value}
+                    onChange={(event) => {
+                      setSelectedValue(event.currentTarget.value)
+                    }}
+                    className={cn(
+                      'border border-gray-300 rounded-full w-[18px] h-[18px] text-primary focus:ring-primary',
+                      { hidden: !showInput }
+                    )}
+                  />
 
-                <div className='flex-1'>{optionItem.content}</div>
-              </label>
+                  <div className='flex-1'>{optionItem.content}</div>
+                </label>
+                {optionItem.checkedElement != null && isSelected && (
+                  <div className='my-2 ml-[18px] pl-4'>
+                    {optionItem.checkedElement}
+                  </div>
+                )}
+              </div>
             )
 
             if (viewMode === 'simple') {
-              return option
+              return <Fragment key={optionItem.value}>{option}</Fragment>
             }
 
             return (

--- a/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputRadioGroup/InputRadioGroup.tsx
@@ -52,7 +52,7 @@ interface Props extends Pick<InputWrapperBaseProps, 'feedback' | 'hint'> {
    * Define how the item options are rendered
    * @default list
    */
-  viewMode?: 'list' | 'inline' | 'grid'
+  viewMode?: 'list' | 'inline' | 'grid' | 'simple'
 }
 
 export const InputRadioGroup = withSkeletonTemplate<Props>(
@@ -80,7 +80,7 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
       <InputWrapper fieldset label={title} feedback={feedback} hint={hint}>
         <div
           className={cn('flex gap-2 wrap', {
-            'flex-col': viewMode === 'list',
+            'flex-col': ['list', 'simple'].includes(viewMode),
             'flex-row [&>*]:flex-shrink [&>*]:flex-grow [&>*]:basis-0':
               viewMode === 'inline',
             'grid grid-cols-2': viewMode === 'grid'
@@ -88,6 +88,37 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
         >
           {options.map((optionItem) => {
             const isSelected = optionItem.value === selectedValue
+
+            const option = (
+              <label
+                className={cn('flex gap-4 cursor-pointer h-full', {
+                  'rounded-md px-4 py-4 hover:bg-gray-50':
+                    viewMode !== 'simple',
+                  'items-center': ['list', 'simple'].includes(viewMode)
+                })}
+                data-testid='InputRadioGroup-item'
+              >
+                <input
+                  type='radio'
+                  checked={isSelected}
+                  name={name}
+                  value={optionItem.value}
+                  onChange={(event) => {
+                    setSelectedValue(event.currentTarget.value)
+                  }}
+                  className={cn(
+                    'border border-gray-300 rounded-full w-[18px] h-[18px] text-primary focus:ring-primary',
+                    { hidden: !showInput }
+                  )}
+                />
+
+                <div className='flex-1'>{optionItem.content}</div>
+              </label>
+            )
+
+            if (viewMode === 'simple') {
+              return option
+            }
 
             return (
               <Card
@@ -112,31 +143,7 @@ export const InputRadioGroup = withSkeletonTemplate<Props>(
                 role='radio'
                 aria-checked={isSelected}
               >
-                <label
-                  className={cn(
-                    'rounded-md cursor-pointer hover:bg-gray-50 flex gap-4 p-4 h-full',
-                    {
-                      'items-center': viewMode === 'list'
-                    }
-                  )}
-                  data-testid='InputRadioGroup-item'
-                >
-                  <input
-                    type='radio'
-                    checked={isSelected}
-                    name={name}
-                    value={optionItem.value}
-                    onChange={(event) => {
-                      setSelectedValue(event.currentTarget.value)
-                    }}
-                    className={cn(
-                      'border border-gray-300 rounded-full w-[18px] h-[18px] text-primary focus:ring-primary',
-                      { hidden: !showInput }
-                    )}
-                  />
-
-                  <div className='flex-1'>{optionItem.content}</div>
-                </label>
+                {option}
               </Card>
             )
           })}

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputRadioGroup.stories.tsx
@@ -5,6 +5,7 @@ import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
 import { HookedForm } from '#ui/forms/Form'
 import { HookedInputRadioGroup } from '#ui/forms/InputRadioGroup'
+import { HookedInputSelect } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 import { useForm } from 'react-hook-form'
 
@@ -25,14 +26,16 @@ export default setup
 const Template: StoryFn<typeof HookedInputRadioGroup> = (args) => {
   const methods = useForm({
     defaultValues: {
-      carrier: 'Fedex'
+      carrier: 'Fedex',
+      option: 'MI',
+      color: 'green'
     }
   })
 
   return (
     <HookedForm
       {...methods}
-      onSubmit={(values) => {
+      onSubmit={(values): void => {
         alert(JSON.stringify(values))
       }}
     >
@@ -146,6 +149,34 @@ Default.args = {
             €37,61
           </Text>
         </ListItem>
+      )
+    }
+  ]
+}
+
+export const WithCheckedElement = Template.bind({})
+WithCheckedElement.args = {
+  title: 'Choose a store',
+  name: 'option',
+  viewMode: 'simple',
+  options: [
+    {
+      value: 'NY',
+      content: <Text weight='semibold'>New York</Text>
+    },
+    {
+      value: 'MI',
+      content: <Text weight='semibold'>Milan</Text>,
+      checkedElement: (
+        <HookedInputSelect
+          name='color'
+          hint={{ text: 'Select your preferred color.' }}
+          initialValues={[
+            { label: 'Red', value: 'red' },
+            { label: 'Green', value: 'green' },
+            { label: 'Blue', value: 'blue' }
+          ]}
+        />
       )
     }
   ]

--- a/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
@@ -3,6 +3,7 @@ import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
 import { InputRadioGroup } from '#ui/forms/InputRadioGroup'
+import { InputSelect } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof InputRadioGroup> = {
@@ -247,7 +248,18 @@ ViewModeSimple.args = {
     },
     {
       value: 'MI',
-      content: <Text weight='semibold'>Milan</Text>
+      content: <Text weight='semibold'>Milan</Text>,
+      checkedElement: (
+        <InputSelect
+          onSelect={() => {}}
+          hint={{ text: 'Select your preferred color.' }}
+          initialValues={[
+            { label: 'Red', value: 'red' },
+            { label: 'Green', value: 'green' },
+            { label: 'Blue', value: 'blue' }
+          ]}
+        />
+      )
     }
   ]
 }

--- a/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
@@ -232,6 +232,26 @@ ViewModeGrid.args = {
   ]
 }
 
+export const ViewModeSimple = Template.bind({})
+ViewModeSimple.args = {
+  title: 'Choose a store',
+  name: 'option',
+  viewMode: 'simple',
+  onChange: (v) => {
+    console.log(v)
+  },
+  options: [
+    {
+      value: 'NY',
+      content: <Text weight='semibold'>New York</Text>
+    },
+    {
+      value: 'MI',
+      content: <Text weight='semibold'>Milan</Text>
+    }
+  ]
+}
+
 /** It possible to specify a custom CSS class name for a single option item */
 export const ItemCustomClassName = Template.bind({})
 ItemCustomClassName.args = {


### PR DESCRIPTION
## What I did

I enhanced the `InputRadioGroup` component by adding a new `simple` viewMode. It will renders the options as simpler radio inputs

<img width="619" alt="Screenshot 2024-03-01 alle 14 18 26" src="https://github.com/commercelayer/app-elements/assets/1681269/d00a4e67-720b-49ce-a8cf-83b95177d307">

I also added the `checkedElement` prop that will be rendered when the radio is selected:


https://github.com/commercelayer/app-elements/assets/1681269/d982ab61-3c16-4301-912e-2067cdf796f3



## How to test

https://deploy-preview-579--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputradiogroup--docs#view-mode-simple

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
