### PR TITLE
Handle total usage for expiration

### DIFF
--- a/packages/app-elements/src/dictionaries/promotions.ts
+++ b/packages/app-elements/src/dictionaries/promotions.ts
@@ -23,14 +23,23 @@ export function getPromotionDisplayStatus(
     expiresAt: promotion.expires_at
   })
 
+  const expiredStatus: PromotionDisplayStatus = {
+    status: 'expired',
+    label: 'Expired',
+    icon: 'flag',
+    color: 'gray'
+  }
+
+  if (
+    promotion.total_usage_limit != null &&
+    promotion.total_usage_count === promotion.total_usage_limit
+  ) {
+    return expiredStatus
+  }
+
   switch (eventDateInfo) {
     case 'past':
-      return {
-        status: 'expired',
-        label: 'Expired',
-        icon: 'flag',
-        color: 'gray'
-      }
+      return expiredStatus
 
     case 'upcoming':
       return {

--- a/packages/app-elements/src/dictionaries/promotions.ts
+++ b/packages/app-elements/src/dictionaries/promotions.ts
@@ -3,7 +3,7 @@ import type { Promotion } from '@commercelayer/sdk'
 import type { DisplayStatus } from './types'
 
 interface PromotionDisplayStatus extends DisplayStatus {
-  status: 'disabled' | 'active' | 'upcoming' | 'expired'
+  status: 'disabled' | 'active' | 'upcoming' | 'expired' | 'used'
 }
 
 export function getPromotionDisplayStatus(
@@ -23,23 +23,26 @@ export function getPromotionDisplayStatus(
     expiresAt: promotion.expires_at
   })
 
-  const expiredStatus: PromotionDisplayStatus = {
-    status: 'expired',
-    label: 'Expired',
-    icon: 'flag',
-    color: 'gray'
-  }
-
   if (
     promotion.total_usage_limit != null &&
     promotion.total_usage_count === promotion.total_usage_limit
   ) {
-    return expiredStatus
+    return {
+      status: 'used',
+      label: 'Expired',
+      icon: 'flag',
+      color: 'gray'
+    }
   }
 
   switch (eventDateInfo) {
     case 'past':
-      return expiredStatus
+      return {
+        status: 'expired',
+        label: 'Expired',
+        icon: 'flag',
+        color: 'gray'
+      }
 
     case 'upcoming':
       return {

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -394,6 +394,20 @@ export const presetResourceListItem = {
     total_usage_limit: 3,
     active: false
   },
+  promotionUsed: {
+    type: 'percentage_discount_promotions',
+    reference_origin: referenceOrigins.appPromotions,
+    id: '',
+    created_at: '',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    starts_at: '2024-01-01T06:38:44.964Z',
+    expires_at: '3033-01-01T06:38:44.964Z',
+    name: 'Jan 30% off',
+    percentage: 30,
+    total_usage_count: 3, // count === limit
+    total_usage_limit: 3,
+    active: true
+  },
   promotionWithCoupons: {
     type: 'percentage_discount_promotions',
     reference_origin: referenceOrigins.appPromotions,

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -14,7 +14,6 @@ import type {
   StockLocation,
   StockTransfer
 } from '@commercelayer/sdk'
-import { referenceOrigins } from './transformers/promotions'
 
 const market = {
   type: 'markets',
@@ -332,7 +331,6 @@ export const presetResourceListItem = {
   },
   promotionActive: {
     type: 'percentage_discount_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -345,7 +343,6 @@ export const presetResourceListItem = {
   },
   promotionDisabled: {
     type: 'percentage_discount_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -359,7 +356,6 @@ export const presetResourceListItem = {
   },
   promotionUpcoming: {
     type: 'free_shipping_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -371,7 +367,6 @@ export const presetResourceListItem = {
   },
   promotionDisabledAndUpcoming: {
     type: 'free_shipping_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -384,7 +379,6 @@ export const presetResourceListItem = {
   },
   promotionExpired: {
     type: 'free_gift_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -396,7 +390,6 @@ export const presetResourceListItem = {
   },
   promotionUsed: {
     type: 'percentage_discount_promotions',
-    reference_origin: referenceOrigins.appPromotions,
     id: '',
     created_at: '',
     updated_at: '2023-06-10T06:38:44.964Z',
@@ -409,22 +402,6 @@ export const presetResourceListItem = {
     active: true
   },
   promotionWithCoupons: {
-    type: 'percentage_discount_promotions',
-    reference_origin: referenceOrigins.appPromotions,
-    id: '',
-    created_at: '',
-    updated_at: '2023-06-10T06:38:44.964Z',
-    starts_at: '2024-01-01T06:38:44.964Z',
-    expires_at: '3033-01-01T06:38:44.964Z',
-    name: '50% off',
-    percentage: 23,
-    total_usage_limit: 3,
-    active: true,
-    coupons: [
-      { code: '1234', created_at: '', id: '', type: 'coupons', updated_at: '' }
-    ]
-  },
-  promotionFromApi: {
     type: 'percentage_discount_promotions',
     id: '',
     created_at: '',

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
@@ -9,28 +9,17 @@ import {
 import type { Promotion } from '@commercelayer/sdk'
 import { type ResourceToProps } from '../types'
 
-export const referenceOrigins = {
-  appPromotions: 'app-promotions'
-} as const
-
 export const promotionToProps: ResourceToProps<Omit<Promotion, 'type'>> = ({
   resource,
   user
 }) => {
   const displayStatus = getPromotionDisplayStatus(resource)
   const hasCoupons = (resource.coupons ?? []).length > 0
-  const createdFromApi =
-    resource.reference_origin !== referenceOrigins.appPromotions
 
   return {
     name: (
       <>
         {resource.name}{' '}
-        {createdFromApi && (
-          <Badge className='ml-1' variant='warning'>
-            API
-          </Badge>
-        )}
         {hasCoupons && (
           <Badge className='ml-1' variant='teal'>
             coupons


### PR DESCRIPTION
## What I did

The `ResourceListItem` is rendered as `expired` for promotions that have the `total_usage_count` equal to the `total_usage_limit`.

## How to test

<!-- Please include the steps to test your changes here -->
https://deploy-preview-582--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelistitem--docs#promotions

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
