### PR TITLE
Enforce HTML `type` attribute of `ListItem` component

### DIFF
--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -61,7 +61,8 @@ export const ListItem: FC<ListItemProps> = ({
 }) => {
   const wantedProps =
     'overflow' in rest ? removeUnwantedProps(rest, ['overflow']) : rest
-  const Tag = rest.href != null ? 'a' : rest.onClick != null ? 'button' : 'div'
+  const JsxTag =
+    rest.href != null ? 'a' : rest.onClick != null ? 'button' : 'div'
   const isClickable = !disabled && (rest.href != null || rest.onClick != null)
 
   const pySize = cn({
@@ -77,7 +78,7 @@ export const ListItem: FC<ListItemProps> = ({
   })
 
   return (
-    <Tag
+    <JsxTag
       className={cn(
         'flex gap-4 w-full',
         'text-gray-800 hover:text-gray-800', // keep default text color also when used as `<a>` tag
@@ -96,7 +97,7 @@ export const ListItem: FC<ListItemProps> = ({
         },
         className
       )}
-      type={rest.onClick != null ? 'button' : undefined}
+      type={JsxTag === 'button' ? 'button' : undefined}
       {...wantedProps}
     >
       <div className={cn('flex gap-4 flex-1 items-center')}>
@@ -117,7 +118,7 @@ export const ListItem: FC<ListItemProps> = ({
         )}
         <FlexRow alignItems={alignItems}>{children}</FlexRow>
       </div>
-    </Tag>
+    </JsxTag>
   )
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced HTML `type` attribute of `ListItem` component by checking the `JsxTag` rendered instead of just the `onClick` prop existance.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
