### PR TITLE
InputReadonly to render multi line text content

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -17,15 +17,15 @@ a {
   --tw-shadow-color: rgb(230 231 231 / 1);
 }
 
-input, textarea {
+
+input, textarea, div[role=textbox] {
   border: none !important;
   box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
   -webkit-box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
   -moz-box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
 }
 
-input:focus-visible,
-textarea:focus-visible {
+input:focus-visible, textarea:focus-visible, div[role=textbox]:focus  {
   ring: none;
   outline: none !important;
   box-shadow: inset 0 0 0 2px theme(colors.primary.DEFAULT) !important;

--- a/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
+++ b/packages/app-elements/src/ui/atoms/CopyToClipboard.tsx
@@ -99,7 +99,7 @@ export const CopyToClipboard: React.FC<CopyToClipboardProps> = ({
           onClick={() => {
             void handleCopy(value)
           }}
-          className='text-xl cursor-pointer text-gray-300 hover:text-gray-500 relative'
+          className='text-xl cursor-pointer text-gray-500 hover:text-gray-300 relative'
           data-testid='copy-value-button'
         >
           {!copied ? (

--- a/packages/app-elements/src/ui/forms/InputReadonly.tsx
+++ b/packages/app-elements/src/ui/forms/InputReadonly.tsx
@@ -6,11 +6,7 @@ import {
 } from '#ui/internals/InputWrapper'
 import cn from 'classnames'
 
-export interface InputReadonlyProps extends InputWrapperBaseProps {
-  /**
-   * Controlled value
-   */
-  value?: string
+export type InputReadonlyProps = InputWrapperBaseProps & {
   /**
    * Optional CSS class names used for the outer wrapper/container element
    */
@@ -23,6 +19,15 @@ export interface InputReadonlyProps extends InputWrapperBaseProps {
    * Optional prop to define whether to show or not the Copy to clipboard button
    */
   showCopyAction?: boolean
+  /**
+   * Value to be rendered as simple input text
+   */
+  value?: string
+  /**
+   * Multi-line content to be rendered as textarea like.
+   * It only accepts a string and will respect new lines when passing a template literal (backticks).
+   */
+  children?: string
 }
 
 export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
@@ -36,8 +41,12 @@ export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
     feedback,
     isLoading,
     delayMs,
+    children,
     ...rest
   }) => {
+    const cssBase =
+      'block w-full rounded bg-gray-50 text-teal text-sm font-mono font-medium marker:font-bold border-none'
+
     return (
       <InputWrapper
         {...rest}
@@ -46,19 +55,44 @@ export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
         label={label}
         hint={hint}
       >
-        <div className='relative w-full select-none group'>
-          <input
-            className={cn(
-              'block w-full bg-gray-50 px-4 h-[44px] text-teal text-sm font-mono font-medium marker:font-bold border-none',
-              'rounded outline-0 !ring-0 group-hover:bg-gray-100',
-              inputClassName
-            )}
-            value={isLoading === true ? '' : value}
-            readOnly
-          />
+        <div className='relative w-full group'>
+          {children == null ? (
+            <input
+              className={cn(
+                cssBase,
+                'px-4 h-[44px] outline-0 !ring-0',
+                inputClassName
+              )}
+              value={isLoading === true ? '' : value}
+              readOnly
+            />
+          ) : (
+            <div
+              tabIndex={0}
+              role='textbox'
+              aria-label={label}
+              className={cn(
+                cssBase,
+                'flex flex-col px-4 py-[11px]',
+                inputClassName
+              )}
+            >
+              {children.split('\n').map((line, idx) => (
+                <span key={idx}>{line}</span>
+              ))}
+            </div>
+          )}
           {showCopyAction && (
-            <div className='absolute top-[2px] bottom-[2px] right-4 group-hover:bg-gray-100 flex items-center opacity-0 group-hover:opacity-100'>
-              <CopyToClipboard value={value} showValue={false} />
+            <div
+              className={cn('absolute right-4  flex', {
+                'top-[2px] items-center': children == null,
+                'top-2': children != null
+              })}
+            >
+              <CopyToClipboard
+                value={value ?? children?.trim()}
+                showValue={false}
+              />
             </div>
           )}
         </div>

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -143,7 +143,7 @@ module.exports = {
     },
     fontFamily: {
       sans: ['Manrope', 'ui-sans-serif', 'sans-serif'],
-      mono: ['ui-monospace', 'Menlo', 'monospace']
+      mono: ['Roboto Mono', 'ui-monospace', 'Menlo', 'monospace']
     },
     fontSize: {
       '2xs': '.688rem',

--- a/packages/docs/.storybook/preview-head.html
+++ b/packages/docs/.storybook/preview-head.html
@@ -3,6 +3,10 @@
   href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&display=swap"
   rel="stylesheet"
 />
+<link 
+  href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,500;1,500&display=swap" 
+  rel="stylesheet"
+/>
 <link rel="stylesheet" href="storybook-preview.css" />
 <script>
   window.global = window;

--- a/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
@@ -27,6 +27,22 @@ Default.args = {
   showCopyAction: true
 }
 
+/**
+ * In this example we are using the `children` prop to render a code snippet with multi-line content.
+ * Special characters like `\` need to be escaped with `\\` to be rendered correctly.
+ */
+export const MultiLine: StoryFn = () => {
+  return (
+    <InputReadonly label='Login with your admin credentials' showCopyAction>
+      {`commercelayer app:login \\
+      -i asdGvqXsOSsdko6ueiX9 \\
+      -s elyFpGvqXsOSss2Ua4No1_HxaKH_0rUsFuYiX9 \\
+      -o demo-store \\
+      -a admin`}
+    </InputReadonly>
+  )
+}
+
 export const WithHint = Template.bind({})
 WithHint.args = {
   label: 'Secret',


### PR DESCRIPTION
## What I did

I've updated the style for the InputReadonly to match the latest design changes and handle case where we want to show the contest as multiple lines of text.
In this case, a string can be passed as children.

Instead of using a `<textarea>` I went for a `<div role='textbox'>`, so we don't need to calculate height dynamically, while keeping everything responsive.

The font family for monospace text is now `Roboto Mono`, so we should update the consumer apps as well
```
<link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,500;1,500&display=swap" rel="stylesheet" />
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
