### PR TITLE
Add `useResourceAddressOverlay` hook and `ResourceAddressFormFields` component can be reused in other forms

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -57,7 +57,7 @@
     "swr": "^2.2.5",
     "ts-invariant": "^0.10.3",
     "type-fest": "^4.15.0",
-    "zod": "^3.22.4"
+    "zod": "^3.23.4"
   },
   "devDependencies": {
     "@commercelayer/eslint-config-ts-react": "^1.4.5",

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -288,7 +288,10 @@ export {
 // Resources
 export {
   ResourceAddress,
+  ResourceAddressFormFields,
+  resourceAddressFormFieldsSchema,
   useResourceAddressOverlay,
+  type ResourceAddressFormFieldsProps,
   type ResourceAddressProps
 } from '#ui/resources/ResourceAddress'
 export {

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -288,6 +288,7 @@ export {
 // Resources
 export {
   ResourceAddress,
+  useResourceAddressOverlay,
   type ResourceAddressProps
 } from '#ui/resources/ResourceAddress'
 export {

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
@@ -3,7 +3,7 @@ import { type Address } from '@commercelayer/sdk'
 export const presetAddresses = {
   withName: {
     type: 'addresses',
-    id: '',
+    id: 'aaZYuDJVXW',
     company: '',
     first_name: 'Darth',
     last_name: 'Vader',
@@ -21,7 +21,7 @@ export const presetAddresses = {
   },
   withCompany: {
     type: 'addresses',
-    id: '',
+    id: 'bbZYuDJVXW',
     company: 'Galactic Empire',
     first_name: '',
     last_name: '',
@@ -39,12 +39,12 @@ export const presetAddresses = {
   },
   withNotes: {
     type: 'addresses',
-    id: '',
+    id: 'ccZYuDJVXW',
     company: '',
-    first_name: 'Darth',
-    last_name: 'Vader',
-    full_name: 'Darth Vader',
-    line_1: 'Via Morte Nera, 13',
+    first_name: 'Luke',
+    last_name: 'Skywalker',
+    full_name: 'Luke Skywalker',
+    line_1: 'Via Polis Massa, 42',
     line_2: 'Ragnatela, 99',
     city: 'Cogorno',
     country_code: 'IT',

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
@@ -51,13 +51,15 @@ describe('ResourceAddress', () => {
 
   test('Should render fullName', async () => {
     const { getByTestId } = setup()
-    expect(getByTestId('ResourceAddress-fullName')).toContainHTML('Darth Vader')
+    expect(getByTestId('ResourceAddress-fullName')).toContainHTML(
+      'Luke Skywalker'
+    )
   })
 
   test('Should render address', async () => {
     const { getByTestId } = setup()
     expect(getByTestId('ResourceAddress-address')).toContainHTML(
-      'Via Morte Nera, 13'
+      'Via Polis Massa, 42'
     )
   })
 

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -1,16 +1,14 @@
-import { useOverlay } from '#hooks/useOverlay'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { Button } from '#ui/atoms/Button'
 import { Hr } from '#ui/atoms/Hr'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
-import { PageLayout } from '#ui/composite/PageLayout'
 import { type Address } from '@commercelayer/sdk'
 import { Note, PencilSimple, Phone } from '@phosphor-icons/react'
 import isEmpty from 'lodash/isEmpty'
 import { useEffect, useState } from 'react'
-import { ResourceAddressForm } from './ResourceAddressForm'
+import { useResourceAddressOverlay } from './useResourceAddressOverlay'
 
 export interface ResourceAddressProps {
   /**
@@ -38,10 +36,17 @@ export interface ResourceAddressProps {
  */
 export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
   ({ resource, title, editable = false, showBillingInfo = false }) => {
-    const { Overlay, open, close } = useOverlay()
+    const [address, setAddress] = useState<Address>(resource)
     const { canUser } = useTokenProvider()
 
-    const [address, setAddress] = useState<Address>(resource)
+    const { ResourceAddressOverlay, openAddressOverlay } =
+      useResourceAddressOverlay({
+        address: resource,
+        showBillingInfo,
+        onUpdate: (updatedAddress) => {
+          setAddress(updatedAddress)
+        }
+      })
 
     useEffect(() => {
       setAddress(resource)
@@ -123,7 +128,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
               <Button
                 variant='link'
                 onClick={() => {
-                  open()
+                  openAddressOverlay()
                 }}
                 data-testid='ResourceAddress-editButton'
               >
@@ -132,29 +137,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
             </div>
           )}
         </div>
-        {editable && canUser('update', 'addresses') && (
-          <Overlay>
-            <PageLayout
-              title='Edit address'
-              minHeight={false}
-              navigationButton={{
-                label: 'Back',
-                onClick: () => {
-                  close()
-                }
-              }}
-            >
-              <ResourceAddressForm
-                address={address}
-                showBillingInfo={showBillingInfo}
-                onChange={(updatedAddress: Address) => {
-                  setAddress(updatedAddress)
-                  close()
-                }}
-              />
-            </PageLayout>
-          </Overlay>
-        )}
+        {editable && <ResourceAddressOverlay />}
       </>
     )
   }

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
@@ -1,49 +1,22 @@
 import { useCoreSdkProvider } from '#providers/CoreSdkProvider'
 import { Button } from '#ui/atoms/Button'
-import { Grid } from '#ui/atoms/Grid'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { HookedForm } from '#ui/forms/Form/HookedForm'
-import { HookedInput } from '#ui/forms/Input/HookedInput'
-import { type InputSelectValue } from '#ui/forms/InputSelect'
-import { HookedInputSelect } from '#ui/forms/InputSelect/HookedInputSelect'
-import { HookedInputTextArea } from '#ui/forms/InputTextArea'
 import { HookedValidationApiError } from '#ui/forms/ReactHookForm/HookedValidationApiError'
 import { type Address } from '@commercelayer/sdk'
 import { zodResolver } from '@hookform/resolvers/zod'
-import React, { useEffect, useState } from 'react'
-import { useForm, useFormContext } from 'react-hook-form'
-import { z } from 'zod'
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import {
+  ResourceAddressFormFields,
+  resourceAddressFormFieldsSchema,
+  type ResourceAddressFormFieldsProps
+} from './ResourceAddressFormFields'
 
-const zodString = z
-  .string({
-    required_error: 'Required field',
-    invalid_type_error: 'Invalid format'
-  })
-  .min(1, {
-    message: 'Required field'
-  })
-
-const addressFormSchema = z.object({
-  first_name: z.string().nullish(),
-  last_name: z.string().nullish(),
-  company: z.string().nullish(),
-  line_1: zodString,
-  line_2: z.string().nullish(),
-  city: zodString,
-  zip_code: z.string().nullish(),
-  state_code: zodString,
-  country_code: zodString,
-  phone: zodString,
-  billing_info: z.string().nullish(),
-  notes: z.string().nullish()
-})
-
-export type ResourceAddressFormValues = z.infer<typeof addressFormSchema>
-
-interface ResourceAddressFormProps {
+interface ResourceAddressFormProps
+  extends Omit<ResourceAddressFormFieldsProps, 'name'> {
   address: Address
-  showBillingInfo?: boolean
   onChange: (updatedAddress: Address) => void
 }
 
@@ -52,7 +25,7 @@ export const ResourceAddressForm =
     ({ address, showBillingInfo = false, onChange }) => {
       const methods = useForm({
         defaultValues: address,
-        resolver: zodResolver(addressFormSchema)
+        resolver: zodResolver(resourceAddressFormFieldsSchema)
       })
 
       const [apiError, setApiError] = useState<any>()
@@ -77,51 +50,7 @@ export const ResourceAddressForm =
               })
           }}
         >
-          <FieldRow columns='2'>
-            <HookedInput name='first_name' label='First name' />
-            <HookedInput name='last_name' label='Last name' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name='company' label='Company' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name='line_1' label='Address line 1' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name='line_2' label='Address line 2' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <SelectCountry />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name='city' label='City' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <div className='grid grid-cols-[2fr_1fr] gap-4'>
-              <SelectStates />
-              <HookedInput name='zip_code' label='ZIP code' />
-            </div>
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name='phone' label='Phone' />
-          </FieldRow>
-
-          {showBillingInfo && (
-            <FieldRow columns='1'>
-              <HookedInput name='billing_info' label='Billing info' />
-            </FieldRow>
-          )}
-
-          <FieldRow columns='1'>
-            <HookedInputTextArea name='notes' label='Notes' rows={2} />
-          </FieldRow>
+          <ResourceAddressFormFields showBillingInfo={showBillingInfo} />
 
           <Spacer top='14'>
             <Button type='submit' disabled={isSubmitting} className='w-full'>
@@ -133,98 +62,3 @@ export const ResourceAddressForm =
       )
     }
   )
-
-const FieldRow = ({
-  children,
-  columns
-}: {
-  children: React.ReactNode
-  columns: '1' | '2'
-}): JSX.Element => {
-  return (
-    <Spacer bottom='8'>
-      <Grid columns={columns}>{children}</Grid>
-    </Spacer>
-  )
-}
-
-const SelectCountry: React.FC = () => {
-  const [countries, setCountries] = useState<InputSelectValue[] | undefined>()
-  const [forceTextInput, setForceTextInput] = useState(false)
-
-  useEffect(() => {
-    void fetch('https://data.commercelayer.app/assets/lists/countries.json')
-      .then<InputSelectValue[]>(async (res) => await res.json())
-      .then((data) => {
-        setCountries(data)
-      })
-      .catch(() => {
-        // error fetching states, fallback to text input
-        setForceTextInput(true)
-      })
-  }, [])
-
-  if (forceTextInput) {
-    return <HookedInput name='country_code' label='Country' />
-  }
-
-  return (
-    <HookedInputSelect
-      name='country_code'
-      label='Country'
-      key={countries?.length}
-      initialValues={countries ?? []}
-      pathToValue='value'
-      isLoading={countries == null}
-    />
-  )
-}
-
-const SelectStates: React.FC = () => {
-  const [states, setStates] = useState<InputSelectValue[] | undefined>()
-  const { watch, setValue } = useFormContext<ResourceAddressFormValues>()
-  const [forceTextInput, setForceTextInput] = useState(false)
-
-  const countryCode = watch('country_code')
-  const stateCode = watch('state_code')
-  const countryWithStates = ['US', 'IT']
-
-  useEffect(() => {
-    if (countryCode != null && countryWithStates.includes(countryCode)) {
-      void fetch(
-        `https://data.commercelayer.app/assets/lists/states/${countryCode}.json`
-      )
-        .then<InputSelectValue[]>(async (res) => await res.json())
-        .then((data) => {
-          setStates(data)
-          if (data.find(({ value }) => value === stateCode) == null) {
-            // reset state_code if not found in the list
-            setValue('state_code', '')
-          }
-        })
-        .catch(() => {
-          // error fetching states, fallback to text input
-          setForceTextInput(true)
-        })
-    }
-  }, [countryCode])
-
-  if (
-    !countryWithStates.includes(countryCode) ||
-    states?.length === 0 ||
-    forceTextInput
-  ) {
-    return <HookedInput name='state_code' label='State code' />
-  }
-
-  return (
-    <HookedInputSelect
-      name='state_code'
-      label='State'
-      key={`${countryCode}_${states?.length}`}
-      initialValues={states ?? []}
-      pathToValue='value'
-      isLoading={states == null}
-    />
-  )
-}

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -1,0 +1,199 @@
+import { Grid } from '#ui/atoms/Grid'
+import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import { Spacer } from '#ui/atoms/Spacer'
+import { HookedInput } from '#ui/forms/Input/HookedInput'
+import { type InputSelectValue } from '#ui/forms/InputSelect'
+import { HookedInputSelect } from '#ui/forms/InputSelect/HookedInputSelect'
+import { HookedInputTextArea } from '#ui/forms/InputTextArea'
+import React, { useEffect, useState } from 'react'
+import { useFormContext } from 'react-hook-form'
+import { z } from 'zod'
+
+const zodRequiredField = z
+  .string({
+    required_error: 'Required field',
+    invalid_type_error: 'Invalid format'
+  })
+  .min(1, {
+    message: 'Required field'
+  })
+
+export const resourceAddressFormFieldsSchema = z.object({
+  first_name: z.string().nullish(),
+  last_name: z.string().nullish(),
+  company: z.string().nullish(),
+  line_1: zodRequiredField,
+  line_2: z.string().nullish(),
+  city: zodRequiredField,
+  zip_code: z.string().nullish(),
+  state_code: zodRequiredField,
+  country_code: zodRequiredField,
+  phone: zodRequiredField,
+  billing_info: z.string().nullish(),
+  notes: z.string().nullish()
+})
+
+export interface ResourceAddressFormFieldsProps {
+  name?: string
+  showBillingInfo?: boolean
+}
+
+export const ResourceAddressFormFields =
+  withSkeletonTemplate<ResourceAddressFormFieldsProps>(
+    ({ name, showBillingInfo = false }) => {
+      const namePrefix = name == null ? '' : `${name}.`
+
+      return (
+        <>
+          <FieldRow columns='2'>
+            <HookedInput name={`${namePrefix}first_name`} label='First name' />
+            <HookedInput name={`${namePrefix}last_name`} label='Last name' />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <HookedInput name={`${namePrefix}company`} label='Company' />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <HookedInput name={`${namePrefix}line_1`} label='Address line 1' />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <HookedInput name={`${namePrefix}line_2`} label='Address line 2' />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <SelectCountry namePrefix={namePrefix} />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <HookedInput name={`${namePrefix}city`} label='City' />
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <div className='grid grid-cols-[2fr_1fr] gap-4'>
+              <SelectStates namePrefix={namePrefix} />
+              <HookedInput name={`${namePrefix}zip_code`} label='ZIP code' />
+            </div>
+          </FieldRow>
+
+          <FieldRow columns='1'>
+            <HookedInput name={`${namePrefix}phone`} label='Phone' />
+          </FieldRow>
+
+          {showBillingInfo && (
+            <FieldRow columns='1'>
+              <HookedInput
+                name={`${namePrefix}billing_info`}
+                label='Billing info'
+              />
+            </FieldRow>
+          )}
+
+          <FieldRow columns='1'>
+            <HookedInputTextArea
+              name={`${namePrefix}notes`}
+              label='Notes'
+              rows={2}
+            />
+          </FieldRow>
+        </>
+      )
+    }
+  )
+
+const FieldRow = ({
+  children,
+  columns
+}: {
+  children: React.ReactNode
+  columns: '1' | '2'
+}): JSX.Element => {
+  return (
+    <Spacer bottom='8'>
+      <Grid columns={columns}>{children}</Grid>
+    </Spacer>
+  )
+}
+
+const SelectCountry: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
+  const [countries, setCountries] = useState<InputSelectValue[] | undefined>()
+  const [forceTextInput, setForceTextInput] = useState(false)
+
+  useEffect(() => {
+    void fetch('https://data.commercelayer.app/assets/lists/countries.json')
+      .then<InputSelectValue[]>(async (res) => await res.json())
+      .then((data) => {
+        setCountries(data)
+      })
+      .catch(() => {
+        // error fetching states, fallback to text input
+        setForceTextInput(true)
+      })
+  }, [])
+
+  if (forceTextInput) {
+    return <HookedInput name={`${namePrefix}country_code`} label='Country' />
+  }
+
+  return (
+    <HookedInputSelect
+      name={`${namePrefix}country_code`}
+      label='Country'
+      key={countries?.length}
+      initialValues={countries ?? []}
+      pathToValue='value'
+      isLoading={countries == null}
+    />
+  )
+}
+
+const SelectStates: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
+  const [states, setStates] = useState<InputSelectValue[] | undefined>()
+  const { watch, setValue } =
+    useFormContext<z.infer<typeof resourceAddressFormFieldsSchema>>()
+  const [forceTextInput, setForceTextInput] = useState(false)
+
+  const countryCode = watch('country_code')
+  const stateCode = watch('state_code')
+  const countryWithStates = ['US', 'IT']
+
+  useEffect(() => {
+    if (countryCode != null && countryWithStates.includes(countryCode)) {
+      void fetch(
+        `https://data.commercelayer.app/assets/lists/states/${countryCode}.json`
+      )
+        .then<InputSelectValue[]>(async (res) => await res.json())
+        .then((data) => {
+          setStates(data)
+          if (data.find(({ value }) => value === stateCode) == null) {
+            // reset state_code if not found in the list
+            setValue('state_code', '')
+          }
+        })
+        .catch(() => {
+          // error fetching states, fallback to text input
+          setForceTextInput(true)
+        })
+    }
+  }, [countryCode])
+
+  if (
+    !countryWithStates.includes(countryCode) ||
+    states?.length === 0 ||
+    forceTextInput
+  ) {
+    return <HookedInput name={`${namePrefix}state_code`} label='State code' />
+  }
+
+  return (
+    <HookedInputSelect
+      name={`${namePrefix}state_code`}
+      label='State'
+      key={`${countryCode}_${states?.length}`}
+      initialValues={states ?? []}
+      pathToValue='value'
+      isLoading={states == null}
+    />
+  )
+}

--- a/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
@@ -1,1 +1,2 @@
 export { ResourceAddress, type ResourceAddressProps } from './ResourceAddress'
+export { useResourceAddressOverlay } from './useResourceAddressOverlay'

--- a/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
@@ -1,2 +1,7 @@
 export { ResourceAddress, type ResourceAddressProps } from './ResourceAddress'
+export {
+  ResourceAddressFormFields,
+  resourceAddressFormFieldsSchema,
+  type ResourceAddressFormFieldsProps
+} from './ResourceAddressFormFields'
 export { useResourceAddressOverlay } from './useResourceAddressOverlay'

--- a/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
@@ -1,0 +1,58 @@
+import { useOverlay } from '#hooks/useOverlay'
+import { useTokenProvider } from '#providers/TokenProvider'
+import { PageLayout } from '#ui/composite/PageLayout'
+import { type Address } from '@commercelayer/sdk'
+import { useCallback } from 'react'
+import { ResourceAddressForm } from './ResourceAddressForm'
+
+export const useResourceAddressOverlay = ({
+  title = 'Edit address',
+  address,
+  showBillingInfo,
+  onUpdate
+}: {
+  title?: string
+  address: Address
+  showBillingInfo?: boolean
+  onUpdate?: (updatedAddress: Address) => void
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+}) => {
+  const { canUser } = useTokenProvider()
+  const { Overlay, open, close } = useOverlay()
+
+  const openAddressOverlay = useCallback(() => {
+    if (canUser('update', 'addresses')) {
+      open()
+    }
+  }, [open, canUser])
+
+  const ResourceAddressOverlay = useCallback(() => {
+    return (
+      canUser('update', 'addresses') && (
+        <Overlay>
+          <PageLayout
+            title={title}
+            minHeight={false}
+            navigationButton={{
+              label: 'Back',
+              onClick: () => {
+                close()
+              }
+            }}
+          >
+            <ResourceAddressForm
+              address={address}
+              showBillingInfo={showBillingInfo}
+              onChange={(updatedAddress: Address) => {
+                onUpdate?.(updatedAddress)
+                close()
+              }}
+            />
+          </PageLayout>
+        </Overlay>
+      )
+    )
+  }, [Overlay, close, canUser, address, showBillingInfo, onUpdate])
+
+  return { ResourceAddressOverlay, openAddressOverlay }
+}

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -25,6 +25,7 @@
     "@babel/core": "^7.24.4",
     "@babel/preset-env": "^7.24.4",
     "@commercelayer/eslint-config-ts-react": "^1.4.5",
+    "@hookform/resolvers": "^3.3.4",
     "@mdx-js/react": "^3.0.1",
     "@storybook/addon-actions": "^7.6.16",
     "@storybook/addon-backgrounds": "^7.6.16",
@@ -66,7 +67,8 @@
     "storybook": "^7.6.16",
     "typescript": "^5.4.5",
     "vite": "^5.2.8",
-    "vite-tsconfig-paths": "^4.3.2"
+    "vite-tsconfig-paths": "^4.3.2",
+    "zod": "^3.23.4"
   },
   "msw": {
     "workerDirectory": "public"

--- a/packages/docs/src/mocks/data/addresses.js
+++ b/packages/docs/src/mocks/data/addresses.js
@@ -1,0 +1,54 @@
+import { HttpResponse, http } from 'msw'
+
+const mockedAddress = {
+  type: 'addresses',
+  attributes: {
+    business: true,
+    first_name: null,
+    last_name: null,
+    company: 'The Brand SRL',
+    full_name: 'The Brand SRL',
+    line_1: 'Via Morte Nera 123',
+    line_2: null,
+    city: 'Firenze',
+    zip_code: '50123',
+    state_code: 'FI',
+    country_code: 'IT',
+    phone: '+39 055 1234567890',
+    full_address:
+      'Via Morte Nera 123, 50123 Firenze FI (IT) +39 055 1234567890',
+    name: 'The Brand SRL, Via Morte Nera 123, 50123 Firenze FI (IT) +39 055 1234567890',
+    email: 'touch@example.com',
+    notes: null,
+    lat: null,
+    lng: null,
+    is_localized: false,
+    is_geocoded: false,
+    provider_name: null,
+    map_url: null,
+    static_map_url: null,
+    billing_info: null,
+    created_at: '2022-02-24T14:08:14.712Z',
+    updated_at: '2022-02-24T14:08:14.712Z',
+    reference: 'address_1',
+    reference_origin: 'CLI',
+    metadata: {}
+  },
+  meta: {
+    mode: 'test',
+    organization_id: 'WXlEOFrjnr'
+  }
+}
+
+const restPatch = ['aaZYuDJVXW', 'bbZYuDJVXW', 'ccZYuDJVXW'].map((id) =>
+  http.patch(`https://mock.localhost/api/addresses/${id}`, async () => {
+    return HttpResponse.json({
+      data: {
+        ...mockedAddress,
+        id
+      }
+    })
+  })
+)
+
+export default [...restPatch]

--- a/packages/docs/src/mocks/handlers.js
+++ b/packages/docs/src/mocks/handlers.js
@@ -1,3 +1,4 @@
+import addresses from './data/addresses'
 import adjustments from './data/adjustments'
 import bundles from './data/bundles'
 import customers from './data/customers'
@@ -8,6 +9,7 @@ import tags from './data/tags'
 
 /** @type {import('msw').RequestHandler[]} */
 export const handlers = [
+  ...addresses,
   ...adjustments,
   ...bundles,
   ...customers,

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -1,15 +1,25 @@
 import { CoreSdkProvider } from '#providers/CoreSdkProvider'
 import { MockTokenProvider as TokenProvider } from '#providers/TokenProvider/MockTokenProvider'
 import { Button } from '#ui/atoms/Button'
+import { Spacer } from '#ui/atoms/Spacer'
 import { Stack } from '#ui/atoms/Stack'
 import { ListItem } from '#ui/composite/ListItem'
+import { HookedForm } from '#ui/forms/Form'
+import { HookedInput } from '#ui/forms/Input'
 import {
   ResourceAddress,
   useResourceAddressOverlay
 } from '#ui/resources/ResourceAddress'
 import { presetAddresses } from '#ui/resources/ResourceAddress/ResourceAddress.mocks'
+import {
+  ResourceAddressFormFields,
+  resourceAddressFormFieldsSchema
+} from '#ui/resources/ResourceAddress/ResourceAddressFormFields'
+import { zodResolver } from '@hookform/resolvers/zod'
 import { type Meta, type StoryFn } from '@storybook/react'
 import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
 
 type Props = Parameters<typeof ResourceAddress>[0] & {
   preset: Array<keyof typeof presetAddresses | 'custom'>
@@ -117,6 +127,52 @@ export const UseResourceAddressOverlay: StoryFn = () => {
       >
         Edit address
       </Button>
+    </>
+  )
+}
+
+export const ReuseTheAddressForm: StoryFn = () => {
+  const methods = useForm({
+    defaultValues: {
+      name: 'John Doe Inc.',
+      address: {
+        first_name: 'John',
+        last_name: 'Doe'
+      }
+    },
+    resolver: zodResolver(
+      z.object({
+        name: z
+          .string({
+            required_error: 'Required field',
+            invalid_type_error: 'Invalid format'
+          })
+          .min(1, {
+            message: 'Required field'
+          }),
+        address: resourceAddressFormFieldsSchema
+      })
+    )
+  })
+
+  return (
+    <>
+      <HookedForm
+        {...methods}
+        onSubmit={(formValues) => {
+          console.log(formValues)
+        }}
+      >
+        <Spacer bottom='8'>
+          <HookedInput name='name' label='Name' />
+        </Spacer>
+        <ResourceAddressFormFields name='address' />
+        <Spacer top='14'>
+          <Button type='submit' className='w-full'>
+            Create merchant
+          </Button>
+        </Spacer>
+      </HookedForm>
     </>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: ^4.15.0
         version: 4.15.0
       zod:
-        specifier: ^3.22.4
-        version: 3.22.4
+        specifier: ^3.23.4
+        version: 3.23.4
     devDependencies:
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.4.5
@@ -190,6 +190,9 @@ importers:
       '@commercelayer/eslint-config-ts-react':
         specifier: ^1.4.5
         version: 1.4.5(@types/eslint@8.56.2)(eslint@8.56.0)(react@18.2.0)(typescript@5.4.5)
+      '@hookform/resolvers':
+        specifier: ^3.3.4
+        version: 3.3.4(react-hook-form@7.51.3(react@18.2.0))
       '@mdx-js/react':
         specifier: ^3.0.1
         version: 3.0.1(@types/react@18.2.78)(react@18.2.0)
@@ -316,6 +319,9 @@ importers:
       vite-tsconfig-paths:
         specifier: ^4.3.2
         version: 4.3.2(typescript@5.4.5)(vite@5.2.8(@types/node@20.12.7)(terser@5.27.1))
+      zod:
+        specifier: ^3.23.4
+        version: 3.23.4
 
 packages:
 
@@ -8603,8 +8609,8 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
-  zod@3.22.4:
-    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+  zod@3.23.4:
+    resolution: {integrity: sha512-/AtWOKbBgjzEYYQRNfoGKHObgfAZag6qUJX1VbHo2PRBgS+wfWagEY2mizjfyAPcGesrJOcx/wcl0L9WnVrHFw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -18824,6 +18830,6 @@ snapshots:
     optionalDependencies:
       commander: 9.5.0
 
-  zod@3.22.4: {}
+  zod@3.23.4: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## What I did

I exported:
- `useResourceAddressOverlay` hook so that the address overlay can be opened from a dropdown.
- `ResourceAddressFormFields` component can be reused in other forms

## How to test

https://deploy-preview-637--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceaddress--docs

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
