### PR TITLE
Add the style for the `a` element to the css

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -42,6 +42,11 @@ select:focus-visible {
   outline-offset: 4px;
 }
 
+/** Style all simple links. Useful with <Link ...> */
+a:not([class]) {
+  @apply rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer;
+}
+
 a,
 button {
   @apply focus-visible:outline focus-visible:outline-2 outline-offset-2 outline-primary;

--- a/packages/docs/src/stories/atoms/A.stories.tsx
+++ b/packages/docs/src/stories/atoms/A.stories.tsx
@@ -41,14 +41,30 @@ Default.args = {
   disabled: false
 }
 
-/** The `a` HTML element is not styled. If you need to add a link to the page, you need to use the `A` component. */
-export const HTMLElementIsNotStyled: StoryFn = () => (
+/**
+ * The `a` HTML element is styled only when the `class` attribute is not defined.
+ * This is useful when using the wouter `Link` component.
+ *
+ * ```tsx
+ * <Link href="https://commercelayer.io">Text</Link>
+ * ```
+ */
+export const HTMLElement: StoryFn = () => (
   <>
     <A href='https://commercelayer.io' target='_blank'>
-      I am the &lt;A&gt; element
+      I am the &lt;A&gt; component
     </A>
     <a href='https://commercelayer.io' target='_blank' rel='noreferrer'>
       I am an &lt;a&gt; HTML element
+    </a>
+    <a
+      href='https://commercelayer.io'
+      target='_blank'
+      rel='noreferrer'
+      className='boh'
+    >
+      I am an &lt;a&gt; HTML element and I'm not styled due to my class
+      attribute
     </a>
   </>
 )


### PR DESCRIPTION
## What I did

I added the style for the `a` element to the css. This will simplify the usage of the wouter `Link`.

```tsx
<Link href="https://commercelayer.io">Text</Link>
```

will render as `A`.

## How to test

https://deploy-preview-606--commercelayer-app-elements.netlify.app/?path=/docs/atoms-a--docs#html-element

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
