### PR TITLE
`A` component can render as a button

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -1,5 +1,5 @@
-@import "react-datepicker/dist/react-datepicker.css";
-@import "../ui/forms/InputDate/InputDateComponent.css";
+@import 'react-datepicker/dist/react-datepicker.css';
+@import '../ui/forms/InputDate/InputDateComponent.css';
 
 select {
   text-align: inherit;
@@ -9,23 +9,22 @@ body {
   @apply text-gray-800 antialiased font-medium;
 }
 
-a {
-  @apply text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer;
-}
-
 :root {
   --tw-shadow-color: rgb(230 231 231 / 1);
 }
 
-
-input, textarea, div[role=textbox] {
+input,
+textarea,
+div[role='textbox'] {
   border: none !important;
   box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
   -webkit-box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
   -moz-box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
 }
 
-input:focus-visible, textarea:focus-visible, div[role=textbox]:focus  {
+input:focus-visible,
+textarea:focus-visible,
+div[role='textbox']:focus {
   ring: none;
   outline: none !important;
   box-shadow: inset 0 0 0 2px theme(colors.primary.DEFAULT) !important;
@@ -33,7 +32,7 @@ input:focus-visible, textarea:focus-visible, div[role=textbox]:focus  {
   -moz-box-shadow: inset 0 0 0 2px theme(colors.primary.DEFAULT) !important;
 }
 
-input[type=radio] {
+input[type='radio'] {
   --tw-shadow-color: theme(colors.gray.200);
 }
 
@@ -64,4 +63,3 @@ progress.progress::-webkit-progress-value {
 progress.progress[value]::-moz-progress-bar {
   @apply rounded bg-primary;
 }
-

--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -42,9 +42,9 @@ select:focus-visible {
   outline-offset: 4px;
 }
 
-button:focus-visible {
-  outline: 2px solid theme(colors.primary.DEFAULT) !important;
-  outline-offset: 2px;
+a,
+button {
+  @apply focus-visible:outline focus-visible:outline-2 outline-offset-2 outline-primary;
 }
 
 progress.progress {

--- a/packages/app-elements/src/ui/atoms/A.test.tsx
+++ b/packages/app-elements/src/ui/atoms/A.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 import { A } from './A'
 
 describe('Anchor', () => {
-  test('Should be rendered', () => {
+  it('Should be rendered', () => {
     const { getByRole } = render(
       <A href='https://commercelayer.io'>My anchor tag</A>
     )
@@ -12,6 +12,75 @@ describe('Anchor', () => {
     expect(a.innerHTML).toBe('My anchor tag')
     expect(a.tagName).toBe('A')
     expect(a).toBeInstanceOf(HTMLAnchorElement)
+    expect(a.className).toContain('text-primary')
     expect(a.getAttribute('href')).toBe('https://commercelayer.io')
+  })
+
+  it('Should render as primary variant', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='primary'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('bg-black')
+    expect(getByRole('link').className).toContain('text-white')
+  })
+
+  it('Should render as secondary variant', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='secondary'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('bg-white')
+    expect(getByRole('link').className).toContain('text-black')
+    expect(getByRole('link').className).toContain('border border-black')
+  })
+
+  it('Should render as danger variant', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='danger'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('bg-white')
+    expect(getByRole('link').className).toContain('text-red')
+    expect(getByRole('link').className).toContain('border border-red')
+  })
+
+  it('Should render as size small', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='primary' size='small'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('px-4 py-2')
+  })
+
+  it('Should render as size regular (default)', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='primary'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('px-6 py-3')
+  })
+
+  it('Should render as size large', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' variant='primary' size='large'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('px-8 py-4')
+  })
+
+  it('Should render with flex alignment', () => {
+    const { getByRole } = render(
+      <A href='https://commercelayer.io' alignItems='center'>
+        click me
+      </A>
+    )
+    expect(getByRole('link').className).toContain('flex gap-1 items-center')
   })
 })

--- a/packages/app-elements/src/ui/atoms/A.tsx
+++ b/packages/app-elements/src/ui/atoms/A.tsx
@@ -1,17 +1,48 @@
+import cn from 'classnames'
 import { type SetRequired } from 'type-fest'
+import {
+  getInteractiveElementClassName,
+  type InteractiveElementProps
+} from '../internals/InteractiveElement.className'
 
 export type AProps = SetRequired<
   React.AnchorHTMLAttributes<HTMLAnchorElement>,
   'href'
->
+> &
+  InteractiveElementProps
 
 /**
  * This component wraps an [`<a>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) HTML element.
- * <span type='info'>All the props are directly sent to the anchor element.</span>
+ * <span type='info'>This component is always rendered as an accessible `<a>` HTML element. It has the same props from the `Button` component, so it can renders as a button (UI only).</span>
  */
-export const A: React.FC<AProps> = ({ children, href, ...rest }) => {
+export const A: React.FC<AProps> = ({
+  alignItems,
+  children,
+  className,
+  disabled,
+  fullWidth,
+  href,
+  size = 'regular',
+  variant = 'link',
+  ...rest
+}) => {
   return (
-    <a href={href} {...rest}>
+    <a
+      className={cn(
+        className,
+        getInteractiveElementClassName({
+          alignItems,
+          children,
+          disabled,
+          fullWidth,
+          size,
+          variant
+        })
+      )}
+      aria-disabled={disabled}
+      href={href}
+      {...rest}
+    >
       {children}
     </a>
   )

--- a/packages/app-elements/src/ui/atoms/Button.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Button.test.tsx
@@ -1,109 +1,59 @@
-import { render, type RenderResult } from '@testing-library/react'
-import { Button, type ButtonProps } from './Button'
-
-interface SetupProps {
-  id: string
-  text: string
-  variant?: ButtonProps['variant']
-  size?: ButtonProps['size']
-  alignItems?: ButtonProps['alignItems']
-}
-
-type SetupResult = RenderResult & {
-  element: HTMLElement
-}
-
-const setup = ({
-  id,
-  variant,
-  size,
-  text,
-  alignItems
-}: SetupProps): SetupResult => {
-  const utils = render(
-    <Button
-      data-testid={id}
-      variant={variant}
-      size={size}
-      alignItems={alignItems}
-    >
-      {text}
-    </Button>
-  )
-  const element = utils.getByTestId(id)
-  return {
-    element,
-    ...utils
-  }
-}
+import { render } from '@testing-library/react'
+import { Button } from './Button'
 
 describe('Button', () => {
-  test('Should be rendered', () => {
-    const { element } = setup({ id: 'clickme', text: 'click me' })
-    expect(element.innerHTML).toBe('click me')
-    expect(element.tagName).toBe('BUTTON')
+  it('Should be rendered', () => {
+    const { getByRole } = render(<Button>click me</Button>)
+
+    const button = getByRole('button')
+    expect(button).toBeVisible()
+    expect(button.innerHTML).toBe('click me')
+    expect(button.tagName).toBe('BUTTON')
+    expect(button).toBeInstanceOf(HTMLButtonElement)
   })
 
-  test('Should render as primary variant', () => {
-    const { element } = setup({ id: 'primary', text: 'Primary variant' })
-    expect(element.className).toContain('bg-black')
-    expect(element.className).toContain('text-white')
+  it('Should render as primary variant', () => {
+    const { getByRole } = render(<Button>click me</Button>)
+    expect(getByRole('button').className).toContain('bg-black')
+    expect(getByRole('button').className).toContain('text-white')
   })
 
-  test('Should render as secondary variant', () => {
-    const { element } = setup({
-      id: 'secondary',
-      variant: 'secondary',
-      text: 'Secondary variant'
-    })
-    expect(element.className).toContain('bg-white')
-    expect(element.className).toContain('text-black')
-    expect(element.className).toContain('border border-black')
+  it('Should render as link variant', () => {
+    const { getByRole } = render(<Button variant='link'>click me</Button>)
+    expect(getByRole('button').className).toContain('text-primary')
   })
 
-  test('Should render as danger variant', () => {
-    const { element } = setup({
-      id: 'danger',
-      variant: 'danger',
-      text: 'Danger variant'
-    })
-    expect(element.className).toContain('bg-white')
-    expect(element.className).toContain('text-red')
-    expect(element.className).toContain('border border-red')
+  it('Should render as secondary variant', () => {
+    const { getByRole } = render(<Button variant='secondary'>click me</Button>)
+    expect(getByRole('button').className).toContain('bg-white')
+    expect(getByRole('button').className).toContain('text-black')
+    expect(getByRole('button').className).toContain('border border-black')
   })
 
-  test('Should render as size small', () => {
-    const { element } = setup({
-      id: 'danger',
-      size: 'small',
-      text: 'Small button'
-    })
-    expect(element.className).toContain('px-4 py-2')
+  it('Should render as danger variant', () => {
+    const { getByRole } = render(<Button variant='danger'>click me</Button>)
+    expect(getByRole('button').className).toContain('bg-white')
+    expect(getByRole('button').className).toContain('text-red')
+    expect(getByRole('button').className).toContain('border border-red')
   })
 
-  test('Should render as size regular (default)', () => {
-    const { element } = setup({
-      id: 'danger',
-      text: 'Regular button'
-    })
-    expect(element.className).toContain('px-6 py-3')
+  it('Should render as size small', () => {
+    const { getByRole } = render(<Button size='small'>click me</Button>)
+    expect(getByRole('button').className).toContain('px-4 py-2')
   })
 
-  test('Should render as size large', () => {
-    const { element } = setup({
-      id: 'danger',
-      size: 'large',
-      text: 'Large button'
-    })
-    expect(element.className).toContain('px-8 py-4')
+  it('Should render as size regular (default)', () => {
+    const { getByRole } = render(<Button>click me</Button>)
+    expect(getByRole('button').className).toContain('px-6 py-3')
   })
 
-  test('Should render with flex alignment', () => {
-    const { element } = setup({
-      id: 'flex',
-      text: 'Flex button',
-      alignItems: 'center'
-    })
-    expect(element.className).toContain('flex gap-1 items-center')
+  it('Should render as size large', () => {
+    const { getByRole } = render(<Button size='large'>click me</Button>)
+    expect(getByRole('button').className).toContain('px-8 py-4')
+  })
+
+  it('Should render with flex alignment', () => {
+    const { getByRole } = render(<Button alignItems='center'>click me</Button>)
+    expect(getByRole('button').className).toContain('flex gap-1 items-center')
   })
 })

--- a/packages/app-elements/src/ui/atoms/Button.tsx
+++ b/packages/app-elements/src/ui/atoms/Button.tsx
@@ -1,75 +1,40 @@
-import { isSpecificReactComponent } from '#utils/children'
 import cn from 'classnames'
-import { type ReactNode } from 'react'
+import {
+  getInteractiveElementClassName,
+  type InteractiveElementProps
+} from '../internals/InteractiveElement.className'
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /**
-   * Button content
-   */
-  children: ReactNode
-  /**
-   * Render a different variant
-   */
-  variant?: ButtonVariant
-  /**
-   * Set button size
-   */
-  size?: ButtonSize
-  /**
-   * Set button width to 100%
-   */
-  fullWidth?: boolean
-  /**
-   * Flex content alignment with a standard gap
-   */
-  alignItems?: 'center'
-}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  InteractiveElementProps
 
-type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'link'
-type ButtonSize = 'small' | 'regular' | 'large'
-
-const sizeCss: Record<ButtonSize, string> = {
-  small: 'px-4 py-2',
-  regular: 'px-6 py-3',
-  large: 'px-8 py-4'
-}
-
-const variantCss: Record<ButtonVariant, string> = {
-  primary: 'font-bold bg-black border border-black text-white hover:opacity-80',
-  secondary:
-    'font-semibold bg-white border border-black text-black hover:opacity-80 hover:bg-gray-50',
-  danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
-  link: 'font-bold text-primary hover:opacity-80'
-}
-
-/** Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, or performing an action. */
+/**
+ * This component wraps a [`<button>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) HTML element.
+ * Button component is used to trigger an action or event, such as submitting a form, opening a Dialog, or performing an action.
+ * <span type='info'>This component is always rendered as an accessible `<button>` HTML element. It has the same props from the `A` component, so it can renders as a link (UI only).</span>
+ */
 export function Button({
+  alignItems,
   children,
   className,
-  size = 'regular',
-  variant = 'primary',
   disabled,
   fullWidth,
-  alignItems,
+  size = 'regular',
+  variant = 'primary',
   ...rest
 }: ButtonProps): JSX.Element {
   return (
     <button
-      className={cn([
+      className={cn(
         className,
-        'rounded text-center focus:outline-none whitespace-nowrap leading-5',
-        {
-          'opacity-50 pointer-events-none touch-none': disabled,
-          'w-full': fullWidth === true,
-          'flex gap-1': alignItems != null,
-          'items-center': alignItems === 'center',
-          [`text-sm transition-opacity duration-500 ${sizeCss[size]}`]:
-            variant !== 'link',
-          '!p-[10px]': isSpecificReactComponent(children, [/^Icon$/])
-        },
-        variantCss[variant]
-      ])}
+        getInteractiveElementClassName({
+          alignItems,
+          children,
+          disabled,
+          fullWidth,
+          size,
+          variant
+        })
+      )}
       disabled={disabled}
       {...rest}
     >

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -82,6 +82,7 @@ export const iconMapping = {
   upload: phosphor.Upload,
   user: phosphor.User,
   userCircle: phosphor.UserCircle,
+  userRectangle: phosphor.UserRectangle,
   users: phosphor.Users,
   warehouse: phosphor.Warehouse,
   warning: phosphor.Warning,

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
+      class="m-0 p-0 align-top rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -2,7 +2,7 @@ import { isSpecificReactComponent } from '#utils/children'
 import cn from 'classnames'
 
 type Variant = 'primary' | 'secondary' | 'danger' | 'link'
-type Size = 'small' | 'regular' | 'large'
+type Size = 'mini' | 'small' | 'regular' | 'large'
 
 export interface InteractiveElementProps {
   children: React.ReactNode
@@ -42,7 +42,7 @@ export function getInteractiveElementClassName({
     {
       'opacity-50 pointer-events-none touch-none': disabled,
       'w-full': fullWidth === true && variant !== 'link',
-      'flex gap-1': alignItems != null,
+      'inline-flex gap-1': alignItems != null,
       'items-center justify-center': alignItems === 'center',
       'inline w-fit': variant === 'link',
       [`inline-block text-center text-sm transition-opacity duration-500 ${getSizeCss(size)}`]:
@@ -59,6 +59,7 @@ function getSizeCss(size: InteractiveElementProps['size']): string | undefined {
   }
 
   const mapping = {
+    mini: 'px-2.5 py-1',
     small: 'px-4 py-2',
     regular: 'px-6 py-3',
     large: 'px-8 py-4'

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -1,0 +1,87 @@
+import { isSpecificReactComponent } from '#utils/children'
+import cn from 'classnames'
+
+type Variant = 'primary' | 'secondary' | 'danger' | 'link'
+type Size = 'small' | 'regular' | 'large'
+
+export interface InteractiveElementProps {
+  children: React.ReactNode
+  /**
+   * Render a different variant
+   */
+  variant?: Variant
+  /**
+   * Set _button size_. It only works when the `variant` prop is different from `link`.
+   */
+  size?: Size
+  /**
+   * Set the _button width_ to 100%. It only works when the `variant` prop is different from `link`.
+   */
+  fullWidth?: boolean
+  /**
+   * Flex content alignment with a standard gap
+   */
+  alignItems?: 'center'
+  /**
+   * When element is disabled, the user cannot interact with it
+   */
+  disabled?: boolean | undefined
+}
+
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export function getInteractiveElementClassName({
+  alignItems,
+  children,
+  disabled,
+  fullWidth,
+  size,
+  variant
+}: InteractiveElementProps) {
+  return cn([
+    'rounded focus:outline-none whitespace-nowrap leading-5',
+    {
+      'opacity-50 pointer-events-none touch-none': disabled,
+      'w-full': fullWidth === true && variant !== 'link',
+      'flex gap-1': alignItems != null,
+      'items-center justify-center': alignItems === 'center',
+      'inline w-fit': variant === 'link',
+      [`inline-block text-center text-sm transition-opacity duration-500 ${getSizeCss(size)}`]:
+        variant !== 'link',
+      '!p-[10px]': isSpecificReactComponent(children, [/^Icon$/])
+    },
+    getVariantCss(variant)
+  ])
+}
+
+function getSizeCss(size: InteractiveElementProps['size']): string | undefined {
+  if (size == null) {
+    return undefined
+  }
+
+  const mapping = {
+    small: 'px-4 py-2',
+    regular: 'px-6 py-3',
+    large: 'px-8 py-4'
+  } satisfies Record<NonNullable<InteractiveElementProps['size']>, string>
+
+  return mapping[size]
+}
+
+function getVariantCss(
+  variant: InteractiveElementProps['variant']
+): string | undefined {
+  if (variant == null) {
+    return undefined
+  }
+
+  const mapping = {
+    primary:
+      'font-bold bg-black border border-black text-white hover:opacity-80',
+    secondary:
+      'font-semibold bg-white border border-black text-black hover:opacity-80 hover:bg-gray-50',
+    danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
+    link: 'text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer'
+  } satisfies Record<NonNullable<InteractiveElementProps['variant']>, string>
+
+  return mapping[variant]
+}

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -38,7 +38,7 @@ export function getInteractiveElementClassName({
   variant
 }: InteractiveElementProps) {
   return cn([
-    'rounded focus:outline-none whitespace-nowrap leading-5',
+    'rounded whitespace-nowrap leading-5',
     {
       'opacity-50 pointer-events-none touch-none': disabled,
       'w-full': fullWidth === true && variant !== 'link',
@@ -81,7 +81,7 @@ function getVariantCss(
     secondary:
       'font-semibold bg-white border border-black text-black hover:opacity-80 hover:bg-gray-50',
     danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
-    link: 'text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer'
+    link: 'text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer'
   } satisfies Record<NonNullable<InteractiveElementProps['variant']>, string>
 
   return mapping[variant]

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               <div>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded text-center focus:outline-none whitespace-nowrap leading-5 font-bold text-primary hover:opacity-80"
+                  class="flex items-center rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               <div>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded focus:outline-none whitespace-nowrap leading-5 inline w-fit text-primary font-bold outline-0 focus-visible:outline-2 focus-visible:rounded outline-offset-4 outline-primary hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"

--- a/packages/docs/src/stories/atoms/A.stories.tsx
+++ b/packages/docs/src/stories/atoms/A.stories.tsx
@@ -1,9 +1,15 @@
 import { A } from '#ui/atoms/A'
+import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
+import { Spacer } from '#ui/atoms/Spacer'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof A> = {
   title: 'Atoms/A',
   component: A,
+  parameters: {
+    layout: 'padded'
+  },
   argTypes: {
     href: {
       type: {
@@ -23,14 +29,103 @@ const setup: Meta<typeof A> = {
 export default setup
 
 const Template: StoryFn<typeof A> = (args) => (
-  <>
-    <A {...args}>I am the &lt;A&gt; element</A>
-    <a {...args}>I am an &lt;a&gt; HTML element</a>
-  </>
+  <div>
+    <A {...args}>Hello</A>
+  </div>
 )
 
 export const Default = Template.bind({})
 Default.args = {
   href: 'https://commercelayer.io',
-  target: '_blank'
+  target: '_blank',
+  disabled: false
 }
+
+/** The `a` HTML element is not styled. If you need to add a link to the page, you need to use the `A` component. */
+export const HTMLElementIsNotStyled: StoryFn = () => (
+  <>
+    <A href='https://commercelayer.io' target='_blank'>
+      I am the &lt;A&gt; element
+    </A>
+    <a href='https://commercelayer.io' target='_blank' rel='noreferrer'>
+      I am an &lt;a&gt; HTML element
+    </a>
+  </>
+)
+
+export const WithText: StoryFn = () => (
+  <div>
+    A{' '}
+    <A href='https://commercelayer.io' target='_blank'>
+      link
+    </A>{' '}
+    in between other text.
+  </div>
+)
+
+export const VariantLink: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A href='https://commercelayer.io' target='_blank'>
+        I am an &lt;a&gt; element
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button variant='link'>I am a &lt;button&gt; element</Button>
+    </Spacer>
+  </div>
+)
+
+export const VariantPrimary: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A href='https://commercelayer.io' target='_blank' variant='primary'>
+        I am an &lt;a&gt; element
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button>I am a &lt;button&gt; element</Button>
+    </Spacer>
+  </div>
+)
+
+export const VariantSecondary: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A href='https://commercelayer.io' target='_blank' variant='secondary'>
+        I am an &lt;a&gt; element
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button variant='secondary'>I am a &lt;button&gt; element</Button>
+    </Spacer>
+  </div>
+)
+
+export const VariantDanger: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A href='https://commercelayer.io' target='_blank' variant='danger'>
+        I am an &lt;a&gt; element
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button variant='danger'>I am a &lt;button&gt; element</Button>
+    </Spacer>
+  </div>
+)
+
+export const WithIconOnly: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A href='https://commercelayer.io' target='_blank' variant='secondary'>
+        <Icon name='dotsThree' size={16} />
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button variant='secondary'>
+        <Icon name='dotsThree' size={16} />
+      </Button>
+    </Spacer>
+  </div>
+)

--- a/packages/docs/src/stories/atoms/A.stories.tsx
+++ b/packages/docs/src/stories/atoms/A.stories.tsx
@@ -115,6 +115,27 @@ export const VariantDanger: StoryFn = () => (
   </div>
 )
 
+export const VariantSecondaryMini: StoryFn = () => (
+  <div>
+    <Spacer>
+      <A
+        href='https://commercelayer.io'
+        target='_blank'
+        variant='secondary'
+        size='mini'
+        alignItems='center'
+      >
+        <Icon name='plus' size={16} /> Rule
+      </A>
+    </Spacer>
+    <Spacer top='4'>
+      <Button variant='secondary' size='mini' alignItems='center'>
+        <Icon name='plus' size={16} /> Rule
+      </Button>
+    </Spacer>
+  </div>
+)
+
 export const WithIconOnly: StoryFn = () => (
   <div>
     <Spacer>

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -38,11 +38,16 @@ Secondary.args = {
   children: 'Add webhook'
 }
 
-export const SecondarySmall = Template.bind({})
-SecondarySmall.args = {
-  size: 'small',
+export const SecondaryMini = Template.bind({})
+SecondaryMini.args = {
+  size: 'mini',
   variant: 'secondary',
-  children: 'Add webhook'
+  alignItems: 'center',
+  children: (
+    <>
+      <Icon name='plus' size={16} /> Rule
+    </>
+  )
 }
 
 /** A `<Button>` can also be rendered as a `link` anytime you need a inline action that doesn't point to a url. */

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -64,6 +64,12 @@ export const Link: StoryFn = (_args) => (
   </div>
 )
 
+export const WithText: StoryFn = () => (
+  <div>
+    A <Button variant='link'>button</Button> in between other text.
+  </div>
+)
+
 /** A `<Button>` that contains only an `Icon` is rendered with a square shape. */
 export const IconOnly = Template.bind({})
 IconOnly.args = {

--- a/packages/docs/src/stories/composite/List.stories.tsx
+++ b/packages/docs/src/stories/composite/List.stories.tsx
@@ -1,4 +1,5 @@
-import { Button } from '#ui/atoms/Button'
+import { A } from '#ui/atoms/A'
+import { Icon } from '#ui/atoms/Icon'
 import { List } from '#ui/composite/List'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -23,7 +24,16 @@ const Template: StoryFn<typeof List> = (args) => (
 export const Default = Template.bind({})
 Default.args = {
   title: 'All items',
-  actionButton: <Button variant='link'>New item</Button>
+  actionButton: (
+    <A
+      href='https://commercelayer.io'
+      variant='secondary'
+      size='mini'
+      alignItems='center'
+    >
+      <Icon name='plus' /> New item
+    </A>
+  )
 }
 
 export const WithPagination = Template.bind({})


### PR DESCRIPTION
## What I did

The `A` component can render as a button (UI only) and the `Button` component can render as a link (UI only).

Examples for `<A>` are here:
https://deploy-preview-598--commercelayer-app-elements.netlify.app/?path=/docs/atoms-a--docs

Examples for `<Button>` are here:
https://deploy-preview-598--commercelayer-app-elements.netlify.app/?path=/docs/atoms-button--docs

I also added the `mini` size that can be used as mini button when adding new elements:
https://deploy-preview-598--commercelayer-app-elements.netlify.app/?path=/docs/composite-list--docs

## Accessibility

When you need to link to an internal or external page, you always have to use the `<A>` component. You can use the `variant` prop to render the link as a button.

When you need to do some action on click, you always have to use the `<Button>` component. You can use the `variant="link"` prop to render the button as a link.

```tsx
<A href="https://example.com" target="_blank" variant="primary">Example link</A>

// will always render to

<a href="https://example.com" target="_blank" class=" . . . ">Example link</a>
```

This is a link even if it looks like a button:
<img width="171" alt="This is a link even if it looks like a button" src="https://github.com/commercelayer/app-elements/assets/1681269/829e6e30-cbe5-46ba-b53d-d89893e19eeb">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
