### PR TITLE
Set `white` background to focused `SearchBar`

### DIFF
--- a/packages/app-elements/src/ui/composite/SearchBar.tsx
+++ b/packages/app-elements/src/ui/composite/SearchBar.tsx
@@ -89,7 +89,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
           className={cn(
             'rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400',
             'shadow-none !outline-0 !border-0 !ring-0',
-            '!focus:shadow-none !active:shadow-none focus:caret-primary'
+            '!focus:shadow-none !active:shadow-none focus:caret-primary focus:bg-white'
           )}
           data-testid='SearchBar-input'
           placeholder={placeholder}


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

According to updated design the `SearchBar` has now a `white` background when focused.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
