### PR TITLE
`Card` can manage `href` and `onClick`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Card.tsx
+++ b/packages/app-elements/src/ui/atoms/Card.tsx
@@ -2,16 +2,17 @@ import { removeUnwantedProps } from '#utils/htmltags'
 import cn from 'classnames'
 import { withSkeletonTemplate } from './SkeletonTemplate'
 
-export type CardProps = React.HTMLAttributes<HTMLDivElement> & {
-  /**
-   * Footer will render in a dedicated section below the main content.
-   */
-  footer?: React.ReactNode
-  /**
-   * Set a gray background color
-   */
-  backgroundColor?: 'light'
-} & (
+export type CardProps = React.HTMLAttributes<HTMLElement> &
+  Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick' | 'href'> & {
+    /**
+     * Footer will render in a dedicated section below the main content.
+     */
+    footer?: React.ReactNode
+    /**
+     * Set a gray background color
+     */
+    backgroundColor?: 'light'
+  } & (
     | {
         /**
          * Possible values are:
@@ -52,19 +53,25 @@ export const Card = withSkeletonTemplate<CardProps>(
     const overflow = 'overflow' in rest ? rest.overflow : 'hidden'
     const divProps =
       'overflow' in rest ? removeUnwantedProps(rest, ['overflow']) : rest
+    const Tag =
+      rest.href != null ? 'a' : rest.onClick != null ? 'button' : 'div'
 
     return (
-      <div
+      <Tag
         className={cn([
           className,
           'border border-solid rounded-md',
+          'text-left', // reset <button>
+          'text-inherit active:text-inherit hover:text-inherit font-inherit', // reset <a>
           {
             'overflow-hidden': overflow === 'hidden',
             'border-gray-200 bg-white': backgroundColor == null,
             'bg-gray-50 border-gray-50': backgroundColor === 'light',
             'p-1': gap === '1',
             'p-4': gap === '4',
-            'p-6': gap === '6'
+            'p-6': gap === '6',
+            [`hover:border-black hover:shadow-hover`]:
+              Tag === 'a' || Tag === 'button'
           }
         ])}
         {...divProps}
@@ -91,7 +98,7 @@ export const Card = withSkeletonTemplate<CardProps>(
             {footer}
           </div>
         )}
-      </div>
+      </Tag>
     )
   }
 )

--- a/packages/app-elements/src/ui/atoms/StatusIcon.tsx
+++ b/packages/app-elements/src/ui/atoms/StatusIcon.tsx
@@ -23,7 +23,7 @@ export interface StatusIconProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * padding around the icon can bne: 'none' | 'small' | 'large'
    */
-  gap?: 'none' | 'small' | 'large'
+  gap?: 'none' | 'small' | 'medium' | 'large'
 }
 
 export const StatusIcon: React.FC<StatusIconProps> = ({
@@ -41,6 +41,7 @@ export const StatusIcon: React.FC<StatusIconProps> = ({
         'w-fit',
         // padding
         { 'p-[10px]': gap === 'large' },
+        { 'p-[6px]': gap === 'medium' },
         { 'p-[3px]': gap === 'small' },
         // variants
         { 'border rounded-full': background !== 'none' },

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -29,10 +29,12 @@ module.exports = {
       full: '9999px'
     },
     boxShadow: {
+      hover: '0 0 0 1px #101111',
       focus: '0 0 0 2px #666EFF',
       inputfocus: 'inset 0 0 0 2px #666EFF'
     },
     colors: {
+      inherit: 'inherit',
       primary: {
         light: `${colorBrand}${alphaToHex(80)}`,
         DEFAULT: colorBrand,
@@ -171,6 +173,9 @@ module.exports = {
       },
       objectPosition: {
         'out-of-bounds': '-99999px 99999px'
+      },
+      fontWeight: {
+        inherit: 'inherit'
       }
     }
   },

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -31,6 +31,18 @@ Default.args = {
   overflow: 'visible'
 }
 
+export const ButtonElement = Template.bind({})
+ButtonElement.args = {
+  onClick: () => {
+    alert('You just clicked!')
+  }
+}
+
+export const AnchorElement = Template.bind({})
+AnchorElement.args = {
+  href: 'https://example.com'
+}
+
 /** Card can have a `footer` that renders in dedicated section. */
 export const Footer: StoryFn<typeof Card> = (args) => (
   <Card {...args}>I'm the card content</Card>

--- a/packages/docs/src/stories/examples/Panel.stories.tsx
+++ b/packages/docs/src/stories/examples/Panel.stories.tsx
@@ -1,0 +1,55 @@
+import { Card } from '#ui/atoms/Card'
+import { Grid } from '#ui/atoms/Grid'
+import { Spacer } from '#ui/atoms/Spacer'
+import { StatusIcon } from '#ui/atoms/StatusIcon'
+import { Text } from '#ui/atoms/Text'
+import { type ListItem } from '#ui/composite/ListItem'
+import { Description, Primary, Subtitle, Title } from '@storybook/addon-docs'
+import { type Meta, type StoryFn } from '@storybook/react'
+
+const setup: Meta = {
+  title: 'Examples/Panel',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <Primary />
+        </>
+      )
+    }
+  }
+}
+export default setup
+
+export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
+  <Grid columns='2'>
+    <Card href='https://example.com' overflow='visible'>
+      <StatusIcon name='percent' background='black' gap='medium' />
+      <Spacer top='4'>
+        <Text weight='semibold'>Percentage discount</Text>
+        <p>
+          <Text size='small' variant='info'>
+            Apply a specific percentage discount to the subtotal amount of
+            orders.
+          </Text>
+        </p>
+      </Spacer>
+    </Card>
+
+    <Card href='https://example.com' overflow='visible'>
+      <StatusIcon name='truck' background='black' gap='medium' />
+      <Spacer top='4'>
+        <Text weight='semibold'>Free shipping</Text>
+        <p>
+          <Text size='small' variant='info'>
+            Set the shipping cost amount to zero for orders.
+          </Text>
+        </p>
+      </Spacer>
+    </Card>
+  </Grid>
+)


### PR DESCRIPTION
## What I did

The `Card` component is rendered as `<a>` when href is set, and is rendered as `<button>` when onClick is set.

https://github.com/commercelayer/app-elements/assets/1681269/18d65583-0c2b-4398-b716-b273b2d6a976

https://deploy-preview-596--commercelayer-app-elements.netlify.app/?path=/docs/atoms-card--docs#button-element

This way the `Card` component can be used as Panel:

<img width="684" alt="Card component as panel" src="https://github.com/commercelayer/app-elements/assets/1681269/37d970a6-505f-4eea-8db9-97a71c0a7187">

https://deploy-preview-596--commercelayer-app-elements.netlify.app/?path=/docs/examples-panel--docs