### PR TITLE
Add currency options with top currencies for `InputSelect`

### DIFF
--- a/packages/app-elements/src/helpers/currencies.test.ts
+++ b/packages/app-elements/src/helpers/currencies.test.ts
@@ -1,0 +1,37 @@
+import { currencyInputSelectOptions } from '#helpers/currencies'
+
+describe('currencyInputSelectOptions', () => {
+  test('should return two groups of currencies', () => {
+    expect(currencyInputSelectOptions.length).toBe(2)
+  })
+
+  test('both groups should have no label', () => {
+    expect(
+      currencyInputSelectOptions.every((group) => group.label == null)
+    ).toBe(true)
+  })
+
+  test('first group should return USD, EUR, GBP only', () => {
+    expect(currencyInputSelectOptions[0]).toEqual({
+      label: undefined,
+      options: [
+        { label: 'USD', value: 'USD' },
+        { label: 'EUR', value: 'EUR' },
+        { label: 'GBP', value: 'GBP' }
+      ]
+    })
+  })
+
+  test('second group should not contain the top currencies from the first group', () => {
+    const topCurrencies =
+      currencyInputSelectOptions[0]?.options.map((o) => o.value as string) ?? []
+    const otherCurrencies =
+      currencyInputSelectOptions[1]?.options.map((o) => o.value as string) ?? []
+
+    expect(
+      otherCurrencies.some((currencyCode) =>
+        topCurrencies.includes(currencyCode)
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/app-elements/src/helpers/currencies.ts
+++ b/packages/app-elements/src/helpers/currencies.ts
@@ -1,3 +1,4 @@
+import { type GroupedSelectValues } from '#ui/forms/InputSelect/InputSelect'
 export interface Currency {
   symbol: string
   subunit_to_unit: number
@@ -2730,3 +2731,24 @@ export const currencies = {
     smallest_denomination: 5
   }
 } satisfies Record<string, Currency>
+
+/**
+ * List of all currencies ready to be used in the `InputSelect` component.
+ * The list is grouped by the top currencies and the rest of the currencies.
+ */
+export const currencyInputSelectOptions: GroupedSelectValues = (() => {
+  const topCurrencies = ['USD', 'EUR', 'GBP']
+
+  return [
+    {
+      options: topCurrencies.map((code) => ({ value: code, label: code }))
+    },
+    {
+      options: Object.entries(currencies)
+        .map(([, item]) => item.iso_code)
+        .filter((code) => !topCurrencies.includes(code))
+        .map((code) => ({ value: code, label: code }))
+        .sort((a, b) => a.label.localeCompare(b.label))
+    }
+  ]
+})()

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -3,7 +3,11 @@ import '#styles/global.css'
 // Helpers
 export { goBack, navigateTo } from '#helpers/appsNavigation'
 export { isAttachmentValidNote, referenceOrigins } from '#helpers/attachments'
-export { currencies, type CurrencyCode } from '#helpers/currencies'
+export {
+  currencies,
+  currencyInputSelectOptions,
+  type CurrencyCode
+} from '#helpers/currencies'
 export {
   formatDate,
   formatDateRange,

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -15,7 +15,7 @@ import { SelectComponent } from './SelectComponent'
 import { getSelectStyles } from './styles'
 
 export type GroupedSelectValues = Array<{
-  label: string
+  label?: string
   options: InputSelectValue[]
 }>
 

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -2,6 +2,7 @@ import { Hr } from '#ui/atoms/Hr'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Tag } from '#ui/atoms/Tag'
 import { X } from '@phosphor-icons/react'
+import { castArray } from 'lodash'
 import {
   components,
   type ClearIndicatorProps,
@@ -98,8 +99,18 @@ function GroupHeading(
       })
   )
 
+  // checking if all values in the previous group are selected,
+  // in that case we don't need the separator since the previous group is empty
+  const prevGroup = props.selectProps.options[idx - 1]
+  const prevGroupIsEmpty =
+    prevGroup != null &&
+    'options' in prevGroup &&
+    prevGroup.options.every((o) =>
+      castArray(props.selectProps.value).includes(o)
+    )
+
   // no separator for the first group
-  if (props.data.label == null && idx === 0) {
+  if ((props.data.label == null && idx === 0) || prevGroupIsEmpty) {
     return null
   }
 

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -1,3 +1,5 @@
+import { Hr } from '#ui/atoms/Hr'
+import { Spacer } from '#ui/atoms/Spacer'
 import { Tag } from '#ui/atoms/Tag'
 import { X } from '@phosphor-icons/react'
 import {
@@ -5,6 +7,7 @@ import {
   type ClearIndicatorProps,
   type DropdownIndicatorProps,
   type GroupBase,
+  type GroupHeadingProps,
   type MultiValueGenericProps
 } from 'react-select'
 import { type InputSelectValue } from '.'
@@ -81,13 +84,45 @@ function MultiValueRemove(props: any): JSX.Element {
   )
 }
 
+function GroupHeading(
+  props: GroupHeadingProps<InputSelectValue>
+): JSX.Element | null {
+  // Since is not exposed in the props, we need to get the index of the current group
+  // by finding  options of the current group (props.data.options) with the options of the selectProps
+  const idx = props.selectProps.options.findIndex(
+    (group) =>
+      'options' in group &&
+      group.options.every((option) => {
+        const currentGroupValues = props.data.options.map((o) => o.value)
+        return currentGroupValues.includes(option.value)
+      })
+  )
+
+  // no separator for the first group
+  if (props.data.label == null && idx === 0) {
+    return null
+  }
+
+  if (props.data.label == null) {
+    return (
+      <Spacer bottom='4'>
+        <Hr />
+      </Spacer>
+    )
+  }
+
+  // standard group heading when label exists
+  return <components.GroupHeading {...props} />
+}
+
 const selectComponentOverrides = {
   DropdownIndicator,
   IndicatorSeparator: () => null,
   ClearIndicator,
   MultiValueContainer,
   MultiValueLabel,
-  MultiValueRemove
+  MultiValueRemove,
+  GroupHeading
 }
 
 export default selectComponentOverrides

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -162,7 +162,7 @@ WithSeparator.args = {
   label: 'Select a currency',
   initialValues: currencyInputSelectOptions,
   placeholder: 'Type to filter list...',
-  isMulti: false,
+  isMulti: true,
   isSearchable: true,
   isClearable: true
 }

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -1,3 +1,4 @@
+import { currencyInputSelectOptions } from '#helpers/currencies'
 import { InputSelect, type InputSelectValue } from '#ui/forms/InputSelect'
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -146,6 +147,20 @@ GroupedOptions.args = {
       ]
     }
   ],
+  placeholder: 'Type to filter list...',
+  isMulti: false,
+  isSearchable: true,
+  isClearable: true
+}
+
+/**
+ * Options group can be separated by an horizontal line when group label is `undefined`.
+ * Separator won't be rendered for the first group.
+ */
+export const WithSeparator = Template.bind({})
+WithSeparator.args = {
+  label: 'Select a currency',
+  initialValues: currencyInputSelectOptions,
   placeholder: 'Type to filter list...',
   isMulti: false,
   isSearchable: true,


### PR DESCRIPTION
## What I did

- `InputSelect` now renders an `<Hr>` when a grouped option has no label. Separator won't be rendered for the first group.
- I've added a list of currencies ready to be used as `initialValues` (options) for the `InputSelect` component. The first group of the options is the most used currencies (USD, EUR, GBP) and the second group contains all others currencies.

The generated output is:
```
[
  // top currencies
  {
    options: [
      {
        label: 'USD',
        value: 'USD'
      },
      {
        label: 'EUR',
        value: 'EUR'
      },
      {
        label: 'GBP',
        value: 'GBP'
      }
    ]
  },
  
  // others
  {
    options: [
      {
        label: 'AED',
        value: 'AED'
      },
      {
        label: 'AFN',
        value: 'AFN'
      },
      ...
    ]
  }
]
```

Since the groups have no label, the select component will render a separator

<img width="638" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/af9ad9ee-7a83-4fe4-9f53-dfde8c364701">

## Preview

https://deploy-preview-659--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputselect--docs#with-separator

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
