### PR TITLE
Enhance `ResourceMetadata` component

### DIFF
--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -26,7 +26,13 @@ export function useEditMetadataOverlay(): OverlayHook {
 
   return {
     show: open,
-    Overlay: ({ title, description, resourceId, resourceType, mode }) => {
+    Overlay: ({
+      title,
+      description,
+      resourceId,
+      resourceType,
+      mode = 'advanced'
+    }) => {
       const [isSubmitting, setIsSubmitting] = useState(false)
       const [apiError, setApiError] = useState<any>(undefined)
 

--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -22,11 +22,7 @@ interface OverlayHook {
 }
 
 export function useEditMetadataOverlay(): OverlayHook {
-  const {
-    Overlay: OverlayElement,
-    open,
-    close
-  } = useOverlay({ queryParam: 'edit-metadata' })
+  const { Overlay: OverlayElement, open, close } = useOverlay()
 
   return {
     show: open,

--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -1,0 +1,108 @@
+import { useOverlay } from '#hooks/useOverlay'
+import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
+import { PageLayout } from '#ui/composite/PageLayout'
+import {
+  type ResourceMetadataOverlay,
+  type ResourceMetadataProps
+} from '#ui/resources/ResourceMetadata'
+import { ResourceMetadataForm } from '#ui/resources/ResourceMetadata/ResourceMetadataForm'
+import { useState } from 'react'
+
+interface OverlayProps {
+  title: ResourceMetadataOverlay['title']
+  description?: ResourceMetadataOverlay['description']
+  resourceId: ResourceMetadataProps['resourceId']
+  resourceType: ResourceMetadataProps['resourceType']
+  mode?: ResourceMetadataProps['mode']
+}
+
+interface OverlayHook {
+  show: () => void
+  Overlay: React.FC<OverlayProps>
+}
+
+export function useEditMetadataOverlay(): OverlayHook {
+  const {
+    Overlay: OverlayElement,
+    open,
+    close
+  } = useOverlay({ queryParam: 'edit-metadata' })
+
+  return {
+    show: open,
+    Overlay: ({ title, description, resourceId, resourceType, mode }) => {
+      const [isSubmitting, setIsSubmitting] = useState(false)
+      const [apiError, setApiError] = useState<any>(undefined)
+
+      const { sdkClient } = useCoreSdkProvider()
+
+      const {
+        data: resourceData,
+        isLoading,
+        mutate: mutateResource
+      } = useCoreApi(resourceType, 'retrieve', [
+        resourceId,
+        {
+          fields: ['metadata']
+        }
+      ])
+
+      if (
+        (mode === 'simple' &&
+          (resourceData?.metadata == null ||
+            Object.keys(resourceData?.metadata).length === 0)) ||
+        isLoading
+      )
+        return <></>
+
+      return (
+        <OverlayElement backgroundColor='light'>
+          <PageLayout
+            title={title}
+            description={description}
+            minHeight={false}
+            navigationButton={{
+              label: 'Back',
+              onClick: () => {
+                close()
+              }
+            }}
+          >
+            <ResourceMetadataForm
+              resourceId={resourceId}
+              defaultValues={{
+                metadata: resourceData?.metadata ?? []
+              }}
+              mode={mode}
+              onSubmit={(formValues) => {
+                setIsSubmitting(true)
+                void sdkClient[resourceType]
+                  .update(
+                    {
+                      id: resourceId,
+                      metadata: formValues.metadata
+                    },
+                    {
+                      fields: ['metadata']
+                    }
+                  )
+                  .then((updatedResource) => {
+                    void mutateResource(updatedResource).then(() => {
+                      setIsSubmitting(false)
+                      close()
+                    })
+                  })
+                  .catch((error) => {
+                    setApiError(error)
+                    setIsSubmitting(false)
+                  })
+              }}
+              isSubmitting={isSubmitting}
+              apiError={apiError}
+            />
+          </PageLayout>
+        </OverlayElement>
+      )
+    }
+  }
+}

--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -82,7 +82,9 @@ export function useEditMetadataOverlay(): OverlayHook {
                   .update(
                     {
                       id: resourceId,
-                      metadata: formValues.metadata
+                      metadata: Object.entries(formValues.metadata).filter(
+                        ([k]) => k.toString().length > 0
+                      )
                     },
                     {
                       fields: ['metadata']

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -39,6 +39,7 @@ export {
 // Hooks
 export { useClickAway } from '#hooks/useClickAway'
 export { useDelayShow } from '#hooks/useDelayShow'
+export { useEditMetadataOverlay } from '#hooks/useEditMetadataOverlay'
 export { useIsChanged } from '#hooks/useIsChanged'
 export { useOnBlurFromContainer } from '#hooks/useOnBlurFromContainer'
 export { useOverlay } from '#hooks/useOverlay'

--- a/packages/app-elements/src/mocks/data/customers.ts
+++ b/packages/app-elements/src/mocks/data/customers.ts
@@ -28,11 +28,41 @@ const mockedCustomer = {
   meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
 }
 
+const mockedCustomerWithNoMetadata = {
+  id: 'OEMAhobdgO',
+  type: 'customers',
+  links: {
+    self: 'https://alessani.commercelayer.co/api/customers/OEMAhobdgO'
+  },
+  attributes: {
+    email: 'ella.murazik31@example.com',
+    status: 'repeat',
+    has_password: false,
+    total_orders_count: 2753,
+    created_at: '2022-03-14T09:13:06.633Z',
+    updated_at: '2023-07-31T09:13:06.049Z',
+    reference: null,
+    reference_origin: null,
+    metadata: null
+  },
+  meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+}
+
 const customerRetrive = http.get(
   `https://*/api/customers/NMWYhbGorj`,
   async () => {
     return HttpResponse.json({
       data: mockedCustomer,
+      meta: { record_count: 1, page_count: 1 }
+    })
+  }
+)
+
+const customerRetriveWithEmptyMetadata = http.get(
+  `https://*/api/customers/OEMAhobdgO`,
+  async () => {
+    return HttpResponse.json({
+      data: mockedCustomerWithNoMetadata,
       meta: { record_count: 1, page_count: 1 }
     })
   }
@@ -48,4 +78,8 @@ const customerUpdate = http.patch(
   }
 )
 
-export default [customerRetrive, customerUpdate]
+export default [
+  customerRetrive,
+  customerRetriveWithEmptyMetadata,
+  customerUpdate
+]

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -15,6 +15,7 @@ export const iconMapping = {
   arrowUUpLeft: phosphor.ArrowUUpLeft,
   asteriskSimple: phosphor.AsteriskSimple,
   bookOpenText: phosphor.BookOpenText,
+  bracketsCurly: phosphor.BracketsCurly,
   buildings: phosphor.Buildings,
   calendarBlank: phosphor.CalendarBlank,
   calendarCheck: phosphor.CalendarCheck,

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -2,7 +2,6 @@ import { useEditMetadataOverlay } from '#hooks/useEditMetadataOverlay'
 import { useCoreApi } from '#providers/CoreSdkProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { Button } from '#ui/atoms/Button'
-import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
@@ -30,6 +29,7 @@ export interface ResourceMetadataProps {
    * Metadata management mode:
    * - If set to 'simple' the metadata block is shown only if any of them is present. The edit page will permit to edit just the values of the existing items.
    * - If set to 'advanced' the metadata block is always shown providing a `create` CTA to add a metadata if any is present. The edit page will permit to fully create, edit and remove the items.
+   * @default simple
    */
   mode?: ResourceMetadataMode
   /**
@@ -65,9 +65,8 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
       ).length > 0
 
     if (
-      (mode === 'simple' &&
-        (resourceData?.metadata == null ||
-          Object.keys(resourceData?.metadata).length === 0)) ||
+      resourceData?.metadata == null ||
+      Object.keys(resourceData?.metadata).length === 0 ||
       isLoading
     )
       return <></>
@@ -91,27 +90,6 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
             )
           }
         >
-          {!hasStringMetadata && mode === 'advanced' && (
-            <ListItem
-              alignIcon='center'
-              icon={<Icon name='bracketsCurly' size={32} />}
-              paddingSize='6'
-              variant='boxed'
-            >
-              <Text>Manage your string metadata keys and values.</Text>
-              <Button
-                alignItems='center'
-                size='small'
-                variant='secondary'
-                onClick={() => {
-                  show()
-                }}
-              >
-                <Icon name='plus' size={16} />
-                Metadata
-              </Button>
-            </ListItem>
-          )}
           {Object.entries(resourceData?.metadata ?? []).map(
             ([metadataKey, metadataValue], idx) => {
               if (typeof metadataValue !== 'string') return null

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -29,7 +29,7 @@ export interface ResourceMetadataProps {
    * Metadata management mode:
    * - If set to `simple` the edit page will permit to edit just the values of the existing items.
    * - If set to `advanced` the edit page will permit to fully create, edit and remove the items.
-   * @default simple
+   * @default advanced
    */
   mode?: ResourceMetadataMode
   /**

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -43,7 +43,7 @@ export interface ResourceMetadataProps {
  * More in detail the `metadata` attribute is a JSON object, customizable for several purposes, and this component will allow to show and manage its keys with a simple (string kind) values.
  */
 export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
-  ({ resourceType, resourceId, mode = 'simple', overlay }) => {
+  ({ resourceType, resourceId, mode = 'advanced', overlay }) => {
     const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
 
     const { canUser } = useTokenProvider()
@@ -75,7 +75,6 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
       <div>
         <Section
           title='Metadata'
-          border={mode === 'advanced' ? 'none' : undefined}
           actionButton={
             hasStringMetadata &&
             canUser('update', resourceType) && (
@@ -100,7 +99,11 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
                   key={idx}
                   data-testid={`ResourceMetadata-item-${metadataKey}`}
                 >
-                  <Text variant='info'>{humanizeString(metadataKey)}</Text>
+                  <Text variant='info'>
+                    {mode === 'advanced'
+                      ? metadataKey
+                      : humanizeString(metadataKey)}
+                  </Text>
                   <Text
                     weight='semibold'
                     data-testid={`ResourceMetadata-value-${metadataKey}`}

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -1,18 +1,16 @@
-import { useOverlay } from '#hooks/useOverlay'
-import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
+import { useEditMetadataOverlay } from '#hooks/useEditMetadataOverlay'
+import { useCoreApi } from '#providers/CoreSdkProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
-import { PageLayout } from '#ui/composite/PageLayout'
 import { humanizeString } from '#utils/text'
 import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
-import { useState } from 'react'
-import { ResourceMetadataForm } from './ResourceMetadataForm'
 
-interface ResourceMetadataOverlay {
+export interface ResourceMetadataOverlay {
   /**
    * Title shown as first line in edit overlay heading
    */
@@ -23,9 +21,17 @@ interface ResourceMetadataOverlay {
   description?: string
 }
 
+export type ResourceMetadataMode = 'simple' | 'advanced'
+
 export interface ResourceMetadataProps {
   resourceType: ListableResourceType
   resourceId: string
+  /**
+   * Metadata management mode:
+   * - If set to 'simple' the metadata block is shown only if any of them is present. The edit page will permit to edit just the values of the existing items.
+   * - If set to 'advanced' the metadata block is always shown providing a `create` CTA to add a metadata if any is present. The edit page will permit to fully create, edit and remove the items.
+   */
+  mode?: ResourceMetadataMode
   /**
    * Edit overlay configuration
    */
@@ -33,32 +39,35 @@ export interface ResourceMetadataProps {
 }
 
 /**
- * This component generates an all-in-one visualization and editing interface for managing metadata object values of requested resource.
+ * This component provides an all-in-one visualization and editing interface for the `metadata` attribute of a given resource.
+ * More in detail the `metadata` attribute is a JSON object, customizable for several purposes, and this component will allow to show and manage its keys with a simple (string kind) values.
  */
 export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
-  ({ resourceType, resourceId, overlay }) => {
-    const { Overlay, open, close } = useOverlay({ queryParam: 'edit-metadata' })
+  ({ resourceType, resourceId, mode = 'simple', overlay }) => {
+    const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
 
-    const [isSubmitting, setIsSubmitting] = useState(false)
-    const [apiError, setApiError] = useState<any>(undefined)
-
-    const { sdkClient } = useCoreSdkProvider()
     const { canUser } = useTokenProvider()
 
-    const {
-      data: resourceData,
-      isLoading,
-      mutate: mutateResource
-    } = useCoreApi(resourceType, 'retrieve', [
-      resourceId,
-      {
-        fields: ['metadata']
-      }
-    ])
+    const { data: resourceData, isLoading } = useCoreApi(
+      resourceType,
+      'retrieve',
+      [
+        resourceId,
+        {
+          fields: ['metadata']
+        }
+      ]
+    )
+
+    const hasStringMetadata =
+      Object.entries(resourceData?.metadata ?? []).filter(
+        ([, metadataValue]) => typeof metadataValue === 'string'
+      ).length > 0
 
     if (
-      resourceData?.metadata == null ||
-      Object.keys(resourceData?.metadata).length === 0 ||
+      (mode === 'simple' &&
+        (resourceData?.metadata == null ||
+          Object.keys(resourceData?.metadata).length === 0)) ||
       isLoading
     )
       return <></>
@@ -67,27 +76,49 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
       <div>
         <Section
           title='Metadata'
+          border={mode === 'advanced' ? 'none' : undefined}
           actionButton={
+            hasStringMetadata &&
             canUser('update', resourceType) && (
-              <div className='pr-4'>
-                <Button
-                  variant='link'
-                  onClick={() => {
-                    open()
-                  }}
-                >
-                  Edit
-                </Button>
-              </div>
+              <Button
+                variant='link'
+                onClick={() => {
+                  show()
+                }}
+              >
+                Edit
+              </Button>
             )
           }
         >
-          {Object.entries(resourceData?.metadata).map(
+          {!hasStringMetadata && mode === 'advanced' && (
+            <ListItem
+              alignIcon='center'
+              icon={<Icon name='bracketsCurly' size={32} />}
+              paddingSize='6'
+              variant='boxed'
+            >
+              <Text>Manage your string metadata keys and values.</Text>
+              <Button
+                alignItems='center'
+                size='small'
+                variant='secondary'
+                onClick={() => {
+                  show()
+                }}
+              >
+                <Icon name='plus' size={16} />
+                Metadata
+              </Button>
+            </ListItem>
+          )}
+          {Object.entries(resourceData?.metadata ?? []).map(
             ([metadataKey, metadataValue], idx) => {
               if (typeof metadataValue !== 'string') return null
 
               return (
                 <ListItem
+                  padding='y'
                   key={idx}
                   data-testid={`ResourceMetadata-item-${metadataKey}`}
                 >
@@ -104,48 +135,13 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
           )}
         </Section>
         {canUser('update', resourceType) && (
-          <Overlay>
-            <PageLayout
-              title={overlay.title}
-              description={overlay.description}
-              minHeight={false}
-              navigationButton={{
-                label: 'Back',
-                onClick: () => {
-                  close()
-                }
-              }}
-            >
-              <ResourceMetadataForm
-                defaultValues={{ metadata: resourceData?.metadata }}
-                onSubmit={(formValues) => {
-                  setIsSubmitting(true)
-                  void sdkClient[resourceType]
-                    .update(
-                      {
-                        id: resourceId,
-                        metadata: formValues.metadata
-                      },
-                      {
-                        fields: ['metadata']
-                      }
-                    )
-                    .then((updatedResource) => {
-                      void mutateResource(updatedResource).then(() => {
-                        setIsSubmitting(false)
-                        close()
-                      })
-                    })
-                    .catch((error) => {
-                      setApiError(error)
-                      setIsSubmitting(false)
-                    })
-                }}
-                isSubmitting={isSubmitting}
-                apiError={apiError}
-              />
-            </PageLayout>
-          </Overlay>
+          <EditMetadataOverlay
+            title={overlay.title}
+            description={overlay.description ?? ''}
+            resourceId={resourceId}
+            resourceType={resourceType}
+            mode={mode}
+          />
         )}
       </div>
     )

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
@@ -12,6 +12,7 @@ import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
 import { humanizeString } from '#utils/text'
 import { type Metadata } from '@commercelayer/sdk/lib/cjs/resource'
+import { useMemo } from 'react'
 import { type ResourceMetadataProps } from './ResourceMetadata'
 
 interface ResourceMetadataFormValues {
@@ -26,28 +27,26 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
   isSubmitting: boolean
   apiError?: any
 }>(({ resourceId, defaultValues, mode, onSubmit, isSubmitting, apiError }) => {
-  interface KeyedMetadata {
-    key: string
-    value: string
-  }
-  const keyedMetadata: KeyedMetadata[] = []
-  Object.entries(defaultValues.metadata).forEach(
-    ([metadataKey, metadataValue]) => {
-      keyedMetadata.push({
+  const keyedMetadata: KeyedMetadata[] = useMemo(() => {
+    const result = Object.entries(defaultValues.metadata).map(
+      ([metadataKey, metadataValue]) => ({
         key: metadataKey,
         value: metadataValue
       })
-    }
-  )
+    )
 
-  if (mode === 'advanced' && keyedMetadata.length === 0) {
-    keyedMetadata.push({
-      key: '',
-      value: ''
-    })
-  }
+    if (mode === 'advanced' && result.length === 0) {
+      result.push({
+        key: '',
+        value: ''
+      })
+    }
+
+    return result
+  }, [defaultValues.metadata, mode])
 
   const medatataKey = `metadata-${resourceId}`
+
   const methods = useForm({
     defaultValues: { [medatataKey]: keyedMetadata }
   })
@@ -135,3 +134,8 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
     </HookedForm>
   )
 })
+
+interface KeyedMetadata {
+  key: string
+  value: string
+}

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
@@ -45,33 +45,31 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
     return result
   }, [defaultValues.metadata, mode])
 
-  const medatataKey = `metadata-${resourceId}`
-
   const methods = useForm({
-    defaultValues: { [medatataKey]: keyedMetadata }
+    defaultValues: { metadata: keyedMetadata }
   })
+
+  const watchedMetadata = methods.watch('metadata')
 
   const addNewRow = (): void => {
     watchedMetadata.push({
       key: '',
       value: ''
     })
-    methods.setValue(medatataKey, watchedMetadata)
+    methods.setValue('metadata', watchedMetadata)
     setTimeout(() => {
-      methods.setFocus(`${medatataKey}.${watchedMetadata.length - 1}.key`, {
+      methods.setFocus(`metadata.${watchedMetadata.length - 1}.key`, {
         shouldSelect: true
       })
     }, 200)
   }
-
-  const watchedMetadata = methods.watch(medatataKey)
 
   return (
     <HookedForm
       {...methods}
       onSubmit={(formValues) => {
         const sdkMetadata: Metadata = {}
-        formValues[medatataKey]?.forEach((m) => {
+        formValues.metadata?.forEach((m) => {
           sdkMetadata[m.key] = m.value
         })
         onSubmit({ metadata: sdkMetadata })
@@ -83,25 +81,25 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
             const label = humanizeString(metadata.key)
             if (typeof metadata.value !== 'string') return <></>
             return (
-              <ListItem
-                key={`${medatataKey}.${idx}`}
-                alignItems='center'
-                padding='y'
-              >
-                {mode === 'simple' ? (
-                  <Text variant='info'>{label}</Text>
-                ) : (
-                  <HookedInput name={`${medatataKey}.${idx}.key`} />
-                )}
-                <HookedInput name={`${medatataKey}.${idx}.value`} />
+              <ListItem key={`metadata.${idx}`} alignItems='center' padding='y'>
+                <div className='flex items-center justify-between gap-4'>
+                  {mode === 'simple' ? (
+                    <Text variant='info'>{label}</Text>
+                  ) : (
+                    <HookedInput name={`metadata.${idx}.key`} />
+                  )}
+                  <div className='md:w-3/5'>
+                    <HookedInput name={`metadata.${idx}.value`} />
+                  </div>
+                </div>
                 {mode === 'advanced' && (
                   <button
                     aria-label='Remove'
                     type='button'
                     className='rounded'
                     onClick={() => {
-                      watchedMetadata.splice(idx)
-                      methods.setValue(medatataKey, watchedMetadata)
+                      watchedMetadata.splice(idx, 1)
+                      methods.setValue('metadata', watchedMetadata)
                     }}
                   >
                     <Icon name='minus' size={24} />

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/index.tsx
@@ -1,4 +1,6 @@
 export {
   ResourceMetadata,
+  type ResourceMetadataMode,
+  type ResourceMetadataOverlay,
   type ResourceMetadataProps
 } from './ResourceMetadata'

--- a/packages/docs/src/mocks/data/customers.js
+++ b/packages/docs/src/mocks/data/customers.js
@@ -1,73 +1,52 @@
+// @ts-check
+
 import { HttpResponse, http } from 'msw'
 
-const mockedCustomer = {
-  id: 'NMWYhbGorj',
-  type: 'customers',
-  links: {
-    self: 'https://alessani.commercelayer.co/api/customers/NMWYhbGorj'
-  },
-  attributes: {
-    email: 'customer@tk.com',
-    status: 'repeat',
-    has_password: false,
-    total_orders_count: 2753,
-    created_at: '2022-03-14T09:13:06.633Z',
-    updated_at: '2023-07-31T09:13:06.049Z',
-    reference: null,
-    reference_origin: null,
-    metadata: {
-      first_name: 'John',
-      last_name: 'Doe'
-    }
-  },
-  meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+/** @type {import('msw').RequestHandler[]} */
+export default [
+  ...mockCustomer('OEMAhobdgO'),
+  ...mockCustomer('NMWYhbGorj', {
+    first_name: 'John',
+    last_name: 'Doe'
+  }),
+  ...mockCustomer('ASEYfdNrwa', {
+    hidden: 'true'
+  })
+]
+
+/** @type {(id: string, metadata?: Record<string, unknown>) => import('msw').RequestHandler[]} */
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function mockCustomer(id, metadata = {}) {
+  const data = {
+    id,
+    type: 'customers',
+    links: {
+      self: `https://myorg.commercelayer.co/api/customers/${id}`
+    },
+    attributes: {
+      email: 'customer@tk.com',
+      status: 'repeat',
+      has_password: false,
+      total_orders_count: 2753,
+      created_at: '2022-03-14T09:13:06.633Z',
+      updated_at: '2023-07-31T09:13:06.049Z',
+      reference: null,
+      reference_origin: null,
+      metadata
+    },
+    meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+  }
+
+  return [
+    http.get(`https://mock.localhost/api/customers/${id}`, async () => {
+      return HttpResponse.json({
+        data
+      })
+    }),
+    http.patch(`https://mock.localhost/api/customers/${id}`, async () => {
+      return HttpResponse.json({
+        data
+      })
+    })
+  ]
 }
-
-const mockedCustomerWithNoMetadata = {
-  id: 'OEMAhobdgO',
-  type: 'customers',
-  links: {
-    self: 'https://alessani.commercelayer.co/api/customers/OEMAhobdgO'
-  },
-  attributes: {
-    email: 'ella.murazik31@example.com',
-    status: 'repeat',
-    has_password: false,
-    total_orders_count: 2753,
-    created_at: '2022-03-14T09:13:06.633Z',
-    updated_at: '2023-07-31T09:13:06.049Z',
-    reference: null,
-    reference_origin: null,
-    metadata: null
-  },
-  meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
-}
-
-const customer = http.get(
-  `https://mock.localhost/api/customers/NMWYhbGorj`,
-  async () => {
-    return HttpResponse.json({
-      data: mockedCustomer
-    })
-  }
-)
-
-const customerWithNoMetadata = http.get(
-  `https://mock.localhost/api/customers/OEMAhobdgO`,
-  async () => {
-    return HttpResponse.json({
-      data: mockedCustomerWithNoMetadata
-    })
-  }
-)
-
-const customerUpdate = http.patch(
-  `https://mock.localhost/api/customers/NMWYhbGorj`,
-  async () => {
-    return HttpResponse.json({
-      data: mockedCustomer
-    })
-  }
-)
-
-export default [customer, customerWithNoMetadata, customerUpdate]

--- a/packages/docs/src/mocks/data/customers.js
+++ b/packages/docs/src/mocks/data/customers.js
@@ -23,11 +23,40 @@ const mockedCustomer = {
   meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
 }
 
+const mockedCustomerWithNoMetadata = {
+  id: 'OEMAhobdgO',
+  type: 'customers',
+  links: {
+    self: 'https://alessani.commercelayer.co/api/customers/OEMAhobdgO'
+  },
+  attributes: {
+    email: 'ella.murazik31@example.com',
+    status: 'repeat',
+    has_password: false,
+    total_orders_count: 2753,
+    created_at: '2022-03-14T09:13:06.633Z',
+    updated_at: '2023-07-31T09:13:06.049Z',
+    reference: null,
+    reference_origin: null,
+    metadata: null
+  },
+  meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+}
+
 const customer = http.get(
   `https://mock.localhost/api/customers/NMWYhbGorj`,
   async () => {
     return HttpResponse.json({
       data: mockedCustomer
+    })
+  }
+)
+
+const customerWithNoMetadata = http.get(
+  `https://mock.localhost/api/customers/OEMAhobdgO`,
+  async () => {
+    return HttpResponse.json({
+      data: mockedCustomerWithNoMetadata
     })
   }
 )
@@ -41,4 +70,4 @@ const customerUpdate = http.patch(
   }
 )
 
-export default [customer, customerUpdate]
+export default [customer, customerWithNoMetadata, customerUpdate]

--- a/packages/docs/src/mocks/handlers.js
+++ b/packages/docs/src/mocks/handlers.js
@@ -6,6 +6,7 @@ import markets from './data/markets'
 import orders from './data/orders'
 import tags from './data/tags'
 
+/** @type {import('msw').RequestHandler[]} */
 export const handlers = [
   ...adjustments,
   ...bundles,

--- a/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
@@ -35,13 +35,13 @@ Default.args = {
 }
 
 /**
- * When mode attribute is set to `advanced` you'll be able to edit the metadata keys and add/remove metadata.
+ * When mode attribute is set to `simple` you'll be able just to edit the metadata values.
  */
-export const Advanced = Template.bind({})
-Advanced.args = {
+export const Simple = Template.bind({})
+Simple.args = {
   resourceType: 'customers',
   resourceId: 'NMWYhbGorj',
-  mode: 'advanced',
+  mode: 'simple',
   overlay: {
     title: 'Edit metadata',
     description: 'hello@commercelayer.io'
@@ -55,7 +55,6 @@ export const WithoutMetadata = Template.bind({})
 WithoutMetadata.args = {
   resourceType: 'customers',
   resourceId: 'OEMAhobdgO',
-  mode: 'advanced',
   overlay: {
     title: 'Edit metadata',
     description: 'hello@commercelayer.io'
@@ -74,7 +73,6 @@ export const EditMetadataOverlay: StoryFn = () => {
           description='hello@commercelayer.io'
           resourceId='ASEYfdNrwa'
           resourceType='customers'
-          mode='advanced'
         />
         <Dropdown
           menuPosition='bottom-left'

--- a/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
@@ -1,9 +1,11 @@
+import { useEditMetadataOverlay } from '#hooks/useEditMetadataOverlay'
 import { CoreSdkProvider } from '#providers/CoreSdkProvider'
 import { MockTokenProvider as TokenProvider } from '#providers/TokenProvider/MockTokenProvider'
+import { Dropdown, DropdownItem } from '#ui/composite/Dropdown'
 import { ResourceMetadata } from '#ui/resources/ResourceMetadata'
 import { type Meta, type StoryFn } from '@storybook/react'
 
-const setup: Meta<typeof ResourceMetadata> = {
+const setup: Meta = {
   title: 'Resources/ResourceMetadata',
   component: ResourceMetadata,
   parameters: {
@@ -30,4 +32,28 @@ Default.args = {
     title: 'Edit metadata',
     description: 'hello@commercelayer.io'
   }
+}
+
+export const WithOverlay: StoryFn = () => {
+  const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
+
+  return (
+    <>
+      <EditMetadataOverlay
+        title='Edit metadata'
+        description='hello@commercelayer.io'
+        resourceId='OEMAhobdgO'
+        resourceType='customers'
+        mode='advanced'
+      />
+      <Dropdown
+        menuPosition='bottom-left'
+        dropdownItems={
+          <>
+            <DropdownItem onClick={show} label='Edit metadata' />
+          </>
+        }
+      />
+    </>
+  )
 }

--- a/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
@@ -34,26 +34,54 @@ Default.args = {
   }
 }
 
-export const WithOverlay: StoryFn = () => {
+/**
+ * When `metadata` are not defined the component doesn't render at all.
+ */
+export const WithoutMetadata = Template.bind({})
+WithoutMetadata.args = {
+  resourceType: 'customers',
+  resourceId: 'OEMAhobdgO',
+  mode: 'advanced',
+  overlay: {
+    title: 'Edit metadata',
+    description: 'hello@commercelayer.io'
+  }
+}
+
+/** If you don't need the readonly metadata table, but you still want to edit the metadata, you can use the `useEditMetadataOverlay` hook: */
+export const EditMetadataOverlay: StoryFn = () => {
   const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
 
   return (
-    <>
-      <EditMetadataOverlay
-        title='Edit metadata'
-        description='hello@commercelayer.io'
-        resourceId='OEMAhobdgO'
-        resourceType='customers'
-        mode='advanced'
-      />
-      <Dropdown
-        menuPosition='bottom-left'
-        dropdownItems={
-          <>
-            <DropdownItem onClick={show} label='Edit metadata' />
-          </>
-        }
-      />
-    </>
+    <TokenProvider kind='integration' appSlug='customers' devMode>
+      <CoreSdkProvider>
+        <EditMetadataOverlay
+          title='Edit metadata'
+          description='hello@commercelayer.io'
+          resourceId='ASEYfdNrwa'
+          resourceType='customers'
+          mode='advanced'
+        />
+        <Dropdown
+          menuPosition='bottom-left'
+          dropdownItems={
+            <>
+              <DropdownItem onClick={show} label='Edit metadata' />
+            </>
+          }
+        />
+      </CoreSdkProvider>
+    </TokenProvider>
   )
 }
+EditMetadataOverlay.decorators = [
+  (Story) => (
+    <div
+      style={{
+        paddingBottom: '100px'
+      }}
+    >
+      <Story />
+    </div>
+  )
+]


### PR DESCRIPTION
Closes #

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

We enhanced the `ResourceMetadata` component by giving the user the opportunity to manage full CRUD operations to text metadata of a given resource.

<img width="600" alt="Screenshot 2024-04-09 alle 10 59 34" src="https://github.com/commercelayer/app-elements/assets/105653649/3cf242e6-4216-419e-bc4f-7a03b108a52d">

This enhanced way of managing `metadata` can be enabled by using the new `mode` prop of the component which actually supports `simple` and `advanced` values.
The `simple` mode is the default one and corresponds to the actual usage of the component. The `advanced` mode enables full CRUD as previously described.

Another enhancement is about splitting from the `ResourceMetadata` component the overlay used to show the metadata management form. Now this overlay can be used stand alone thanks to the new `useEditMetadataOverlay` hook.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
