### PR TITLE
Replace variant `card` with `boxed` in `ListItem` component

### DIFF
--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -4,7 +4,7 @@ import cn from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 import { useMemo, type FC } from 'react'
 
-type ListItemVariant = 'list' | 'card'
+type ListItemVariant = 'list' | 'boxed'
 
 type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
   /**
@@ -27,14 +27,14 @@ type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
    * Control the padding size.
    * @default '4'
    */
-  paddingSize?: '4' | '2'
+  paddingSize?: '6' | '4' | '2'
   /**
    * Border style to render
    * @default 'solid'
    */
-  borderStyle?: 'dashed' | 'solid' | 'none'
+  borderStyle?: 'solid' | 'none'
   /**
-   * ListItem variant: 'list' or 'card' with rounded borders
+   * ListItem variant: 'list' or 'boxed' with rounded borders
    * @default 'list'
    */
   variant?: ListItemVariant
@@ -88,11 +88,13 @@ export const ListItem: FC<ListItemProps> = ({
     (rest.onClick != null || (rest.tag === 'a' && !isEmpty(rest.href)))
 
   const pySize = cn({
+    'py-6': paddingSize === '6',
     'py-4': paddingSize === '4',
     'py-2': paddingSize === '2'
   })
 
   const pxSize = cn({
+    'px-6': paddingSize === '6',
     'px-4': paddingSize === '4',
     'px-2': paddingSize === '2'
   })
@@ -100,16 +102,16 @@ export const ListItem: FC<ListItemProps> = ({
   return (
     <JsxTag
       className={cn(
-        'flex gap-4 border-gray-100',
-        'text-gray-800 hover:text-gray-800 font-normal', // keep default text color also when used as `<a>` tag
+        'flex gap-4 bg-white',
+        'text-gray-800 hover:text-gray-800', // keep default text color also when used as `<a>` tag
         {
           [pySize]: padding !== 'none' && padding !== 'x',
           [pxSize]: padding !== 'none' && padding !== 'y',
-          'border-dashed': borderStyle === 'dashed',
           'border-b': borderStyle !== 'none',
           'cursor-pointer hover:bg-gray-50': hasHover,
-          'border rounded': variant === 'card',
-          'border-gray-200 bg-gray-100': disabled
+          'border-gray-200 bg-gray-100': disabled,
+          'border-gray-100': variant === 'list',
+          'rounded border border-gray-200': variant === 'boxed'
         },
         className
       )}

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -57,7 +57,6 @@ const children = (
     <WithSkeletonComponentB>C</WithSkeletonComponentB>
     <ListItem
       tag='div'
-      borderStyle='dashed'
       onClick={() => {
         alert('Hello world!')
       }}
@@ -73,7 +72,7 @@ const children = (
       <StatusIcon name='check' background='green' gap='large' />
       <RadialProgress percentage={42} />
     </ListItem>
-    <ListItem tag='div' borderStyle='dashed'>
+    <ListItem tag='div'>
       <div>
         <Text tag='div'>Ehi there!</Text>
         <Badge variant='primary'>APPROVED</Badge>

--- a/packages/docs/src/stories/composite/ListDetails.stories.tsx
+++ b/packages/docs/src/stories/composite/ListDetails.stories.tsx
@@ -47,7 +47,6 @@ export const WithListItem: StoryFn<typeof ListDetails> = (args) => (
       <ListItem
         tag='div'
         padding='y'
-        borderStyle='dashed'
         icon={
           <Avatar
             src='https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'

--- a/packages/docs/src/stories/composite/ListItem.stories.tsx
+++ b/packages/docs/src/stories/composite/ListItem.stories.tsx
@@ -1,4 +1,6 @@
 import { Avatar } from '#ui/atoms/Avatar'
+import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
 import { RadialProgress } from '#ui/atoms/RadialProgress'
 import { StatusIcon } from '#ui/atoms/StatusIcon'
 import { Text } from '#ui/atoms/Text'
@@ -56,12 +58,33 @@ WithIcon.args = {
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />
 }
 
-export const Card = WithIconTemplate.bind({})
-Card.args = {
+export const Boxed = WithIconTemplate.bind({})
+Boxed.args = {
   tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
   onClick: () => {},
-  variant: 'card'
+  variant: 'boxed'
+}
+
+const BoxedCTATemplate: StoryFn<typeof ListItem> = (args) => (
+  <ListItem {...args}>
+    <Text>
+      Enable flexible price adjustments based on the quantities purchased.
+    </Text>
+    <Button variant='secondary' size='small' alignItems='center'>
+      <Icon name='plus' size={16} />
+      Volume tier
+    </Button>
+  </ListItem>
+)
+
+export const BoxedCTA = BoxedCTATemplate.bind({})
+BoxedCTA.args = {
+  tag: 'div',
+  icon: <Icon name='stack' size={32} />,
+  alignIcon: 'center',
+  variant: 'boxed',
+  paddingSize: '6'
 }
 
 export const Disabled = WithIconTemplate.bind({})
@@ -69,7 +92,7 @@ Disabled.args = {
   tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
   onClick: () => {},
-  variant: 'card',
+  variant: 'boxed',
   disabled: true
 }
 
@@ -108,7 +131,6 @@ export const OrderLine: StoryFn<typeof ListItem> = (args) => (
 )
 OrderLine.args = {
   padding: 'y',
-  borderStyle: 'dashed',
   icon: (
     <Avatar
       src='https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/BASEBHAT000000FFFFFFXXXX_FLAT.png'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Replaced variant `card` with `boxed` in `ListItem` component. All involved stories have been updated.
- Added new padding size `6` in `ListItem` component.
- Added a dedicated doc story to describe how to create the new card-like box with button that is now based on `ListItem` component.

<img width="800" alt="Boxed with CTA" src="https://github.com/commercelayer/app-elements/assets/105653649/217e59ab-d575-486d-b424-385382797f41">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
