### PR TITLE
Make app (cross) linking work when in dashboard

### DIFF
--- a/packages/app-elements/src/helpers/appsNavigation.test.ts
+++ b/packages/app-elements/src/helpers/appsNavigation.test.ts
@@ -197,3 +197,146 @@ describe('goBack', () => {
     )
   })
 })
+
+describe('navigateTo - When in dashboard', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    allowLocationMocks()
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('should return a valid onClick handlers ans store key in sessionStorage when navigating to another app', () => {
+    // simulating we are on order details in app-order
+    // @ts-expect-error we want to mock window.location.origin
+    window.location.origin = 'https://dashboard.commercelayer.io'
+    window.location.pathname = '/test/demo-store/hub/orders/list/<orderId>'
+    window.location.href = `${window.location.origin}${window.location.pathname}`
+
+    window.location.assign = vi.fn()
+
+    // we want to x-link to a customer details in app-customers
+    const navigate = navigateTo({
+      destination: {
+        app: 'customers',
+        resourceId: '<customerId>',
+        mode: 'test'
+      }
+    })
+
+    navigate?.onClick(fakeEvent)
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(window.location.assign).toBeCalledWith(
+      'https://dashboard.commercelayer.io/test/demo-store/hub/customers/list/<customerId>?mode=test'
+    )
+    expect(
+      getSessionStorageItem(
+        'https://dashboard.commercelayer.io/test/demo-store/hub/customers/list/<customerId>'
+      )
+    ).toEqual({
+      url: 'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list/<orderId>',
+      version: currentVersion
+    })
+  })
+
+  test('should return a valid onClick handlers and store key in sessionStorage when navigating internally from list to details', () => {
+    // @ts-expect-error we want to mock window.location.origin
+    window.location.origin = 'https://dashboard.commercelayer.io'
+    window.location.pathname =
+      '/test/demo-store/hub/orders/list?archived_at_null=show&fulfillment_status_in=in_progress&status_in=approved&viewTitle=Fulfillment+in+progress'
+    // simulating we are on orders filtered list in app-orders
+    window.location.href = `${window.location.origin}${window.location.pathname}`
+
+    const mockedSetLocation = vi.fn()
+
+    // we want to x-link to customers app
+    const navigate = navigateTo({
+      setLocation: mockedSetLocation,
+      destination: {
+        app: 'orders',
+        resourceId: 'xbSzDaQsAZ'
+      }
+    })
+
+    navigate?.onClick(fakeEvent)
+
+    // internal react router should be called
+    expect(mockedSetLocation).toBeCalledWith('/list/xbSzDaQsAZ')
+
+    // session storage key should contain url to go back to filtered list
+    expect(
+      getSessionStorageItem(
+        'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list/xbSzDaQsAZ'
+      )
+    ).toEqual({
+      url: 'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list?archived_at_null=show&fulfillment_status_in=in_progress&status_in=approved&viewTitle=Fulfillment+in+progress',
+      version: 0.2
+    })
+  })
+})
+
+describe('goBack - When in dashboard', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    allowLocationMocks()
+    vi.resetAllMocks()
+  })
+
+  afterEach(() => {
+    vi.resetAllMocks()
+  })
+
+  test('should go back to url in session storage when found (internal linking)', () => {
+    const mockedSetLocation = vi.fn()
+
+    // @ts-expect-error we want to mock window.location.origin
+    window.location.origin = 'https://dashboard.commercelayer.io'
+    window.location.pathname = '/test/demo-store/hub/orders/list/xbSzDaQsAZ'
+    window.location.href = `${window.location.origin}${window.location.pathname}`
+
+    sessionStorage.setItem(
+      'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list/xbSzDaQsAZ',
+      JSON.stringify({
+        url: 'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list?archived_at_null=show&fulfillment_status_in=in_progress&status_in=approved&viewTitle=Fulfillment+in+progress',
+        version: currentVersion
+      })
+    )
+    goBack({
+      defaultRelativePath: '/list',
+      setLocation: mockedSetLocation
+    })
+    expect(mockedSetLocation).toBeCalledWith(
+      '/list?archived_at_null=show&fulfillment_status_in=in_progress&status_in=approved&viewTitle=Fulfillment+in+progress'
+    )
+  })
+
+  test('should go back to url in session storage when found (cross app linking)', () => {
+    // @ts-expect-error we want to mock window.location.origin
+    window.location.origin = 'https://dashboard.commercelayer.io'
+    window.location.pathname = '/test/demo-store/hub/customers/list/customerId'
+    window.location.href = `${window.location.origin}${window.location.pathname}`
+
+    window.location.assign = vi.fn()
+
+    sessionStorage.setItem(
+      'https://dashboard.commercelayer.io/test/demo-store/hub/customers/list/customerId',
+      JSON.stringify({
+        url: 'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list/xbSzDaQsAZ',
+        version: currentVersion
+      })
+    )
+    goBack({
+      defaultRelativePath: '/list',
+      setLocation: () => undefined
+    })
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    expect(window.location.assign).toBeCalledWith(
+      'https://dashboard.commercelayer.io/test/demo-store/hub/orders/list/xbSzDaQsAZ'
+    )
+  })
+})


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've added some new conditions to make `navigateTo` and `backTo` methods be able to work also when apps are loaded within the dashboard.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
