### PR TITLE
Remove `tag` prop from `ListItem` component

### DIFF
--- a/packages/app-elements/src/ui/composite/CardDialog.tsx
+++ b/packages/app-elements/src/ui/composite/CardDialog.tsx
@@ -63,7 +63,6 @@ export const CardDialog = withSkeletonTemplate<CardDialogProps>(
     return (
       <Card {...rest} overflow='visible' footer={footer}>
         <ListItem
-          tag='div'
           alignItems='top'
           padding='y'
           borderStyle='none'
@@ -73,7 +72,6 @@ export const CardDialog = withSkeletonTemplate<CardDialogProps>(
           <div>
             <ListItem
               borderStyle={hasChildren ? undefined : 'none'}
-              tag='div'
               padding='y'
               className={cn('pt-0', { 'pb-0': !hasChildren })}
               alignItems='top'

--- a/packages/app-elements/src/ui/composite/ListItem.test.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.test.tsx
@@ -17,14 +17,21 @@ const setup = (props: ListItemProps): SetupResult => {
 
 describe('ListItem', () => {
   test('Should be rendered as div', async () => {
-    const onClick = vi.fn()
     const { element } = setup({
-      tag: 'div',
-      onClick,
       children: <div>Content</div>
     })
     expect(element).toBeInTheDocument()
     expect(element.tagName).toBe('DIV')
+  })
+
+  test('Should be rendered as button', async () => {
+    const onClick = vi.fn()
+    const { element } = setup({
+      onClick,
+      children: <div>Content</div>
+    })
+    expect(element).toBeInTheDocument()
+    expect(element.tagName).toBe('BUTTON')
     act(() => {
       element.click()
     })
@@ -33,33 +40,20 @@ describe('ListItem', () => {
 
   test('Should be rendered as anchor', () => {
     const { element } = setup({
-      tag: 'a',
       href: 'https://www.commercelayer.io',
       children: <div>Content</div>
     })
     expect(element).toBeInTheDocument()
     expect(element.tagName).toBe('A')
     expect(element.getAttribute('href')).toBe('https://www.commercelayer.io')
-    expect(element).toHaveClass('cursor-pointer', 'hover:bg-gray-50')
+    expect(element).toHaveClass('hover:bg-gray-50')
   })
 
   test('Should not have hover effect when href is not set', () => {
     const { element } = setup({
-      tag: 'a',
       children: <div>Content</div>
     })
     expect(element).toBeInTheDocument()
-    expect(element.tagName).toBe('A')
-    expect(element).not.toHaveClass('cursor-pointer', 'hover:bg-gray-50')
-  })
-
-  test('Should not be rendered with `tag` as attribute', () => {
-    // this should never happen <div tag="div" /> | <a tag="a" />
-    const { element } = setup({
-      tag: 'div',
-      children: <div>Content</div>
-    })
-    expect(element).toBeInTheDocument()
-    expect(element.getAttribute('tag')).toBe(null)
+    expect(element).not.toHaveClass('hover:bg-gray-50')
   })
 })

--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -59,7 +59,7 @@ export const ListItem: FC<ListItemProps> = ({
   disabled = false,
   ...rest
 }) => {
-  const divProps =
+  const wantedProps =
     'overflow' in rest ? removeUnwantedProps(rest, ['overflow']) : rest
   const Tag = rest.href != null ? 'a' : rest.onClick != null ? 'button' : 'div'
   const isClickable = !disabled && (rest.href != null || rest.onClick != null)
@@ -92,11 +92,12 @@ export const ListItem: FC<ListItemProps> = ({
           'bg-gray-100': disabled,
           'border-gray-200': variant === 'boxed' || disabled,
           'border-gray-100': variant === 'list',
-          'text-left': divProps.onClick != null // to prevent standard behavior of `button` elements (with centered content)
+          'text-left': wantedProps.onClick != null // to prevent standard behavior of `button` elements (with centered content)
         },
         className
       )}
-      {...divProps}
+      type={rest.onClick != null ? 'button' : undefined}
+      {...wantedProps}
     >
       <div className={cn('flex gap-4 flex-1 items-center')}>
         {icon != null && (

--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -1,65 +1,50 @@
 import { FlexRow, type FlexRowProps } from '#ui/internals/FlexRow'
-import { enforceAllowedTags, removeUnwantedProps } from '#utils/htmltags'
+import { removeUnwantedProps } from '#utils/htmltags'
 import cn from 'classnames'
-import isEmpty from 'lodash/isEmpty'
-import { useMemo, type FC } from 'react'
+import { type FC } from 'react'
 
 type ListItemVariant = 'list' | 'boxed'
 
-type Props = Pick<FlexRowProps, 'alignItems' | 'children'> & {
-  /**
-   * Icon component
-   * Example: `<StatusIcon>` or `<RadialProgress>` or `<Avatar>`
-   */
-  icon?: JSX.Element
-  /**
-   * Icon alignment
-   * @default 'top'
-   */
-  alignIcon?: 'top' | 'center' | 'bottom'
-  /**
-   * Control the horizontal padding (`x`) or vertical padding (`y`).
-   * You can specify `none` to remove the padding.
-   * @default 'xy'
-   */
-  padding?: 'xy' | 'x' | 'y' | 'none'
-  /**
-   * Control the padding size.
-   * @default '4'
-   */
-  paddingSize?: '6' | '4' | '2'
-  /**
-   * Border style to render
-   * @default 'solid'
-   */
-  borderStyle?: 'solid' | 'none'
-  /**
-   * ListItem variant: 'list' or 'boxed' with rounded borders
-   * @default 'list'
-   */
-  variant?: ListItemVariant
-  /**
-   * Disabled effect
-   * @default undefined
-   */
-  disabled?: boolean
-}
-
-export type ListItemProps = Props &
-  (
-    | ({
-        /**
-         * HTML tag to render
-         */
-        tag: 'div'
-      } & Omit<React.HTMLAttributes<HTMLDivElement>, 'children'>)
-    | ({
-        /**
-         * HTML tag to render
-         */
-        tag: 'a'
-      } & Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'children'>)
-  )
+export type ListItemProps = React.HTMLAttributes<HTMLElement> &
+  Pick<FlexRowProps, 'alignItems' | 'children'> &
+  Pick<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'onClick' | 'href'> & {
+    /**
+     * Icon component
+     * Example: `<StatusIcon>` or `<RadialProgress>` or `<Avatar>`
+     */
+    icon?: JSX.Element
+    /**
+     * Icon alignment
+     * @default 'top'
+     */
+    alignIcon?: 'top' | 'center' | 'bottom'
+    /**
+     * Control the horizontal padding (`x`) or vertical padding (`y`).
+     * You can specify `none` to remove the padding.
+     * @default 'xy'
+     */
+    padding?: 'xy' | 'x' | 'y' | 'none'
+    /**
+     * Control the padding size.
+     * @default '4'
+     */
+    paddingSize?: '6' | '4' | '2'
+    /**
+     * Border style to render
+     * @default 'solid'
+     */
+    borderStyle?: 'solid' | 'none'
+    /**
+     * ListItem variant: 'list' or 'boxed' with rounded borders
+     * @default 'list'
+     */
+    variant?: ListItemVariant
+    /**
+     * Disabled effect
+     * @default undefined
+     */
+    disabled?: boolean
+  }
 
 export const ListItem: FC<ListItemProps> = ({
   icon,
@@ -74,18 +59,10 @@ export const ListItem: FC<ListItemProps> = ({
   disabled = false,
   ...rest
 }) => {
-  const JsxTag = useMemo(
-    () =>
-      enforceAllowedTags({
-        tag: rest.tag,
-        allowedTags: ['a', 'div'],
-        defaultTag: 'div'
-      }),
-    [rest.tag]
-  )
-  const hasHover =
-    !disabled &&
-    (rest.onClick != null || (rest.tag === 'a' && !isEmpty(rest.href)))
+  const divProps =
+    'overflow' in rest ? removeUnwantedProps(rest, ['overflow']) : rest
+  const Tag = rest.href != null ? 'a' : rest.onClick != null ? 'button' : 'div'
+  const isClickable = !disabled && (rest.href != null || rest.onClick != null)
 
   const pySize = cn({
     'py-6': paddingSize === '6',
@@ -100,24 +77,26 @@ export const ListItem: FC<ListItemProps> = ({
   })
 
   return (
-    <JsxTag
+    <Tag
       className={cn(
-        'flex gap-4 bg-white',
+        'flex gap-4 w-full',
         'text-gray-800 hover:text-gray-800', // keep default text color also when used as `<a>` tag
         {
           [pySize]: padding !== 'none' && padding !== 'x',
           [pxSize]: padding !== 'none' && padding !== 'y',
           'border-b': borderStyle !== 'none',
-          'cursor-pointer hover:bg-gray-50': hasHover,
-          'border-gray-200 bg-gray-100': disabled,
+          'rounded border': variant === 'boxed',
+          'hover:bg-gray-50 focus-visible:ring-primary focus-visible:ring-2 focus-visible:ring-inset focus-visible:outline-none':
+            isClickable,
+          'bg-white': !disabled && variant === 'boxed',
+          'bg-gray-100': disabled,
+          'border-gray-200': variant === 'boxed' || disabled,
           'border-gray-100': variant === 'list',
-          'rounded border border-gray-200': variant === 'boxed'
+          'text-left': divProps.onClick != null // to prevent standard behavior of `button` elements (with centered content)
         },
         className
       )}
-      // we don't want `tag` prop to be present as attribute on html tag
-      // still we need to be part of `rest` to discriminate the union type
-      {...(removeUnwantedProps(rest, ['tag']) as any)}
+      {...divProps}
     >
       <div className={cn('flex gap-4 flex-1 items-center')}>
         {icon != null && (
@@ -137,7 +116,7 @@ export const ListItem: FC<ListItemProps> = ({
         )}
         <FlexRow alignItems={alignItems}>{children}</FlexRow>
       </div>
-    </JsxTag>
+    </Tag>
   )
 }
 

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroupItem.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroupItem.tsx
@@ -60,7 +60,6 @@ export const InputCheckboxGroupItem = withSkeletonTemplate<Props>(
         alignItems='center'
         alignIcon='center'
         borderStyle='none'
-        tag='div'
         padding='none'
         className='rounded flex items-center gap-3 p-3'
         onClick={() => {

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -2,7 +2,7 @@ import { useTokenProvider } from '#providers/TokenProvider'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { StatusIcon } from '#ui/atoms/StatusIcon'
 import { Text } from '#ui/atoms/Text'
-import { ListItem } from '#ui/composite/ListItem'
+import { ListItem, type ListItemProps } from '#ui/composite/ListItem'
 import {
   customerToProps,
   orderToProps,
@@ -23,15 +23,13 @@ export interface ResourceListItemProps {
    */
   resource: ResourceListItemType
   /**
-   * HTML tag to render
+   * Optional href
    */
-  tag?: 'a' | 'div'
+  href?: ListItemProps['href']
   /**
    * Optional onClick function
    */
-  onClick?: (
-    e: React.MouseEvent<HTMLAnchorElement | HTMLDivElement, MouseEvent>
-  ) => void
+  onClick?: ListItemProps['onClick']
   /**
    * Optional setting to show right content, if available, instead of right arrow
    */
@@ -47,16 +45,16 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
     description,
     icon,
     rightContent,
-    tag = 'div',
+    href,
     onClick,
     showRightContent = false
   }) => {
     return (
       <ListItem
-        tag={onClick !== undefined ? 'a' : tag}
         icon={icon}
         alignItems={showRightContent ? 'top' : 'center'}
         data-test-id='ResourceListItem'
+        href={href}
         onClick={onClick}
       >
         <div>
@@ -91,7 +89,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
  * This component generates a list item based on the requested resource data and type.
  */
 export const ResourceListItem = withSkeletonTemplate<ResourceListItemProps>(
-  ({ resource, tag = 'div', isLoading, delayMs, onClick, ...rest }) => {
+  ({ resource, isLoading, delayMs, href, onClick, ...rest }) => {
     const { user } = useTokenProvider()
     const listItemProps = useMemo(() => {
       switch (resource.type) {
@@ -118,7 +116,7 @@ export const ResourceListItem = withSkeletonTemplate<ResourceListItemProps>(
     return (
       <ResourceListItemComponent
         {...listItemProps}
-        tag={tag}
+        href={href}
         onClick={onClick}
         {...rest}
       />

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -53,7 +53,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
       <ListItem
         icon={icon}
         alignItems={showRightContent ? 'top' : 'center'}
-        data-test-id='ResourceListItem'
+        data-testid='ResourceListItem'
         href={href}
         onClick={onClick}
       >
@@ -61,7 +61,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
           <Text
             tag='div'
             weight='semibold'
-            data-test-id='ResourceListItem-number'
+            data-testid='ResourceListItem-number'
           >
             {name}
           </Text>
@@ -70,7 +70,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
             weight='medium'
             size='small'
             variant='info'
-            data-test-id='ResourceListItem-content'
+            data-testid='ResourceListItem-content'
           >
             {description}
           </Text>

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
@@ -49,7 +49,7 @@ export const orderToProps: ResourceToProps<Order> = ({ resource, user }) => {
         <Text
           tag='div'
           weight='semibold'
-          data-test-id='ResourceListItem-total'
+          data-testid='ResourceListItem-total'
           className='break-keep'
           wrap='nowrap'
         >
@@ -60,7 +60,7 @@ export const orderToProps: ResourceToProps<Order> = ({ resource, user }) => {
           weight='medium'
           size='small'
           variant='info'
-          data-test-id='ResourceListItem-payment'
+          data-testid='ResourceListItem-payment'
           wrap='nowrap'
         >
           {getOrderPaymentStatusName(resource.payment_status)}

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -88,7 +88,6 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
 
               return (
                 <ListItem
-                  tag='div'
                   key={idx}
                   data-testid={`ResourceMetadata-item-${metadataKey}`}
                 >

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
@@ -43,7 +43,7 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
               const label = humanizeString(metadataKey)
               if (typeof metadataValue !== 'string') return <></>
               return (
-                <ListItem tag='div' key={idx}>
+                <ListItem key={idx}>
                   <Text variant='info'>{label}</Text>
                   <HookedInput name={`metadata.${metadataKey}`} />
                 </ListItem>

--- a/packages/docs/src/stories/atoms/Card.stories.tsx
+++ b/packages/docs/src/stories/atoms/Card.stories.tsx
@@ -108,13 +108,13 @@ FooterNoGap.args = {
  */
 export const ChildrenWithBackground: StoryFn<typeof Card> = (args) => (
   <Card {...args}>
-    <ListItem tag='a' onClick={() => {}} borderStyle='none'>
+    <ListItem onClick={() => {}} borderStyle='none'>
       Item #1
     </ListItem>
-    <ListItem tag='a' onClick={() => {}} borderStyle='none'>
+    <ListItem onClick={() => {}} borderStyle='none'>
       Item #2
     </ListItem>
-    <ListItem tag='a' onClick={() => {}} borderStyle='none'>
+    <ListItem onClick={() => {}} borderStyle='none'>
       Item #3
     </ListItem>
   </Card>

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -56,7 +56,6 @@ const children = (
     </ForwardRefComponent>
     <WithSkeletonComponentB>C</WithSkeletonComponentB>
     <ListItem
-      tag='div'
       onClick={() => {
         alert('Hello world!')
       }}
@@ -72,7 +71,7 @@ const children = (
       <StatusIcon name='check' background='green' gap='large' />
       <RadialProgress percentage={42} />
     </ListItem>
-    <ListItem tag='div'>
+    <ListItem>
       <div>
         <Text tag='div'>Ehi there!</Text>
         <Badge variant='primary'>APPROVED</Badge>

--- a/packages/docs/src/stories/composite/CardDialog.stories.tsx
+++ b/packages/docs/src/stories/composite/CardDialog.stories.tsx
@@ -44,7 +44,6 @@ Parcel.args = {
   children: (
     <div>
       <ListItem
-        tag='div'
         padding='y'
         icon={
           <Avatar
@@ -72,7 +71,6 @@ Parcel.args = {
         </div>
       </ListItem>
       <ListItem
-        tag='div'
         padding='y'
         icon={
           <Avatar

--- a/packages/docs/src/stories/composite/ListDetails.stories.tsx
+++ b/packages/docs/src/stories/composite/ListDetails.stories.tsx
@@ -45,7 +45,6 @@ export const WithListItem: StoryFn<typeof ListDetails> = (args) => (
   <ListDetails {...args}>
     {Array(3).fill(
       <ListItem
-        tag='div'
         padding='y'
         icon={
           <Avatar

--- a/packages/docs/src/stories/composite/ListDetailsItem.stories.tsx
+++ b/packages/docs/src/stories/composite/ListDetailsItem.stories.tsx
@@ -88,19 +88,19 @@ export const ListWithActions: StoryFn<typeof ListDetailsItem> = (_args) => {
   return (
     <Section title='List' actionButton={<Button variant='link'>Add</Button>}>
       <ListDetailsItem label='Number' gutter='none'>
-        <ListItem tag='div' padding='none' borderStyle='none'>
+        <ListItem padding='none' borderStyle='none'>
           <Text weight='semibold'>is greater than 10</Text>
           {Menu}
         </ListItem>
       </ListDetailsItem>
       <ListDetailsItem label='Color' gutter='none'>
-        <ListItem tag='div' padding='none' borderStyle='none'>
+        <ListItem padding='none' borderStyle='none'>
           <Text weight='semibold'>is not Red</Text>
           {Menu}
         </ListItem>
       </ListDetailsItem>
       <ListDetailsItem label='Item' gutter='none'>
-        <ListItem tag='div' padding='none' borderStyle='none'>
+        <ListItem padding='none' borderStyle='none'>
           <Text weight='semibold'>is the last one</Text>
           {Menu}
         </ListItem>

--- a/packages/docs/src/stories/composite/ListItem.stories.tsx
+++ b/packages/docs/src/stories/composite/ListItem.stories.tsx
@@ -54,13 +54,11 @@ const WithIconTemplate: StoryFn<typeof ListItem> = (args) => (
 
 export const WithIcon = WithIconTemplate.bind({})
 WithIcon.args = {
-  tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />
 }
 
 export const Boxed = WithIconTemplate.bind({})
 Boxed.args = {
-  tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
   onClick: () => {},
   variant: 'boxed'
@@ -80,7 +78,6 @@ const BoxedCTATemplate: StoryFn<typeof ListItem> = (args) => (
 
 export const BoxedCTA = BoxedCTATemplate.bind({})
 BoxedCTA.args = {
-  tag: 'div',
   icon: <Icon name='stack' size={32} />,
   alignIcon: 'center',
   variant: 'boxed',
@@ -89,7 +86,6 @@ BoxedCTA.args = {
 
 export const Disabled = WithIconTemplate.bind({})
 Disabled.args = {
-  tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
   onClick: () => {},
   variant: 'boxed',
@@ -98,16 +94,13 @@ Disabled.args = {
 
 export const WithCenteredIcon = WithIconTemplate.bind({})
 WithCenteredIcon.args = {
-  tag: 'div',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />,
   alignIcon: 'center'
 }
 
 export const AsAnchor = WithIconTemplate.bind({})
 AsAnchor.args = {
-  tag: 'a',
-  href: 'https://www.commercelayer.io',
-  target: '_blank',
+  href: '#',
   icon: <StatusIcon name='arrowDown' background='orange' gap='large' />
 }
 

--- a/packages/docs/src/stories/examples/ListImports.stories.tsx
+++ b/packages/docs/src/stories/examples/ListImports.stories.tsx
@@ -54,7 +54,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
             pageCount: 5
           }}
         >
-          <ListItem tag='div' icon={<RadialProgress percentage={45} />}>
+          <ListItem icon={<RadialProgress percentage={45} />}>
             <div>
               <Text tag='div' weight='semibold'>
                 Prices
@@ -66,7 +66,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
             <Button variant='danger'>Cancel</Button>
           </ListItem>
 
-          <ListItem tag='div' icon={<RadialProgress />}>
+          <ListItem icon={<RadialProgress />}>
             <div>
               <Text tag='div' weight='semibold'>
                 Orders
@@ -79,7 +79,6 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
           </ListItem>
 
           <ListItem
-            tag='div'
             icon={<StatusIcon gap='large' name='check' background='green' />}
           >
             <div>
@@ -93,10 +92,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => {
             <StatusIcon name='caretRight' />
           </ListItem>
 
-          <ListItem
-            tag='div'
-            icon={<StatusIcon gap='large' name='x' background='red' />}
-          >
+          <ListItem icon={<StatusIcon gap='large' name='x' background='red' />}>
             <div>
               <Text tag='div' weight='semibold'>
                 SKUs

--- a/packages/docs/src/stories/examples/ListResources.stories.tsx
+++ b/packages/docs/src/stories/examples/ListResources.stories.tsx
@@ -59,7 +59,7 @@ const Template: StoryFn<typeof List> = (args) => (
           'Tax rules',
           'Wire transfers'
         ].map((resource) => (
-          <ListItem tag='a' key={resource} href='#' target='_blank'>
+          <ListItem key={resource} href='#'>
             <Text weight='semibold'>{resource}</Text>
             <StatusIcon name='caretRight' />
           </ListItem>

--- a/packages/docs/src/stories/examples/ListSkus.stories.tsx
+++ b/packages/docs/src/stories/examples/ListSkus.stories.tsx
@@ -45,7 +45,7 @@ const Template: StoryFn<typeof List> = (args) => (
         }}
       >
         {[...Array(10).keys()].map((_, idx) => (
-          <ListItem tag='div' key={idx} onClick={() => {}}>
+          <ListItem key={idx} onClick={() => {}}>
             <div>
               <Text weight='semibold' tag='div'>
                 WGDMSMNOwJ

--- a/packages/docs/src/stories/examples/OrderHistory.stories.tsx
+++ b/packages/docs/src/stories/examples/OrderHistory.stories.tsx
@@ -28,7 +28,6 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
   <Spacer bottom='14'>
     <List title='Results · 13,765'>
       <ListItem
-        tag='div'
         icon={<StatusIcon name='arrowDown' background='orange' gap='large' />}
       >
         <div>
@@ -52,10 +51,7 @@ export const Default: StoryFn<typeof ListItem> = (args): JSX.Element => (
         </div>
       </ListItem>
 
-      <ListItem
-        tag='div'
-        icon={<StatusIcon name='x' background='gray' gap='large' />}
-      >
+      <ListItem icon={<StatusIcon name='x' background='gray' gap='large' />}>
         <div>
           <Text tag='div' weight='semibold'>
             US online #19346523

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputRadioGroup.stories.tsx
@@ -56,7 +56,6 @@ Default.args = {
       value: 'DHL1',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'
@@ -89,7 +88,6 @@ Default.args = {
       value: 'Fedex',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'
@@ -122,7 +120,6 @@ Default.args = {
       value: 'DHL2',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSimpleSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSimpleSelect.stories.tsx
@@ -67,7 +67,7 @@ export const WithinAListItem: StoryFn = () => {
       }}
     >
       <Section title='More options' titleSize='small'>
-        <ListItem tag='div'>
+        <ListItem>
           <HookedInputSimpleSelect
             options={[
               { label: 'JSON', value: 'json' },
@@ -82,7 +82,7 @@ export const WithinAListItem: StoryFn = () => {
             hint={{ text: 'Select a format' }}
           />
         </ListItem>
-        <ListItem tag='div'>
+        <ListItem>
           <HookedInputSimpleSelect
             options={[
               { label: 'Black', value: '#000' },

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSwitch.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSwitch.stories.tsx
@@ -64,10 +64,10 @@ export const WithinAListItem: StoryFn = () => {
       }}
     >
       <Section title='More options' titleSize='small'>
-        <ListItem tag='div'>
+        <ListItem>
           <HookedInputSwitch name='export-all' label='Export all' inline />
         </ListItem>
-        <ListItem tag='div'>
+        <ListItem>
           <HookedInputSwitch
             name='exclude-last'
             label='Exclude last'

--- a/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
@@ -58,7 +58,7 @@ WithListItem.args = {
     />
   ),
   children: (
-    <ListItem tag='div' alignItems='top' borderStyle='none' padding='none'>
+    <ListItem alignItems='top' borderStyle='none' padding='none'>
       <div>
         <Text size='regular' weight='bold'>
           Express Easy

--- a/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputRadioGroup.stories.tsx
@@ -31,7 +31,6 @@ Default.args = {
       value: 'DHL1',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'
@@ -64,7 +63,6 @@ Default.args = {
       value: 'Fedex',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'
@@ -97,7 +95,6 @@ Default.args = {
       value: 'DHL2',
       content: (
         <ListItem
-          tag='div'
           alignItems='top'
           alignIcon='center'
           borderStyle='none'

--- a/packages/docs/src/stories/forms/ui/InputSimpleSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSimpleSelect.stories.tsx
@@ -93,7 +93,7 @@ WithoutLabel.args = {
 export const WithinAListItem: StoryFn = () => {
   return (
     <Section title='More options' titleSize='small'>
-      <ListItem tag='div'>
+      <ListItem>
         <InputSimpleSelect
           options={Default.args?.options ?? []}
           name='export-format'
@@ -102,7 +102,7 @@ export const WithinAListItem: StoryFn = () => {
           hint={{ text: 'Select a format' }}
         />
       </ListItem>
-      <ListItem tag='div'>
+      <ListItem>
         <InputSimpleSelect
           options={[
             { label: 'Black', value: '#000' },

--- a/packages/docs/src/stories/forms/ui/InputSwitch.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSwitch.stories.tsx
@@ -69,10 +69,10 @@ WithoutLabel.args = {
 export const WithinAListItem: StoryFn = () => {
   return (
     <Section title='More options' titleSize='small'>
-      <ListItem tag='div'>
+      <ListItem>
         <InputSwitch name='export-all' label='Export all' inline />
       </ListItem>
-      <ListItem tag='div'>
+      <ListItem>
         <InputSwitch
           name='exclude-last'
           label='Exclude last'

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -82,10 +82,10 @@ const ListedTemplate: StoryFn = () => {
   return (
     <TokenProvider kind='integration' appSlug='orders' devMode>
       <CoreSdkProvider>
-        <ListItem tag='div'>
+        <ListItem>
           <ResourceAddress resource={presetAddresses.withCompany} editable />
         </ListItem>
-        <ListItem tag='div'>
+        <ListItem>
           <ResourceAddress resource={presetAddresses.withName} editable />
         </ListItem>
       </CoreSdkProvider>

--- a/packages/docs/src/stories/resources/ResourceLineItems.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceLineItems.stories.tsx
@@ -61,7 +61,7 @@ const footer: Props['footer'] = [
     key: 'first-row',
     element: (
       <Spacer top='4' bottom='4'>
-        <ListItem tag='div' borderStyle='none' padding='y' paddingSize='2'>
+        <ListItem borderStyle='none' padding='y' paddingSize='2'>
           <Text>Coupon</Text>
           <Button variant='link'>Add coupon</Button>
         </ListItem>
@@ -72,15 +72,15 @@ const footer: Props['footer'] = [
     key: 'second-row',
     element: (
       <Spacer top='4' bottom='4'>
-        <ListItem tag='div' borderStyle='none' padding='y' paddingSize='2'>
+        <ListItem borderStyle='none' padding='y' paddingSize='2'>
           <Text>Subtotal</Text>
           <Text>$141.60</Text>
         </ListItem>
-        <ListItem tag='div' borderStyle='none' padding='y' paddingSize='2'>
+        <ListItem borderStyle='none' padding='y' paddingSize='2'>
           <Text>Shipping method</Text>
           <Text>$12.00</Text>
         </ListItem>
-        <ListItem tag='div' borderStyle='none' padding='y' paddingSize='2'>
+        <ListItem borderStyle='none' padding='y' paddingSize='2'>
           <Text weight='bold'>Total</Text>
           <Text weight='bold'>$163.60</Text>
         </ListItem>

--- a/packages/docs/src/stories/resources/ResourceList.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceList.stories.tsx
@@ -38,7 +38,12 @@ export const WithItem: StoryFn<typeof ResourceList> = () => {
           ItemTemplate={({ resource = mockedOrder, isLoading }) => {
             return (
               <SkeletonTemplate isLoading={isLoading}>
-                <ResourceListItem resource={resource} />
+                <ResourceListItem
+                  resource={resource}
+                  onClick={() => {
+                    console.log('click')
+                  }}
+                />
               </SkeletonTemplate>
             )
           }}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Following recent changes applied to the `Card` component, now also the `ListItem` is losing its `tag` prop to generate the right HTML tag (`div` or `a` or `button`) depending on the optional `href` and `onClick` props.
- The accessibility of the component was improved.
- All the involved stories and test were adapted to meet the new setup.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
