### PR TITLE
`Button` component is square when contains only one `Icon`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Button.tsx
+++ b/packages/app-elements/src/ui/atoms/Button.tsx
@@ -1,3 +1,4 @@
+import { isSpecificReactComponent } from '#utils/children'
 import cn from 'classnames'
 import { type ReactNode } from 'react'
 
@@ -57,14 +58,15 @@ export function Button({
     <button
       className={cn([
         className,
-        'rounded text-center focus:outline-none whitespace-nowrap',
+        'rounded text-center focus:outline-none whitespace-nowrap leading-5',
         {
           'opacity-50 pointer-events-none touch-none': disabled,
           'w-full': fullWidth === true,
           'flex gap-1': alignItems != null,
           'items-center': alignItems === 'center',
           [`text-sm transition-opacity duration-500 ${sizeCss[size]}`]:
-            variant !== 'link'
+            variant !== 'link',
+          '!p-[10px]': isSpecificReactComponent(children, [/^Icon$/])
         },
         variantCss[variant]
       ])}

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               <div>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded text-center focus:outline-none whitespace-nowrap font-bold text-primary hover:opacity-80"
+                  class="flex items-center rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
                 >
                   <svg
                     fill="currentColor"

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -1,5 +1,6 @@
 import { A } from '#ui/atoms/A'
 import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Button> = {
@@ -62,3 +63,11 @@ export const Link: StoryFn = (_args) => (
     </Button>
   </div>
 )
+
+/** A `<Button>` that contains only an `Icon` is rendered with a square shape. */
+export const IconOnly = Template.bind({})
+IconOnly.args = {
+  size: 'small',
+  variant: 'secondary',
+  children: <Icon name='dotsThree' size={16} />
+}


### PR DESCRIPTION

## What I did

`Button` component is square when contains only one `Icon`.

<img width="652" alt="Screenshot 2024-03-29 alle 15 24 26" src="https://github.com/commercelayer/app-elements/assets/1681269/e61634c8-8bf5-4e40-a193-5aca8ce9d362">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
