### PR TITLE
Handle amounts and currencies  in sdk-to-metrics filters adapter

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.test.ts
@@ -21,7 +21,8 @@ describe('adaptSdkToMetrics', () => {
       aggregated_details: 'Commerce Layer',
       updated_at_gteq: '2023-01-31T23:00:00.000Z',
       updated_at_lteq: '2023-02-28T22:59:59.999Z',
-      total_amount_cents_lteq: '3000',
+      total_amount_cents_lteq: '3010',
+      total_amount_cents_gteq: '1030',
       currency_code_eq: 'USD',
       archived: true
     }
@@ -36,8 +37,6 @@ describe('adaptSdkToMetrics', () => {
           'aggregated_details',
           'updated_at_gteq',
           'updated_at_lteq',
-          'total_amount_cents_lteq',
-          'currency_code_eq',
           'archived'
         ]
       })
@@ -56,11 +55,11 @@ describe('adaptSdkToMetrics', () => {
         fulfillment_statuses: {
           in: ['fulfilled']
         },
-        total_amount_cents: {
-          lte: '3000'
+        currency_codes: {
+          in: ['USD']
         },
-        currency_code: {
-          eq: 'USD'
+        total_amount: {
+          gte_lte: [10.3, 30.1]
         },
         aggregated_details: { query: 'Commerce Layer' }
       },
@@ -86,5 +85,116 @@ describe('adaptSdkToMetrics', () => {
     expect(metricsFilters.order?.date_from).toBe('2022-04-05T15:20:01Z')
     expect(metricsFilters.order?.date_to).toBe('2023-04-05T15:20:00Z')
     expect(metricsFilters.order?.date_field).toBe('updated_at')
+  })
+
+  test('Should handle amount range and currency', () => {
+    const sdkFilters = {
+      total_amount_cents_lteq: '3010',
+      total_amount_cents_gteq: '1030',
+      currency_code_eq: 'EU'
+    }
+    expect(
+      adaptSdkToMetrics({
+        sdkFilters,
+        resourceType: 'orders',
+        instructions,
+        predicateWhitelist: []
+      })
+    ).toStrictEqual({
+      order: {
+        date_from: '2022-04-05T15:20:01Z',
+        date_to: '2023-04-05T15:20:00Z',
+        date_field: 'updated_at',
+        currency_codes: {
+          in: ['EU']
+        },
+        total_amount: {
+          gte_lte: [10.3, 30.1]
+        }
+      }
+    })
+  })
+
+  test('Should accept only lower then ', () => {
+    const sdkFilters = {
+      total_amount_cents_lteq: '3010'
+    }
+    expect(
+      adaptSdkToMetrics({
+        sdkFilters,
+        resourceType: 'orders',
+        instructions,
+        predicateWhitelist: []
+      })
+    ).toStrictEqual({
+      order: {
+        date_from: '2022-04-05T15:20:01Z',
+        date_to: '2023-04-05T15:20:00Z',
+        date_field: 'updated_at',
+        total_amount: {
+          lte: 30.1
+        }
+      }
+    })
+  })
+
+  test('Should accept only greaten', () => {
+    const sdkFilters = {
+      total_amount_cents_gt: '10'
+    }
+    expect(
+      adaptSdkToMetrics({
+        sdkFilters,
+        resourceType: 'orders',
+        instructions,
+        predicateWhitelist: []
+      })
+    ).toStrictEqual({
+      order: {
+        date_from: '2022-04-05T15:20:01Z',
+        date_to: '2023-04-05T15:20:00Z',
+        date_field: 'updated_at',
+        total_amount: {
+          gt: 0.1
+        }
+      }
+    })
+  })
+
+  test('Should handle values received as amount_float', () => {
+    const sdkFilters = {
+      total_amount_float_gt: 100.4
+    }
+    expect(
+      adaptSdkToMetrics({
+        sdkFilters,
+        resourceType: 'orders',
+        instructions: [
+          {
+            label: 'Amount',
+            type: 'currencyRange',
+            sdk: {
+              predicate: 'total_amount_float'
+            },
+            render: {
+              component: 'inputCurrencyRange',
+              props: {
+                label: 'Amount'
+              }
+            }
+          }
+        ],
+        predicateWhitelist: []
+      })
+    ).toStrictEqual({
+      order: {
+        date_from: '2022-04-05T15:20:01Z',
+        date_to: '2023-04-05T15:20:00Z',
+        date_field: 'created_at',
+        total_amount: {
+          gt: 100.4
+        }
+      }
+    })
   })
 })

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
@@ -53,7 +53,8 @@ export const makeFilterAdapters: MakeFiltersAdapters = ({
     adaptSdkToMetrics: (params) =>
       adaptSdkToMetricsFn({
         ...params,
-        instructions: validInstructions
+        instructions: validInstructions,
+        predicateWhitelist
       }),
 
     validInstructions


### PR DESCRIPTION
## What I did

I've added the missing logic to handle amounts and currency when using metrics API to fetch a filtered list of orders.

For each `currencyRange` item found in the filters instruction, I build the relative metrics API filter converting the logic, predicate and operators to valid ones.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
