### PR TITLE
Add `wide` variant to `DropdownMenu`

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -9,7 +9,7 @@ import { Children, cloneElement, useMemo, useState } from 'react'
 import { DropdownMenu } from './DropdownMenu'
 
 export interface DropdownProps
-  extends Pick<DropdownMenuProps, 'menuHeader' | 'menuPosition'> {
+  extends Pick<DropdownMenuProps, 'menuHeader' | 'menuPosition' | 'menuWidth'> {
   /** The trigger for the dropdown menu. Can be a JSX Element or simply a `string`. */
   dropdownLabel?: React.ReactNode
   /** List of links and actions. You can use a combination of `DropdownItem` and `DropdownDivider` components. */
@@ -27,7 +27,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
   dropdownLabel = <DotsThreeCircle size={32} />,
   menuHeader,
   dropdownItems,
-  menuPosition = 'bottom-right'
+  menuPosition = 'bottom-right',
+  menuWidth
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -107,6 +108,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
             menuHeader={menuHeader}
             menuPosition={menuPosition}
             parentElementRef={clickAwayRef}
+            menuWidth={menuWidth}
           >
             {dropdownItems}
           </DropdownMenu>

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownDivider.tsx
@@ -10,7 +10,7 @@ export const DropdownDivider: FC<DropdownDividerProps> = ({
   ...rest
 }) => {
   return (
-    <div {...rest} className='h-px my-1'>
+    <div {...rest} className='h-px my-2'>
       <hr className='border-gray-600' />
     </div>
   )

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -19,6 +19,11 @@ export interface DropdownMenuProps extends React.HTMLAttributes<HTMLElement> {
    * Otherwise it will fallback to a default centering based on 32px trigger button
    */
   parentElementRef?: React.RefObject<HTMLDivElement>
+  /**
+   * Set a wider menu, fixed to 280px.
+   * By default, when no width is set, the menu adjusts its width dynamically to accommodate content, within a range of 150px to 250px.
+   **/
+  menuWidth?: 'wide'
 }
 
 export const DropdownMenu: FC<DropdownMenuProps> = ({
@@ -27,6 +32,7 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
   menuHeader,
   menuPosition = 'bottom-right',
   parentElementRef,
+  menuWidth,
   ...rest
 }) => {
   const [centerToWidth, setCenterToWidth] = useState<number>()
@@ -48,7 +54,10 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
       )}
       <div
         {...rest}
-        className='bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]'
+        className={cn('bg-black text-white rounded overflow-hidden py-2', {
+          'min-w-[150px] md:max-w-[250px]': menuWidth == null, // default width
+          'w-[280px]': menuWidth === 'wide'
+        })}
       >
         {menuHeader != null && (
           <>

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -80,7 +80,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -125,7 +125,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -170,7 +170,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded min-w-[150px] overflow-hidden py-1 md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
         >
           <button
             aria-label="Payments"
@@ -217,7 +217,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
             </span>
           </button>
           <div
-            class="h-px my-1"
+            class="h-px my-2"
           >
             <hr
               class="border-gray-600"

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -53,6 +53,37 @@ Default.args = {
   )
 }
 
+/**
+ * While by default, the dropdown menu will try to fit its content using a min/max width range,
+ * it can be also set to use a fixed `wider` width.
+ **/
+export const MenuWidthWide = Template.bind({})
+MenuWidthWide.args = {
+  menuWidth: 'wide',
+  dropdownItems: (
+    <>
+      <DropdownItem
+        onClick={() => {
+          alert('Edit clicked!')
+        }}
+        label='Lorem impsum dolor sit amet elit.'
+      />
+      <DropdownItem
+        onClick={() => {
+          alert('Delete clicked!')
+        }}
+        label='Short label'
+      />
+      <DropdownItem
+        onClick={() => {
+          alert('Delete clicked!')
+        }}
+        label='Still trimmed when max width is reached'
+      />
+    </>
+  )
+}
+
 /** By default, the component renders as a `dots-three-circle` Phosphor icon, but you can provide instead a different icon or a more generic JSX Element. */
 export const DropdownLabelAsJSXElement = Template.bind({})
 DropdownLabelAsJSXElement.args = {


### PR DESCRIPTION
## What I did

I've added a `menuWidth` prop to render a wider dropdown menu with a fixed width of 280px.
I've also tuned some spacings in dropdown elements to match the latest design changes.

https://deploy-preview-625--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#menu-width-wide

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
