### PR TITLE
Expose `debounceMs` prop to filters search bar

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
@@ -1,10 +1,11 @@
-import { SearchBar } from '#ui/composite/SearchBar'
+import { SearchBar, type SearchBarProps } from '#ui/composite/SearchBar'
 import castArray from 'lodash/castArray'
 import isEmpty from 'lodash/isEmpty'
 import { makeFilterAdapters } from './adapters'
 import { type FiltersInstructions } from './types'
 
-export interface FilterSearchBarProps {
+export interface FilterSearchBarProps
+  extends Pick<SearchBarProps, 'placeholder' | 'debounceMs'> {
   /**
    * Array of instruction items to build the filters behaviors
    */
@@ -20,10 +21,6 @@ export interface FilterSearchBarProps {
    * It must be "reactive", so most of the time it should come for router.
    */
   queryString: string
-  /**
-   * Input placeholder
-   */
-  placeholder?: string
   /**
    * By default, we strip out all filters that are not part of the `instructions` array.
    * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
@@ -44,7 +41,8 @@ function FiltersSearchBar({
   placeholder,
   onUpdate,
   queryString,
-  predicateWhitelist
+  predicateWhitelist,
+  debounceMs
 }: FilterSearchBarProps): JSX.Element {
   const { adaptUrlQueryToFormValues, adaptFormValuesToUrlQuery } =
     makeFilterAdapters({
@@ -92,6 +90,7 @@ function FiltersSearchBar({
       onClear={updateTextFilter}
       onSearch={updateTextFilter}
       autoFocus={safeInitialValue !== undefined && safeInitialValue.length > 0}
+      debounceMs={debounceMs}
     />
   )
 }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
@@ -60,6 +60,11 @@ interface UseResourceFiltersHook {
        * @default 'Search...'
        */
       searchBarPlaceholder?: string
+      /**
+       * Milliseconds to wait before triggering the search bar callback
+       * @default 500
+       */
+      searchBarDebounceMs?: number
     }
   ) => JSX.Element
   /**
@@ -167,6 +172,7 @@ export function useResourceFilters({
       onFilterClick,
       onUpdate,
       searchBarPlaceholder,
+      searchBarDebounceMs,
       // we need this value as prop to avoid re-rendering the component and losing the focus on searchbar
       // so we can't reuse the `queryString` variable we have in the hook scope
       queryString: queryStringProp,
@@ -183,6 +189,7 @@ export function useResourceFilters({
             <Spacer bottom='2'>
               <FiltersSearchBar
                 placeholder={searchBarPlaceholder ?? 'Search...'}
+                debounceMs={searchBarDebounceMs}
                 instructions={validInstructions}
                 onUpdate={onUpdate}
                 queryString={queryStringProp}


### PR DESCRIPTION
## What I did

I've exposed the debounceMs prop in FiltersSearchBar so the consumer app can use a custom debounce value.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
