### PR TITLE
Enforce font sizes of `Button` component

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
@@ -33,7 +33,7 @@ describe('Dropdown', () => {
           <button
             aria-expanded="false"
             aria-haspopup="true"
-            class="rounded whitespace-nowrap leading-5 inline-block text-center text-sm transition-opacity duration-500 px-6 py-3 font-bold bg-black border border-black text-white hover:opacity-80"
+            class="rounded whitespace-nowrap leading-5 text-base inline-block text-center transition-opacity duration-500 px-6 py-3 font-bold bg-black border border-black text-white hover:opacity-80"
           >
             Open dropdown
           </button>

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -2,7 +2,14 @@ import { isSpecificReactComponent } from '#utils/children'
 import cn from 'classnames'
 import { Children } from 'react'
 
-type Variant = 'primary' | 'secondary' | 'danger' | 'link' | 'circle'
+// The `relationship` variant is temporary to cover the old dashed `ButtonCard` behavior until there will be an updated design proof solution
+type Variant =
+  | 'primary'
+  | 'secondary'
+  | 'danger'
+  | 'link'
+  | 'circle'
+  | 'relationship'
 type Size = 'mini' | 'small' | 'regular' | 'large'
 
 export interface InteractiveElementProps {
@@ -48,14 +55,14 @@ export function getInteractiveElementClassName({
     isSpecificReactComponent(childrenAsArray[0], [/^Icon$/])
 
   return cn([
-    'rounded whitespace-nowrap leading-5',
+    `rounded whitespace-nowrap leading-5 ${getFontSizeCss(size)}`,
     {
       'opacity-50 pointer-events-none touch-none': disabled,
       'w-full': fullWidth === true && variant !== 'link',
       'inline-flex gap-1': alignItems != null,
       'items-center justify-center': alignItems === 'center',
       'inline w-fit': variant === 'link',
-      [`inline-block text-center text-sm transition-opacity duration-500 ${getSizeCss(size)}`]:
+      [`inline-block text-center transition-opacity duration-500 ${getSizeCss(size)}`]:
         variant !== 'link',
       '!p-2.5': isIcon && variant !== 'circle',
       '!p-1': isIcon && variant === 'circle'
@@ -79,6 +86,23 @@ function getSizeCss(size: InteractiveElementProps['size']): string | undefined {
   return mapping[size]
 }
 
+function getFontSizeCss(
+  size: InteractiveElementProps['size']
+): string | undefined {
+  if (size == null) {
+    return undefined
+  }
+
+  const mapping = {
+    mini: 'text-sm',
+    small: 'text-sm',
+    regular: 'text-base',
+    large: 'text-base'
+  } satisfies Record<NonNullable<InteractiveElementProps['size']>, string>
+
+  return mapping[size]
+}
+
 function getVariantCss(
   variant: InteractiveElementProps['variant']
 ): string | undefined {
@@ -94,7 +118,8 @@ function getVariantCss(
     circle:
       'font-semibold bg-white text-black hover:opacity-80 hover:bg-gray-50 rounded-full',
     danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
-    link: 'text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer'
+    link: 'text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer',
+    relationship: 'font-bold text-primary border border-gray-300 border-dashed'
   } satisfies Record<NonNullable<InteractiveElementProps['variant']>, string>
 
   return mapping[variant]

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               <div>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Managed dedicated `Button` font sizes based on the `size` prop
- Introduced a new temporary `variant` aimed to replace the deprecated dashed `ButtonCard` until the design will find a solution for single relationship selections

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
