### PR TITLE
Add `bg-white` to `Td` component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Table/Table.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Table.tsx
@@ -12,7 +12,8 @@ export interface TableProps {
  * `<Table>` component is used to organize and display data efficiently.
  *
  * These are all the available components you can use to manage a table:
- * ```
+ *
+ * ```js
  * import {
  *   Table,
  *   Tr,
@@ -32,7 +33,7 @@ export const Table: React.FC<TableProps> = ({
       className={cn([
         'w-full',
         {
-          'border border-gray-200 border-separate border-spacing-0 rounded [&>tbody>tr:last-of-type>td]:border-0':
+          'border border-gray-200 border-separate border-spacing-0 rounded [&>tbody>tr:last-of-type>td]:border-0 [&>tbody>tr:last-of-type>td]:first-of-type:rounded-es [&>tbody>tr:last-of-type>td]:last-of-type:rounded-ee':
             variant === 'boxed'
         },
         className

--- a/packages/app-elements/src/ui/atoms/Table/Td.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Td.tsx
@@ -14,7 +14,7 @@ export const Td: React.FC<TdProps> = ({
 }) => {
   return (
     <td
-      className={cn('p-4 text-sm border-b border-gray-100', className)}
+      className={cn('p-4 text-sm border-b border-gray-100 bg-white', className)}
       {...rest}
     >
       {textEllipsis !== undefined ? (

--- a/packages/docs/.storybook/preview.tsx
+++ b/packages/docs/.storybook/preview.tsx
@@ -18,6 +18,14 @@ export const parameters: Parameters = {
       date: /Date$/,
     },
   },
+  backgrounds: {
+    values: [
+      {
+        name: 'overlay',
+        value: '#F8F8F8',
+      },
+    ],
+  },
   options: {
     storySort: {
       method: 'alphabetical',

--- a/packages/docs/src/stories/atoms/Table.stories.tsx
+++ b/packages/docs/src/stories/atoms/Table.stories.tsx
@@ -60,6 +60,10 @@ Default.args = {
 }
 
 export const VariantBoxed = Template.bind({})
+VariantBoxed.parameters = {
+  ...(VariantBoxed.parameters ?? {}),
+  backgrounds: { default: 'overlay' }
+}
 VariantBoxed.args = {
   ...baseProps,
   variant: 'boxed'


### PR DESCRIPTION
## What I did

I added a `bg-white` to the `Td` component.

This way the table renders well on an overlay:

<img width="684" alt="Screenshot 2024-04-04 alle 17 46 57" src="https://github.com/commercelayer/app-elements/assets/1681269/e360415b-ca29-4b8e-bd82-63ca21d80d3b">

https://deploy-preview-608--commercelayer-app-elements.netlify.app/?path=/docs/atoms-table--docs#variant-boxed
