### PR TITLE
Refactor `PageSkeleton` with a single and generic layout

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -54,6 +54,7 @@ export {
   useCoreApi,
   useCoreSdkProvider
 } from '#providers/CoreSdkProvider'
+export { createApp, type ClAppKey, type ClAppProps } from '#providers/createApp'
 export { ErrorBoundary } from '#providers/ErrorBoundary'
 export { GTMProvider, useTagManager } from '#providers/GTMProvider'
 export {
@@ -66,7 +67,6 @@ export {
   type TokenProviderRolePermissions,
   type TokenProviderTokenApplicationKind
 } from '#providers/TokenProvider'
-export { createApp, type ClAppKey, type ClAppProps } from '#providers/createApp'
 
 // Atoms
 export { A, type AProps } from '#ui/atoms/A'
@@ -163,10 +163,7 @@ export {
 export { ListItem, type ListItemProps } from '#ui/composite/ListItem'
 export { PageError, type PageErrorProps } from '#ui/composite/PageError'
 export { PageLayout, type PageLayoutProps } from '#ui/composite/PageLayout'
-export {
-  PageSkeleton,
-  type PageSkeletonProps
-} from '#ui/composite/PageSkeleton'
+export { PageSkeleton } from '#ui/composite/PageSkeleton'
 export { Report, type ReportProps } from '#ui/composite/Report'
 export { SearchBar, type SearchBarProps } from '#ui/composite/SearchBar'
 export { TableData, type TableDataProps } from '#ui/composite/TableData'

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -1,6 +1,7 @@
 import { type TokenProviderTokenApplicationKind } from '#providers/TokenProvider'
 import { isProductionHostname } from '#providers/TokenProvider/url'
 import { PageError } from '#ui/composite/PageError'
+import { PageSkeleton } from '#ui/composite/PageSkeleton'
 import { type Organization } from '@commercelayer/sdk'
 import { type ListableResourceType } from '@commercelayer/sdk/lib/cjs/api'
 import {
@@ -80,6 +81,7 @@ export interface TokenProviderProps {
   onInvalidAuth?: (info: { dashboardUrl: string; reason: string }) => void
   /**
    * The UI element to be used as loader (e.g. skeleton or spinner icon).
+   * This element is ignored when app is running within the dashboard, since it will use the standard PageSkeleton ad not-overridable ui loader.
    */
   loadingElement?: ReactNode
   /**
@@ -282,7 +284,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
   }
 
   if (_state.isLoading) {
-    return <>{loadingElement}</>
+    return <>{isInDashboard ? <PageSkeleton /> : loadingElement}</>
   }
 
   return (

--- a/packages/app-elements/src/ui/atoms/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading.tsx
@@ -2,6 +2,7 @@ import cn from 'classnames'
 import { type ReactNode } from 'react'
 import { Badge, type BadgeProps } from './Badge'
 import { Icon } from './Icon'
+import { withSkeletonTemplate } from './SkeletonTemplate'
 import { Text } from './Text'
 
 export interface PageHeadingProps {
@@ -45,58 +46,62 @@ export interface PageHeadingProps {
   actionButton?: React.ReactNode
 }
 
-function PageHeading({
-  gap = 'both',
-  badge,
-  navigationButton,
-  title,
-  description,
-  actionButton,
-  ...rest
-}: PageHeadingProps): JSX.Element {
-  return (
-    <div
-      className={cn([
-        'w-full',
-        {
-          'pt-10 pb-14': gap === 'both',
-          'pt-10': gap === 'only-top',
-          'pb-14': gap === 'only-bottom'
-        }
-      ])}
-      {...rest}
-    >
-      {(navigationButton != null || actionButton != null) && (
-        <div className={cn('mb-4 flex items-center justify-between')}>
-          {navigationButton != null ? (
-            <button
-              type='button'
-              className='flex items-center gap-1'
-              onClick={() => {
-                navigationButton.onClick()
-              }}
-            >
-              <Icon name={navigationButton.icon ?? 'arrowLeft'} size={24} />{' '}
-              <Text weight='semibold'>{navigationButton.label}</Text>
-            </button>
-          ) : null}
-          {actionButton != null ? <div>{actionButton}</div> : null}
-        </div>
-      )}
-      {badge != null && (
-        <div className='flex mb-4 md:!mt-0' data-testid='page-heading-badge'>
-          <Badge variant={badge.variant ?? 'warning-solid'}>
-            {badge.label}
-          </Badge>
-        </div>
-      )}
-      <h1 className='font-semibold text-title leading-title'>{title}</h1>
-      {description !== null && (
-        <div className='text-gray-500 leading-6 mt-2'>{description}</div>
-      )}
-    </div>
-  )
-}
+const PageHeading = withSkeletonTemplate<PageHeadingProps>(
+  ({
+    gap = 'both',
+    badge,
+    navigationButton,
+    title,
+    description,
+    actionButton,
+    isLoading,
+    delayMs,
+    ...rest
+  }) => {
+    return (
+      <div
+        className={cn([
+          'w-full',
+          {
+            'pt-10 pb-14': gap === 'both',
+            'pt-10': gap === 'only-top',
+            'pb-14': gap === 'only-bottom'
+          }
+        ])}
+        {...rest}
+      >
+        {(navigationButton != null || actionButton != null) && (
+          <div className={cn('mb-4 flex items-center justify-between')}>
+            {navigationButton != null ? (
+              <button
+                type='button'
+                className='flex items-center gap-1'
+                onClick={() => {
+                  navigationButton.onClick()
+                }}
+              >
+                <Icon name={navigationButton.icon ?? 'arrowLeft'} size={24} />{' '}
+                <Text weight='semibold'>{navigationButton.label}</Text>
+              </button>
+            ) : null}
+            {actionButton != null ? <div>{actionButton}</div> : null}
+          </div>
+        )}
+        {badge != null && (
+          <div className='flex mb-4 md:!mt-0' data-testid='page-heading-badge'>
+            <Badge variant={badge.variant ?? 'warning-solid'}>
+              {badge.label}
+            </Badge>
+          </div>
+        )}
+        <h1 className='font-semibold text-title leading-title'>{title}</h1>
+        {description !== null && (
+          <div className='text-gray-500 leading-6 mt-2'>{description}</div>
+        )}
+      </div>
+    )
+  }
+)
 
 PageHeading.displayName = 'PageHeading'
 export { PageHeading }

--- a/packages/app-elements/src/ui/composite/PageLayout.tsx
+++ b/packages/app-elements/src/ui/composite/PageLayout.tsx
@@ -3,6 +3,7 @@ import type { ContainerProps } from '#ui/atoms/Container'
 import { Container } from '#ui/atoms/Container'
 import { PageHeading, type PageHeadingProps } from '#ui/atoms/PageHeading'
 import { ScrollToTop } from '#ui/atoms/ScrollToTop'
+import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Overlay } from '#ui/internals/Overlay'
 import { type ReactNode } from 'react'
@@ -32,54 +33,60 @@ export interface PageLayoutProps
   scrollToTop?: boolean
 }
 
-export function PageLayout({
-  title,
-  description,
-  navigationButton,
-  children,
-  actionButton,
-  mode,
-  gap,
-  minHeight,
-  scrollToTop,
-  overlay = false,
-  ...rest
-}: PageLayoutProps): JSX.Element {
-  const {
-    settings: { isInDashboard }
-  } = useTokenProvider()
+export const PageLayout = withSkeletonTemplate<PageLayoutProps>(
+  ({
+    title,
+    description,
+    navigationButton,
+    children,
+    actionButton,
+    mode,
+    gap,
+    minHeight,
+    scrollToTop,
+    overlay = false,
+    isLoading,
+    delayMs,
+    ...rest
+  }) => {
+    const {
+      settings: { isInDashboard }
+    } = useTokenProvider()
 
-  const component = (
-    <>
-      <PageHeading
-        title={title}
-        description={description}
-        navigationButton={navigationButton}
-        actionButton={actionButton}
-        badge={
-          mode === 'test' && !isInDashboard
-            ? {
-                label: 'TEST DATA',
-                variant: 'warning-solid'
-              }
-            : undefined
-        }
-        gap={gap}
-      />
-      {children}
-      {scrollToTop === true && <ScrollToTop />}
-    </>
-  )
+    const component = (
+      <>
+        <PageHeading
+          title={title}
+          description={description}
+          navigationButton={navigationButton}
+          actionButton={actionButton}
+          badge={
+            mode === 'test' && !isInDashboard
+              ? {
+                  label: 'TEST DATA',
+                  variant: 'warning-solid'
+                }
+              : undefined
+          }
+          gap={gap}
+          isLoading={isLoading}
+          delayMs={delayMs}
+        />
+        {children}
+        {scrollToTop === true && <ScrollToTop />}
+      </>
+    )
 
-  if (overlay) {
-    return <Overlay backgroundColor='light'>{component}</Overlay>
+    if (overlay) {
+      return <Overlay backgroundColor='light'>{component}</Overlay>
+    }
+
+    return (
+      <Container minHeight={minHeight} {...rest}>
+        <Spacer bottom='14'>{component}</Spacer>
+      </Container>
+    )
   }
-
-  return (
-    <Container minHeight={minHeight} {...rest}>
-      <Spacer bottom='14'>{component}</Spacer>
-    </Container>
-  )
-}
+)
 
 PageLayout.displayName = 'PageLayout'

--- a/packages/app-elements/src/ui/composite/PageSkeleton.test.tsx
+++ b/packages/app-elements/src/ui/composite/PageSkeleton.test.tsx
@@ -1,34 +1,10 @@
-import { PageSkeleton } from './PageSkeleton'
 import { render } from '@testing-library/react'
+import { PageSkeleton } from './PageSkeleton'
 
 describe('PageSkeleton', () => {
   test('Should be rendered', () => {
-    const { getByTestId } = render(<PageSkeleton delayMs={0} />)
-    const element = getByTestId('page-skeleton')
-    expect(element).toBeVisible()
-    expect(
-      element.querySelector('loading-header-description')
-    ).not.toBeInTheDocument()
-  })
-
-  test('Should have skeleton for header description ', () => {
-    const { getByTestId } = render(
-      <PageSkeleton hasHeaderDescription delayMs={0} />
-    )
-    expect(getByTestId('loading-header-description')).toBeVisible()
-  })
-
-  test('Should render a skeleton for list page', () => {
-    const { getByTestId } = render(<PageSkeleton layout='list' delayMs={0} />)
-    expect(getByTestId('page-skeleton')).toBeVisible()
-    expect(getByTestId('loading-list')).toBeVisible()
-  })
-
-  test('Should render a skeleton for list page', () => {
-    const { getByTestId } = render(
-      <PageSkeleton layout='details' delayMs={0} />
-    )
-    expect(getByTestId('page-skeleton')).toBeVisible()
-    expect(getByTestId('loading-details')).toBeVisible()
+    const { container } = render(<PageSkeleton />)
+    expect(container).toBeVisible()
+    expect(container).toMatchSnapshot()
   })
 })

--- a/packages/app-elements/src/ui/composite/PageSkeleton.tsx
+++ b/packages/app-elements/src/ui/composite/PageSkeleton.tsx
@@ -1,47 +1,61 @@
-import { Container } from '#ui/atoms/Container'
-import { Skeleton, SkeletonItem } from '#ui/atoms/Skeleton'
+import { Section } from '#ui/atoms/Section'
+import { SkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import { Spacer } from '#ui/atoms/Spacer'
+import { StatusIcon } from '#ui/atoms/StatusIcon'
+import { Text } from '#ui/atoms/Text'
 import { List } from '#ui/composite/List'
-import { ListDetails } from '#ui/composite/ListDetails'
-import { Report } from './Report'
+import { ListItem } from '#ui/composite/ListItem'
+import { PageLayout } from '#ui/composite/PageLayout'
+import { SearchBar } from '#ui/composite/SearchBar'
 
-export interface PageSkeletonProps {
-  layout?: 'list' | 'details'
-  hasHeaderDescription?: boolean
-  delayMs?: number
-}
-
-function PageSkeleton({
-  layout,
-  hasHeaderDescription,
-  delayMs
-}: PageSkeletonProps): JSX.Element {
+/**
+ * This component renders a skeleton page layout simulating the presence of the common elements of an initial app page:
+ * - page title,
+ * - back button,
+ * - search bar,
+ * - list of items.
+ *
+ * <span type='info'>You can use this component to display generic loading UI when you can't rely on single SkeletonTemplate blocks.</span>
+ **/
+function PageSkeleton(): JSX.Element {
   return (
-    <Container data-testid='page-skeleton'>
-      <Skeleton delayMs={delayMs}>
-        {/* PageHeading */}
-        <div className='pt-10 pb-14'>
-          <div>
-            <SkeletonItem className='w-8 h-8 mb-2' />
-            <SkeletonItem className='w-36 h-8' />
-            {hasHeaderDescription === true && (
-              <SkeletonItem
-                data-testid='loading-header-description'
-                className='w-36 h-5 mt-2'
-              />
-            )}
-          </div>
-        </div>
+    <SkeletonTemplate isLoading delayMs={0}>
+      <PageLayout
+        title='Loading'
+        navigationButton={{
+          label: 'Back',
+          onClick: () => {}
+        }}
+        gap='only-top'
+      >
+        <Spacer bottom='14'>
+          <SearchBar onSearch={() => {}} isLoading delayMs={0} />
+        </Spacer>
 
-        {layout === 'list' ? (
-          <List data-testid='loading-list' isLoading />
-        ) : layout === 'details' ? (
-          <div data-testid='loading-details'>
-            <Report isLoading loadingLines={2} items={[]} />
-            <ListDetails title='Details' isLoading loadingLines={4} />
-          </div>
-        ) : null}
-      </Skeleton>
-    </Container>
+        <Section title='Loading' border='none'>
+          <List>
+            {Array.from({ length: 2 }).map((_, index) => (
+              <ListItem
+                key={index}
+                icon={
+                  <StatusIcon name='arrowDown' background='gray' gap='large' />
+                }
+              >
+                <div>
+                  <Text tag='div' weight='semibold'>
+                    Loading item number {index}
+                  </Text>
+                  <Text tag='div' weight='medium' size='small' variant='info'>
+                    please wait a moment
+                  </Text>
+                </div>
+                <StatusIcon name='caretRight' />
+              </ListItem>
+            ))}
+          </List>
+        </Section>
+      </PageLayout>
+    </SkeletonTemplate>
   )
 }
 

--- a/packages/app-elements/src/ui/composite/SearchBar.tsx
+++ b/packages/app-elements/src/ui/composite/SearchBar.tsx
@@ -1,10 +1,15 @@
+import {
+  SkeletonTemplate,
+  type SkeletonTemplateProps
+} from '#ui/atoms/SkeletonTemplate'
 import { StatusIcon } from '#ui/atoms/StatusIcon'
 import cn from 'classnames'
 import debounce from 'lodash/debounce'
 import isEmpty from 'lodash/isEmpty'
 import { forwardRef, useCallback, useEffect, useState } from 'react'
 
-export interface SearchBarProps {
+export interface SearchBarProps
+  extends Pick<SkeletonTemplateProps, 'isLoading' | 'delayMs'> {
   /**
    * Initial value of the search bar. When changed, the search bar will be updated.
    */
@@ -52,10 +57,12 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
       className,
       placeholder,
       autoFocus,
+      isLoading,
+      delayMs,
       ...rest
     },
     ref
-  ): JSX.Element => {
+  ) => {
     const [searchValue, setSearchValue] = useState('')
 
     const debouncedOnSearch = useCallback(debounce(onSearch, debounceMs), [
@@ -76,50 +83,56 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
     )
 
     return (
-      <div
-        data-testid='SearchBar'
-        className={cn('relative w-full', className)}
-        {...rest}
-      >
-        <StatusIcon
-          name='magnifyingGlass'
-          className='absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-[20px]'
-        />
-        <input
-          className={cn(
-            'rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400',
-            'shadow-none !outline-0 !border-0 !ring-0',
-            '!focus:shadow-none !active:shadow-none focus:caret-primary focus:bg-white'
-          )}
-          data-testid='SearchBar-input'
-          placeholder={placeholder}
-          value={searchValue}
-          onChange={({ currentTarget: { value } }) => {
-            setSearchValue(value)
-            debouncedOnSearch(value)
-          }}
-          ref={ref}
-          autoFocus={autoFocus}
-        />
-
-        {onClear != null && !isEmpty(searchValue) ? (
-          <button
-            data-testid='SearchBar-clear'
+      <SkeletonTemplate isLoading={isLoading} delayMs={delayMs}>
+        <div
+          data-testid='SearchBar'
+          className={cn('relative w-full', className)}
+          {...rest}
+        >
+          <StatusIcon
+            name='magnifyingGlass'
+            className='absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-[20px]'
+          />
+          <input
             className={cn(
-              'flex items-center absolute top-1/2 right-4 transform -translate-y-1/2 text-gray-400',
-              'rounded outline-none ring-0 border-0',
-              'focus-within:shadow-focus focus:text-black'
+              'rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400',
+              'shadow-none !outline-0 !border-0 !ring-0',
+              '!focus:shadow-none !active:shadow-none focus:caret-primary focus:bg-white',
+              {
+                'animate-pulse !bg-gray-50 placeholder:text-gray-50':
+                  isLoading === true
+              }
             )}
-            aria-label='Clear text'
-            onClick={() => {
-              setSearchValue('')
-              onClear()
+            data-testid='SearchBar-input'
+            placeholder={placeholder}
+            value={searchValue}
+            onChange={({ currentTarget: { value } }) => {
+              setSearchValue(value)
+              debouncedOnSearch(value)
             }}
-          >
-            <StatusIcon name='x' className='text-[20px]' />
-          </button>
-        ) : null}
-      </div>
+            ref={ref}
+            autoFocus={autoFocus}
+          />
+
+          {onClear != null && !isEmpty(searchValue) ? (
+            <button
+              data-testid='SearchBar-clear'
+              className={cn(
+                'flex items-center absolute top-1/2 right-4 transform -translate-y-1/2 text-gray-400',
+                'rounded outline-none ring-0 border-0',
+                'focus-within:shadow-focus focus:text-black'
+              )}
+              aria-label='Clear text'
+              onClick={() => {
+                setSearchValue('')
+                onClear()
+              }}
+            >
+              <StatusIcon name='x' className='text-[20px]' />
+            </button>
+          ) : null}
+        </div>
+      </SkeletonTemplate>
     )
   }
 )

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
@@ -1,0 +1,303 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`PageSkeleton > Should be rendered 1`] = `
+<div>
+  <div
+    class="select-none pointer-events-none inline"
+  >
+    <div
+      class="select-none pointer-events-none inline"
+    >
+      <div
+        class="container mx-auto flex flex-col px-4 md:px-0 min-h-screen"
+      >
+        <div
+          class="mb-14"
+        >
+          <div
+            class="select-none pointer-events-none inline"
+          >
+            <div
+              class="w-full pt-10"
+            >
+              <div
+                class="mb-4 flex items-center justify-between"
+              >
+                <button
+                  class="flex items-center gap-1"
+                  type="button"
+                >
+                  <svg
+                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                    fill="currentColor"
+                    height="24"
+                    viewBox="0 0 256 256"
+                    width="24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M224,128a8,8,0,0,1-8,8H59.31l58.35,58.34a8,8,0,0,1-11.32,11.32l-72-72a8,8,0,0,1,0-11.32l72-72a8,8,0,0,1,11.32,11.32L59.31,120H216A8,8,0,0,1,224,128Z"
+                    />
+                  </svg>
+                   
+                  <span
+                    class="font-semibold [overflow-wrap:anywhere]"
+                  >
+                    <span
+                      class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                    >
+                      Back
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <h1
+                class="font-semibold text-title leading-title"
+              >
+                <span
+                  class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                >
+                  Loading
+                </span>
+              </h1>
+              <div
+                class="text-gray-500 leading-6 mt-2"
+              />
+            </div>
+          </div>
+          <div
+            class="mb-14"
+          >
+            <div
+              class="select-none pointer-events-none inline"
+            >
+              <div
+                class="relative w-full"
+                data-testid="SearchBar"
+              >
+                <div
+                  class="inline-block align-middle w-fit absolute top-1/2 left-4 transform -translate-y-1/2 text-gray-400 pointer-events-none select-none text-[20px] select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                >
+                  <svg
+                    fill="currentColor"
+                    height="1em"
+                    viewBox="0 0 256 256"
+                    width="1em"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M229.66,218.34l-50.07-50.06a88.11,88.11,0,1,0-11.31,11.31l50.06,50.07a8,8,0,0,0,11.32-11.32ZM40,112a72,72,0,1,1,72,72A72.08,72.08,0,0,1,40,112Z"
+                    />
+                  </svg>
+                </div>
+                <input
+                  class="rounded px-11 py-2 bg-gray-100 font-medium w-full transition placeholder:text-gray-400 shadow-none !outline-0 !border-0 !ring-0 !focus:shadow-none !active:shadow-none focus:caret-primary focus:bg-white animate-pulse !bg-gray-50 placeholder:text-gray-50"
+                  data-testid="SearchBar-input"
+                  value=""
+                />
+              </div>
+            </div>
+          </div>
+          <div
+            class="select-none pointer-events-none inline"
+          >
+            <section
+              aria-label="Loading"
+            >
+              <header
+                class="border-b pb-4 flex justify-between items-center border-transparent"
+              >
+                <h2
+                  class="text-lg font-semibold"
+                >
+                  <span
+                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                  >
+                    Loading
+                  </span>
+                </h2>
+              </header>
+              <div>
+                <div>
+                  <div>
+                    <div
+                      class=""
+                    >
+                      <div
+                        class="flex gap-4 w-full text-gray-800 hover:text-gray-800 py-4 px-4 border-b border-gray-100"
+                      >
+                        <div
+                          class="flex gap-4 flex-1 items-center"
+                        >
+                          <div
+                            class="flex-shrink-0 my-0.5 self-start"
+                          >
+                            <div
+                              class="select-none pointer-events-none inline"
+                            >
+                              <div
+                                class="inline-block align-middle w-fit p-[10px] border rounded-full bg-gray-300 border-gray-300 text-white select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="1.25rem"
+                                  viewBox="0 0 256 256"
+                                  width="1.25rem"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M208.49,152.49l-72,72a12,12,0,0,1-17,0l-72-72a12,12,0,0,1,17-17L116,187V40a12,12,0,0,1,24,0V187l51.51-51.52a12,12,0,0,1,17,17Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="flex justify-between w-full gap-4 items-center"
+                          >
+                            <div
+                              class="flex-grow"
+                            >
+                              <div>
+                                <div
+                                  class="font-semibold [overflow-wrap:anywhere]"
+                                >
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    Loading item number 
+                                  </span>
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    0
+                                  </span>
+                                </div>
+                                <div
+                                  class="text-gray-500 font-medium text-sm [overflow-wrap:anywhere]"
+                                >
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    please wait a moment
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="text-right"
+                            >
+                              <div
+                                class="inline-block align-middle w-fit select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="1em"
+                                  viewBox="0 0 256 256"
+                                  width="1em"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        class="flex gap-4 w-full text-gray-800 hover:text-gray-800 py-4 px-4 border-b border-gray-100"
+                      >
+                        <div
+                          class="flex gap-4 flex-1 items-center"
+                        >
+                          <div
+                            class="flex-shrink-0 my-0.5 self-start"
+                          >
+                            <div
+                              class="select-none pointer-events-none inline"
+                            >
+                              <div
+                                class="inline-block align-middle w-fit p-[10px] border rounded-full bg-gray-300 border-gray-300 text-white select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="1.25rem"
+                                  viewBox="0 0 256 256"
+                                  width="1.25rem"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M208.49,152.49l-72,72a12,12,0,0,1-17,0l-72-72a12,12,0,0,1,17-17L116,187V40a12,12,0,0,1,24,0V187l51.51-51.52a12,12,0,0,1,17,17Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                          <div
+                            class="flex justify-between w-full gap-4 items-center"
+                          >
+                            <div
+                              class="flex-grow"
+                            >
+                              <div>
+                                <div
+                                  class="font-semibold [overflow-wrap:anywhere]"
+                                >
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    Loading item number 
+                                  </span>
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    1
+                                  </span>
+                                </div>
+                                <div
+                                  class="text-gray-500 font-medium text-sm [overflow-wrap:anywhere]"
+                                >
+                                  <span
+                                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                                  >
+                                    please wait a moment
+                                  </span>
+                                </div>
+                              </div>
+                            </div>
+                            <div
+                              class="text-right"
+                            >
+                              <div
+                                class="inline-block align-middle w-fit select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                              >
+                                <svg
+                                  fill="currentColor"
+                                  height="1em"
+                                  viewBox="0 0 256 256"
+                                  width="1em"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M181.66,133.66l-80,80a8,8,0,0,1-11.32-11.32L164.69,128,90.34,53.66a8,8,0,0,1,11.32-11.32l80,80A8,8,0,0,1,181.66,133.66Z"
+                                  />
+                                </svg>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/docs/src/stories/composite/PageSkeleton.stories.tsx
+++ b/packages/docs/src/stories/composite/PageSkeleton.stories.tsx
@@ -1,0 +1,19 @@
+import { PageSkeleton } from '#ui/composite/PageSkeleton'
+import type { Meta, StoryObj } from '@storybook/react'
+
+const meta: Meta<typeof PageSkeleton> = {
+  title: 'Composite/PageSkeleton',
+  component: PageSkeleton,
+  parameters: {
+    layout: 'padded'
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof PageSkeleton>
+
+export const Default: Story = {
+  args: {
+    delayMs: 0
+  }
+}


### PR DESCRIPTION
## What I did

I've removed the old and not-required logic in the existing `PageSkeleton` component and replaced it with a generic loading layout simulating the initial app screen (title, navigation button, search bar, and some list items).

To do so I've also added `withSkeletonTemplate` support to PageHeading, PageLayout, and SearchBar.

Now TokenProvider uses this new `PageSkeleton` component when app is loaded in the dashboard (ignoring the `loadingElement` prop)

https://deploy-preview-641--commercelayer-app-elements.netlify.app/?path=/docs/composite-pageskeleton--docs

<img width="705" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/a7322212-7632-4c40-a1ce-3a2684ed9843">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
