### PR TITLE
Avoid setting button font size with variant `link`

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.test.tsx
@@ -33,7 +33,7 @@ describe('Dropdown', () => {
           <button
             aria-expanded="false"
             aria-haspopup="true"
-            class="rounded whitespace-nowrap leading-5 text-base inline-block text-center transition-opacity duration-500 px-6 py-3 font-bold bg-black border border-black text-white hover:opacity-80"
+            class="rounded whitespace-nowrap leading-5 inline-block text-center transition-opacity duration-500 px-6 py-3 text-base font-bold bg-black border border-black text-white hover:opacity-80"
           >
             Open dropdown
           </button>

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -55,7 +55,7 @@ export function getInteractiveElementClassName({
     isSpecificReactComponent(childrenAsArray[0], [/^Icon$/])
 
   return cn([
-    `rounded whitespace-nowrap leading-5 ${getFontSizeCss(size)}`,
+    `rounded whitespace-nowrap leading-5`,
     {
       'opacity-50 pointer-events-none touch-none': disabled,
       'w-full': fullWidth === true && variant !== 'link',
@@ -65,7 +65,8 @@ export function getInteractiveElementClassName({
       [`inline-block text-center transition-opacity duration-500 ${getSizeCss(size)}`]:
         variant !== 'link',
       '!p-2.5': isIcon && variant !== 'circle',
-      '!p-1': isIcon && variant === 'circle'
+      '!p-1': isIcon && variant === 'circle',
+      [`${getFontSizeCss(size)}`]: variant !== 'link'
     },
     getVariantCss(variant)
   ])

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -367,7 +367,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               <div>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded whitespace-nowrap leading-5 text-base inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Avoided to set button font size with variant `link`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
