### PR TITLE
`hasCoupons` is now checking for the related promotion rule

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -412,9 +412,12 @@ export const presetResourceListItem = {
     percentage: 23,
     total_usage_limit: 3,
     active: true,
-    coupons: [
-      { code: '1234', created_at: '', id: '', type: 'coupons', updated_at: '' }
-    ]
+    coupon_codes_promotion_rule: {
+      type: 'coupon_codes_promotion_rules',
+      id: '',
+      created_at: '',
+      updated_at: '2023-06-10T06:38:44.964Z'
+    }
   }
 } satisfies Record<
   string,

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/promotions.tsx
@@ -14,7 +14,7 @@ export const promotionToProps: ResourceToProps<Omit<Promotion, 'type'>> = ({
   user
 }) => {
   const displayStatus = getPromotionDisplayStatus(resource)
-  const hasCoupons = (resource.coupons ?? []).length > 0
+  const hasCoupons = resource.coupon_codes_promotion_rule != null
 
   return {
     name: (


### PR DESCRIPTION
## What I did

I updated the `hasCoupons` check, that is now checking for the related promotion rule since it is faster.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
