### PR TITLE
Enhance visualization of return line items reason

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.mocks.ts
@@ -307,7 +307,7 @@ export const presetLineItems = {
     image_url:
       'https://res.cloudinary.com/commercelayer/image/upload/f_auto,b_white/demo-store/skus/EMUG12OZFFFFFF000000XXXX_FLAT.png',
     return_reason: {
-      0: 'The product received does not match what I ordered.'
+      status: 'The product received does not match what I ordered.'
     },
     restocked_at: '2023-08-11T09:18:49.214Z',
     created_at: '2023-08-10T08:13:49.214Z',

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -440,7 +440,10 @@ const ReturnLineItemReason = withSkeletonTemplate<{
     <Spacer top='4'>
       <LineItemOptionsWrapper title='Reason'>
         {Object.entries(reason).map(([reasonName, reasonValue]) => (
-          <LineItemOptionsItem key={reasonName} title={reasonValue} />
+          <LineItemOptionsItem
+            key={reasonName}
+            title={`${reasonName}: ${reasonValue}`}
+          />
         ))}
       </LineItemOptionsWrapper>
     </Spacer>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enhanced visualization of return line items reason by showing both key and value of reason object rows

<img width="800" alt="Screenshot 2024-04-10 alle 12 15 56" src="https://github.com/commercelayer/app-elements/assets/105653649/2b04a813-9658-4769-87e0-28b98b0b7eec">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
