### PR TITLE
Add prop to `InputReadonly` to toggle hidden values

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -24,7 +24,8 @@ div[role='textbox'] {
 
 input:focus-visible,
 textarea:focus-visible,
-div[role='textbox']:focus {
+div[role='textbox']:focus,
+.group:focus-within input, .group:focus-within div[role='textbox']  {
   ring: none;
   outline: none !important;
   box-shadow: inset 0 0 0 2px theme(colors.primary.DEFAULT) !important;

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -35,6 +35,7 @@ export const iconMapping = {
   dotsThree: phosphor.DotsThree,
   download: phosphor.Download,
   eye: phosphor.Eye,
+  eyeSlash: phosphor.EyeSlash,
   flag: phosphor.Flag,
   folderOpen: phosphor.FolderOpen,
   funnelSimple: phosphor.FunnelSimple,

--- a/packages/app-elements/src/ui/forms/InputReadonly.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputReadonly.test.tsx
@@ -1,39 +1,27 @@
-import { render, type RenderResult } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { InputReadonly } from './InputReadonly'
-
-interface SetupProps {
-  id: string
-  value: string
-}
-
-type SetupResult = RenderResult & {
-  element: HTMLInputElement
-}
-
-const setup = ({ id, value }: SetupProps): SetupResult => {
-  const utils = render(<InputReadonly data-testid={id} value={value} />)
-  const element = utils.getByTestId(id) as HTMLInputElement
-  return {
-    element,
-    ...utils
-  }
-}
 
 describe('InputReadonly', () => {
   test('Should be rendered', () => {
-    const { element } = setup({
-      id: 'my-input-readonly',
-      value: ''
-    })
-    expect(element).toBeInTheDocument()
+    const { container } = render(<InputReadonly value='' />)
+    expect(container.querySelector('input')).toBeInTheDocument()
   })
+
   test('Should has value', () => {
-    const { element } = setup({
-      id: 'my-input-readonly',
-      value: 'NAx1zYM55_B3Eq2wiFg'
-    })
-    expect(element.getElementsByTagName('input')[0]?.value).toBe(
-      'NAx1zYM55_B3Eq2wiFg'
+    const { container } = render(<InputReadonly value='NAx1zYM55_B3Eq2wiFg' />)
+    expect(container.querySelector('input')?.value).toBe('NAx1zYM55_B3Eq2wiFg')
+  })
+
+  test('Should handle secret value', () => {
+    const { container, getByTestId } = render(
+      <InputReadonly value='abc-123' secret />
     )
+    expect(container.querySelector('input')?.value).includes('****')
+
+    fireEvent.click(getByTestId('toggle-secret'))
+    expect(container.querySelector('input')?.value).toBe('abc-123')
+
+    fireEvent.click(getByTestId('toggle-secret'))
+    expect(container.querySelector('input')?.value).includes('****')
   })
 })

--- a/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
@@ -22,9 +22,20 @@ const Template: StoryFn<typeof InputReadonly> = (args) => {
 
 export const Default = Template.bind({})
 Default.args = {
+  label: 'Domain',
+  value: 'https://demo-store.commercelayer.io',
+  showCopyAction: true
+}
+
+/**
+ * This component can be used to hide (from the screen) sensitive information like API keys or secrets.
+ */
+export const Secret = Template.bind({})
+Secret.args = {
   label: 'Secret',
   value: 'elyFpGvqXsOSsvEko6ues2Ua4No1_HxaKH_0rUaFuYiX9',
-  showCopyAction: true
+  showCopyAction: true,
+  secret: true
 }
 
 /**
@@ -34,6 +45,22 @@ Default.args = {
 export const MultiLine: StoryFn = () => {
   return (
     <InputReadonly label='Login with your admin credentials' showCopyAction>
+      {`commercelayer app:login \\
+      -i asdGvqXsOSsdko6ueiX9 \\
+      -s elyFpGvqXsOSss2Ua4No1_HxaKH_0rUsFuYiX9 \\
+      -o demo-store \\
+      -a admin`}
+    </InputReadonly>
+  )
+}
+
+export const MultiLineSecret: StoryFn = () => {
+  return (
+    <InputReadonly
+      label='Login with your admin credentials'
+      showCopyAction
+      secret
+    >
       {`commercelayer app:login \\
       -i asdGvqXsOSsdko6ueiX9 \\
       -s elyFpGvqXsOSss2Ua4No1_HxaKH_0rUsFuYiX9 \\


### PR DESCRIPTION
## What I did

- Added a `secret` prop to hide value from  `InputReadonly` and also show a button to show/hide input value
- add focus outline on the input group level to display outline feedback also when buttons are focused

https://deploy-preview-626--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputreadonly--docs#secret

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
