### PR TITLE
Allow Dropdown to receive a plain jsx `<button>` tag as label

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -2,7 +2,7 @@ import { useClickAway } from '#hooks/useClickAway'
 import { useOnBlurFromContainer } from '#hooks/useOnBlurFromContainer'
 import { Button } from '#ui/atoms/Button'
 import { type DropdownMenuProps } from '#ui/composite/Dropdown/DropdownMenu'
-import { isSpecificReactComponent } from '#utils/children'
+import { isSpecificJsxTag, isSpecificReactComponent } from '#utils/children'
 import { CaretDown, DotsThreeCircle } from '@phosphor-icons/react'
 import cn from 'classnames'
 import { Children, cloneElement, useMemo, useState } from 'react'
@@ -57,7 +57,10 @@ export const Dropdown: React.FC<DropdownProps> = ({
   }
 
   const dropdownButton = useMemo(() => {
-    if (isSpecificReactComponent(dropdownLabel, [/^Button$/])) {
+    if (
+      isSpecificReactComponent(dropdownLabel, [/^Button$/]) ||
+      isSpecificJsxTag(dropdownLabel, ['button'])
+    ) {
       return cloneElement(dropdownLabel, {
         'aria-haspopup': true,
         'aria-expanded': isExpanded,

--- a/packages/app-elements/src/utils/children.test.tsx
+++ b/packages/app-elements/src/utils/children.test.tsx
@@ -1,3 +1,4 @@
+import { isSpecificJsxTag } from '#utils/children'
 import {
   filterByDisplayName,
   getInnerText,
@@ -35,6 +36,16 @@ describe('isSpecificReactComponent', () => {
     expect(
       isSpecificReactComponent('string is a valid ReactNode', [/^Button$/])
     ).toBe(false)
+  })
+})
+
+describe('isSpecificJsxTag', () => {
+  it('should return `true` for matched named component as jsx element', () => {
+    expect(isSpecificJsxTag(<button>foo</button>, ['button'])).toBe(true)
+  })
+
+  it('should return `false` for not matched named component', () => {
+    expect(isSpecificJsxTag(<div>foo</div>, ['button'])).toBe(false)
   })
 })
 

--- a/packages/app-elements/src/utils/children.ts
+++ b/packages/app-elements/src/utils/children.ts
@@ -30,7 +30,6 @@ export function isFunctionComponent(
  * // will return an array of true/false values depending if some child is a button
  * ```
  */
-
 export function isSpecificReactComponent(
   reactNode: ReactNode,
   displayNames: RegExp[]
@@ -47,6 +46,35 @@ export function isSpecificReactComponent(
         reactNode.type.displayName != null &&
         rx.test(reactNode.type.displayName)
     ) != null
+  )
+}
+
+/**
+ * Checks if a ReactNode matches a specific JSX tag.
+ * @param reactNode - a ReactNode single child
+ * @param tagNames - a list of names of the jsx tags we would like to match
+ * @returns a boolean value indicating argument match the passed displayNames
+ *
+ * @example
+ * ```jsx
+ * React.Children.map(children, (child) =>
+ *   isSpecificJsxTag(child, ['button', 'input'])
+ * )
+ * // will return an array of true/false values depending if some child is a button
+ * ```
+ */
+export function isSpecificJsxTag(
+  reactNode: ReactNode,
+  tagNames: string[]
+): reactNode is JSX.Element {
+  if (reactNode == null) {
+    return false
+  }
+
+  return (
+    isValidElement(reactNode) &&
+    typeof reactNode.type === 'string' &&
+    tagNames.includes(reactNode.type)
   )
 }
 

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -54,6 +54,21 @@ Default.args = {
 }
 
 /**
+ * It is possible to pass a custom `<button>` element as the dropdown label.
+ * In this case the Dropdown component will use the provided button instead of creating a new one.
+ **/
+export const CustomButton = Template.bind({})
+CustomButton.args = {
+  dropdownLabel: <button>click me</button>,
+  dropdownItems: (
+    <>
+      <DropdownItem label='Edit' />
+      <DropdownItem label='Delete' />
+    </>
+  )
+}
+
+/**
  * While by default, the dropdown menu will try to fit its content using a min/max width range,
  * it can be also set to use a fixed `wider` width.
  **/


### PR DESCRIPTION
## What I did

This won't generate anymore nested buttons
```
<Dropdown
  dropdownLabel={
    <button>
      <Icon name='lifebuoy' size={28} />
    </button>
  }
 ...
/>
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
