### PR TITLE
Add resource filters adapter to transform SDK filter object to URL query string

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToUrlQuery.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToUrlQuery.test.ts
@@ -1,0 +1,56 @@
+import { adaptSdkToUrlQuery } from '#ui/resources/useResourceFilters/adaptSdkToUrlQuery'
+import { instructions } from './mockedInstructions'
+
+describe('adaptSdkToUrlQuery', () => {
+  test('should build proper query string alphabetically sorted', () => {
+    expect(
+      adaptSdkToUrlQuery({
+        sdkFilters: {
+          payment_status_eq: 'authorized',
+          status_in: 'approved,cancelled',
+          market_id_in: 'dlQbPhNNop'
+        },
+        instructions
+      })
+    ).toBe(
+      'market_id_in=dlQbPhNNop&payment_status_eq=authorized&status_in=approved&status_in=cancelled'
+    )
+  })
+
+  test('should ignore empty values', () => {
+    expect(
+      adaptSdkToUrlQuery({
+        sdkFilters: {
+          market_id_in: '',
+          status_in: 'approved'
+        },
+        instructions
+      })
+    ).toBe('status_in=approved')
+  })
+
+  test('should ignore predicates not defined in instructions', () => {
+    expect(
+      adaptSdkToUrlQuery({
+        sdkFilters: {
+          lastname_eq: 'doe',
+          status_in: 'approved,cancelled'
+        },
+        instructions
+      })
+    ).toBe('status_in=approved&status_in=cancelled')
+  })
+
+  test('should consider predicates not defined in instructions but whitelisted', () => {
+    expect(
+      adaptSdkToUrlQuery({
+        sdkFilters: {
+          lastname_eq: 'doe',
+          status_in: 'approved,cancelled'
+        },
+        instructions,
+        predicateWhitelist: ['lastname_eq']
+      })
+    ).toBe('lastname_eq=doe&status_in=approved&status_in=cancelled')
+  })
+})

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToUrlQuery.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToUrlQuery.ts
@@ -1,0 +1,37 @@
+import { type FiltersInstructions } from '#ui/resources/useResourceFilters/types'
+import { type QueryFilter } from '@commercelayer/sdk/lib/cjs/query'
+import queryString from 'query-string'
+import { adaptUrlQueryToUrlQuery } from './adaptUrlQueryToUrlQuery'
+
+export interface AdaptSdkToUrlQueryParams {
+  sdkFilters: QueryFilter
+  instructions: FiltersInstructions
+  predicateWhitelist?: string[]
+}
+
+export function adaptSdkToUrlQuery({
+  sdkFilters,
+  predicateWhitelist,
+  instructions
+}: AdaptSdkToUrlQueryParams): string {
+  const sdkFiltersWithArrayValues = Object.entries(sdkFilters).reduce(
+    (acc, [key, value]) => {
+      return {
+        ...acc,
+        [key]:
+          key.includes('_in') && typeof value === 'string'
+            ? value.split(',')
+            : value
+      }
+    },
+    {}
+  )
+
+  const query = queryString.stringify(sdkFiltersWithArrayValues)
+
+  return adaptUrlQueryToUrlQuery({
+    queryString: query,
+    predicateWhitelist,
+    instructions
+  })
+}

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.ts
@@ -1,6 +1,7 @@
 import { adaptFormValuesToSdk as adaptFormValuesToSdkFn } from './adaptFormValuesToSdk'
 import { adaptFormValuesToUrlQuery as adaptFormValuesToUrlQueryFn } from './adaptFormValuesToUrlQuery'
 import { adaptSdkToMetrics as adaptSdkToMetricsFn } from './adaptSdkToMetrics'
+import { adaptSdkToUrlQuery as adaptSdkToUrlQueryFn } from './adaptSdkToUrlQuery'
 import { adaptUrlQueryToFormValues as adaptUrlQueryToFormValuesFn } from './adaptUrlQueryToFormValues'
 import { adaptUrlQueryToSdk as adaptUrlQueryToSdkFn } from './adaptUrlQueryToSdk'
 import { adaptUrlQueryToUrlQuery as adaptUrlQueryToUrlQueryFn } from './adaptUrlQueryToUrlQuery'
@@ -52,6 +53,13 @@ export const makeFilterAdapters: MakeFiltersAdapters = ({
 
     adaptSdkToMetrics: (params) =>
       adaptSdkToMetricsFn({
+        ...params,
+        instructions: validInstructions,
+        predicateWhitelist
+      }),
+
+    adaptSdkToUrlQuery: (params) =>
+      adaptSdkToUrlQueryFn({
         ...params,
         instructions: validInstructions,
         predicateWhitelist

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adapters.types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adapters.types.ts
@@ -1,10 +1,11 @@
-import {
-  type AdaptSdkToMetricsParams,
-  type MetricsFilters
-} from '#ui/resources/useResourceFilters/adaptSdkToMetrics'
 import { type QueryFilter } from '@commercelayer/sdk/lib/cjs/query'
 import { type AdaptFormValuesToSdkParams } from './adaptFormValuesToSdk'
 import { type AdaptFormValuesToUrlQueryParams } from './adaptFormValuesToUrlQuery'
+import {
+  type AdaptSdkToMetricsParams,
+  type MetricsFilters
+} from './adaptSdkToMetrics'
+import { type AdaptSdkToUrlQueryParams } from './adaptSdkToUrlQuery'
 import { type AdaptUrlQueryToFormValuesParams } from './adaptUrlQueryToFormValues'
 import { type AdaptUrlQueryToSdkParams } from './adaptUrlQueryToSdk'
 import { type AdaptUrlQueryToUrlQueryParams } from './adaptUrlQueryToUrlQuery'
@@ -49,6 +50,10 @@ interface MakeFilterAdaptersReturn<FilterFormValues extends FormFullValues> {
   adaptSdkToMetrics: (
     params: Pick<AdaptSdkToMetricsParams, 'sdkFilters' | 'resourceType'>
   ) => MetricsFilters
+
+  adaptSdkToUrlQuery: (
+    params: Pick<AdaptSdkToUrlQueryParams, 'sdkFilters'>
+  ) => string
 
   validInstructions: FiltersInstructions
 }


### PR DESCRIPTION
## What I did

I've added a new adapter `adaptSdkToUrlQuery` in the `useResourceFilters` hook.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
