### PR TITLE
Remove `queryParam` in InputResourceGroup view all overlay

### DIFF
--- a/packages/app-elements/src/ui/forms/InputResourceGroup/InputResourceGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputResourceGroup/InputResourceGroup.tsx
@@ -61,9 +61,7 @@ export const InputResourceGroup: React.FC<InputResourceGroupProps> = ({
   showCheckboxIcon = true,
   title
 }) => {
-  const { Overlay, close, open } = useOverlay({
-    queryParam: `${resource}ViewAll`
-  })
+  const { Overlay, close, open } = useOverlay()
 
   const { values, toggleValue, setValues } =
     useToggleCheckboxValues(defaultValues)


### PR DESCRIPTION
## What I did

Using `queryParam` in  `InputResourceGroup` is causing unwanted component re-rendering when filters are used inside an overlay that already relies on query strings.

Since there is no reason to have the overlay opening with a query param in this component we can safely remove it and keep it simple instead of controlling it with a prop.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
