### PR TITLE
Remove `tag` prop from `Tag` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tag.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Tag.test.tsx
@@ -11,11 +11,7 @@ type SetupResult = RenderResult & {
 }
 
 const setup = ({ id, text }: SetupProps): SetupResult => {
-  const utils = render(
-    <Tag tag='div' data-testid={id}>
-      {text}
-    </Tag>
-  )
+  const utils = render(<Tag data-testid={id}>{text}</Tag>)
   const element = utils.getByTestId(id)
   return {
     element,

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -5,8 +5,7 @@ import {
   type ClearIndicatorProps,
   type DropdownIndicatorProps,
   type GroupBase,
-  type MultiValueGenericProps,
-  type MultiValueRemoveProps
+  type MultiValueGenericProps
 } from 'react-select'
 import { type InputSelectValue } from '.'
 
@@ -59,7 +58,7 @@ function MultiValueContainer(
     >
   >
 ): JSX.Element {
-  return <Tag tag='div'>{props.children}</Tag>
+  return <Tag>{props.children}</Tag>
 }
 
 function MultiValueLabel(
@@ -74,13 +73,11 @@ function MultiValueLabel(
   return props.data.label
 }
 
-function MultiValueRemove(
-  props: MultiValueRemoveProps<InputSelectValue>
-): JSX.Element {
+function MultiValueRemove(props: any): JSX.Element {
   return (
-    <div {...props.innerProps} className='cursor-pointer py-1 px-2 -mx-2'>
+    <button {...props.innerProps} className='cursor-pointer -mr-2 rounded'>
       <X weight='bold' />
-    </div>
+    </button>
   )
 }
 

--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -129,8 +129,6 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
             if (onTagClick != null) {
               return (
                 <TagUi
-                  tag='button'
-                  buttonStyle='button'
                   key={idx}
                   onClick={() => {
                     onTagClick(tag.id)
@@ -140,22 +138,16 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
                 </TagUi>
               )
             }
-            return (
-              <TagUi tag='div' key={idx}>
-                {tag.name}
-              </TagUi>
-            )
+            return <TagUi key={idx}>{tag.name}</TagUi>
           })}
           <TagUi
-            tag='button'
-            buttonStyle='anchor'
             icon={<TagIcon weight='bold' />}
             onClick={(e) => {
               e.preventDefault()
               open()
             }}
           >
-            Edit tags
+            tags
           </TagUi>
         </div>
         <Overlay


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Following recent changes applied to the `Card` component, now also the `Tag` is losing its `tag` prop to generate the right HTML tag (`div` or `a` or `button`) depending on the optional `href` and `onClick` props.
- The accessibility of the Remove button overridden in `app-elements` from the `react-select` package was improved by forcing a `button` tag (also if the library force it to be a `div`). This button is visible in the `ResourceTags` component.
- All the involved stories and test were adapted to meet the new setup.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
