### PR TITLE
Add 'suffix' prop to the `Input` component

### DIFF
--- a/packages/app-elements/src/ui/forms/Input/Input.tsx
+++ b/packages/app-elements/src/ui/forms/Input/Input.tsx
@@ -1,3 +1,4 @@
+import { Text } from '#ui/atoms/Text'
 import {
   InputWrapper,
   getFeedbackStyle,
@@ -17,11 +18,24 @@ export interface InputProps
    * Optional CSS class names used for the input element
    */
   className?: string
+  /**
+   * Optional suffix that renders close to the right-edge of the input
+   */
+  suffix?: React.ReactNode
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
-    { type = 'text', className, label, hint, feedback, inline, ...rest },
+    {
+      type = 'text',
+      className,
+      label,
+      hint,
+      feedback,
+      inline,
+      suffix,
+      ...rest
+    },
     ref
   ): JSX.Element => {
     return (
@@ -32,22 +46,37 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         name={rest.id ?? rest.name}
         inline={inline}
       >
-        <input
-          {...rest}
-          data-lpignore={rest.autoComplete === 'off' && 'true'}
-          data-1p-ignore={rest.autoComplete === 'off' && true}
-          data-form-type={rest.autoComplete === 'off' && 'other'}
-          id={rest.id ?? rest.name}
-          className={cn(
-            className,
-            'block w-full px-4 py-2.5 font-medium',
-            'rounded outline-0',
-            rest.autoComplete === 'off' && '!bg-white',
-            getFeedbackStyle(feedback)
+        <div className='relative'>
+          <input
+            {...rest}
+            data-lpignore={rest.autoComplete === 'off' && 'true'}
+            data-1p-ignore={rest.autoComplete === 'off' && true}
+            data-form-type={rest.autoComplete === 'off' && 'other'}
+            id={rest.id ?? rest.name}
+            className={cn(
+              className,
+              'block w-full px-4 py-2.5 font-medium',
+              'rounded outline-0',
+              {
+                '[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none':
+                  suffix != null,
+                '!bg-white': rest.autoComplete === 'off'
+              },
+              getFeedbackStyle(feedback)
+            )}
+            type={type}
+            ref={ref}
+          />
+          {suffix != null && (
+            <Text
+              size='small'
+              weight='semibold'
+              className='absolute right-4 top-1/2 -translate-y-1/2'
+            >
+              {suffix}
+            </Text>
           )}
-          type={type}
-          ref={ref}
-        />
+        </div>
       </InputWrapper>
     )
   }

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInput.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInput.stories.tsx
@@ -25,7 +25,7 @@ const Template: StoryFn<typeof HookedInput> = (args) => {
   return (
     <HookedForm
       {...methods}
-      onSubmit={(values) => {
+      onSubmit={(values): void => {
         alert(JSON.stringify(values))
       }}
     >
@@ -41,4 +41,12 @@ export const Default = Template.bind({})
 Default.args = {
   label: 'First name',
   name: 'firstname'
+}
+
+export const WithSuffix = Template.bind({})
+WithSuffix.args = {
+  type: 'number',
+  label: 'Assign a priority',
+  name: 'priority',
+  suffix: 'index'
 }

--- a/packages/docs/src/stories/forms/ui/Input.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/Input.stories.tsx
@@ -1,3 +1,4 @@
+import { Icon } from '#ui/atoms/Icon'
 import { Input } from '#ui/forms/Input'
 import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
@@ -35,6 +36,23 @@ WithSuffix.args = {
   label: 'Percentage',
   name: 'percentage',
   suffix: '%'
+}
+
+export const WithActionSuffix = Template.bind({})
+WithActionSuffix.args = {
+  type: 'number',
+  label: 'Weight',
+  name: 'weight',
+  suffix: (
+    <Icon
+      name='arrowClockwise'
+      style={{ cursor: 'pointer' }}
+      size={22}
+      onClick={() => {
+        alert('Refresh')
+      }}
+    />
+  )
 }
 
 export const WithHint = Template.bind({})

--- a/packages/docs/src/stories/forms/ui/Input.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/Input.stories.tsx
@@ -29,6 +29,14 @@ WithLabel.args = {
   name: 'fullname'
 }
 
+export const WithSuffix = Template.bind({})
+WithSuffix.args = {
+  type: 'number',
+  label: 'Percentage',
+  name: 'percentage',
+  suffix: '%'
+}
+
 export const WithHint = Template.bind({})
 WithHint.args = {
   label: 'Your name',


### PR DESCRIPTION
Closes commercelayer/issues-app#10

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added a `suffix` prop to the `Input` component.

This can be combined with `Icon`s to manage Input actions:
![Image](https://github.com/commercelayer/issues-app/assets/30926550/817ce3f6-2546-4314-aa44-56eb2e171d42)

Or it can be simply a text:
![Image](https://github.com/commercelayer/issues-app/assets/1681269/d4ac49d9-fc8e-4420-9f0d-8a7bb8da2b69)

## How to test

https://deploy-preview-581--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-input--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
