### PR TITLE
Improve the `ResourceAddress` component

### DIFF
--- a/packages/app-elements/src/ui/forms/ReactHookForm/HookedValidationApiError.tsx
+++ b/packages/app-elements/src/ui/forms/ReactHookForm/HookedValidationApiError.tsx
@@ -1,3 +1,6 @@
+import isObject from 'lodash/isObject'
+import merge from 'lodash/merge'
+import reduce from 'lodash/reduce'
 import { useEffect } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { HookedValidationError } from './HookedValidationError'
@@ -26,12 +29,24 @@ export function HookedValidationApiError({
 }: ValidationApiErrorProps): JSX.Element {
   const { setError, getValues } = useFormContext()
 
+  const flattenKeys = (obj: any, path: string[] = []): Record<string, any> =>
+    !isObject(obj)
+      ? { [path.join('.')]: obj }
+      : reduce(
+          obj,
+          (cum, next, key) => merge(cum, flattenKeys(next, [...path, key])),
+          {}
+        )
+
   useEffect(() => {
     if (apiError != null) {
       setApiFormErrors({
         apiError,
         setError,
-        formFields: Object.keys(getValues()),
+        formFields: [
+          ...Object.keys(getValues()),
+          ...Object.keys(flattenKeys(getValues()))
+        ],
         fieldMap
       })
     }

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
@@ -4,6 +4,7 @@ export const presetAddresses = {
   withName: {
     type: 'addresses',
     id: 'aaZYuDJVXW',
+    business: false,
     company: '',
     first_name: 'Darth',
     last_name: 'Vader',
@@ -22,6 +23,7 @@ export const presetAddresses = {
   withCompany: {
     type: 'addresses',
     id: 'bbZYuDJVXW',
+    business: true,
     company: 'Galactic Empire',
     first_name: '',
     last_name: '',

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
@@ -55,5 +55,24 @@ export const presetAddresses = {
     created_at: '',
     updated_at: '',
     notes: 'Kindly leave the package to my neighbor, Adam Sandler.'
+  },
+  withErrors: {
+    type: 'addresses',
+    id: 'ddZYuDJVXW',
+    company: '',
+    first_name: '',
+    last_name: '',
+    full_name: '',
+    line_1: 'Via Polis Massa, 42',
+    line_2: 'Ragnatela, 99',
+    city: 'Cogorno',
+    country_code: 'IT',
+    state_code: 'GE',
+    zip_code: '16030',
+    phone: '+39 055 1234567890',
+    billing_info: 'ABCDEFGHIJKLMNOPQRSTUVWYXZ',
+    created_at: '',
+    updated_at: '',
+    notes: 'Kindly leave the package to my neighbor, Adam Sandler.'
   }
 } satisfies Record<string, Address>

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -27,15 +27,27 @@ export interface ResourceAddressProps {
   editable?: boolean
   /**
    * Optional setting to define if given `Address` `billing_info` data is visible.
+   * @default false
    */
   showBillingInfo?: boolean
+  /**
+   * Optional setting to define if given `Address` `billing_info` data is visible.
+   * @default true
+   */
+  showNotes?: boolean
 }
 
 /**
  * Renders an all-in-one visualization and editing solution to deal with a given resource of type `Address`
  */
 export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
-  ({ resource, title, editable = false, showBillingInfo = false }) => {
+  ({
+    resource,
+    title,
+    editable = false,
+    showBillingInfo = false,
+    showNotes = true
+  }) => {
     const [address, setAddress] = useState<Address>(resource)
     const { canUser } = useTokenProvider()
 
@@ -43,6 +55,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
       useResourceAddressOverlay({
         address: resource,
         showBillingInfo,
+        showNotes,
         onUpdate: (updatedAddress) => {
           setAddress(updatedAddress)
         }
@@ -92,7 +105,8 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
               </Text>
             ) : null}
 
-            {!isEmpty(address.phone) || !isEmpty(address.notes) ? (
+            {!isEmpty(address.phone) ||
+            (showNotes && !isEmpty(address.notes)) ? (
               <>
                 <Spacer top='4' bottom='4'>
                   <Hr variant='dashed' />
@@ -109,7 +123,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
                       </Text>
                     </div>
                   )}
-                  {!isEmpty(address.notes) && (
+                  {showNotes && !isEmpty(address.notes) && (
                     <div className='flex gap-2'>
                       <Text tag='div' variant='info' className='mt-[2px]'>
                         <Note weight='bold' />

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
@@ -22,7 +22,7 @@ interface ResourceAddressFormProps
 
 export const ResourceAddressForm =
   withSkeletonTemplate<ResourceAddressFormProps>(
-    ({ address, showBillingInfo = false, onChange }) => {
+    ({ address, showBillingInfo = false, showNotes = true, onChange }) => {
       const methods = useForm({
         defaultValues: address,
         resolver: zodResolver(resourceAddressFormFieldsSchema)
@@ -50,7 +50,10 @@ export const ResourceAddressForm =
               })
           }}
         >
-          <ResourceAddressFormFields showBillingInfo={showBillingInfo} />
+          <ResourceAddressFormFields
+            showBillingInfo={showBillingInfo}
+            showNotes={showNotes}
+          />
 
           <Spacer top='14'>
             <Button type='submit' disabled={isSubmitting} className='w-full'>

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -98,9 +98,9 @@ export const ResourceAddressFormFields =
       showNameOrCompany = false
     }) => {
       const namePrefix = name == null ? '' : `${name}.`
-      const { getValues } = useFormContext()
+      const { watch } = useFormContext()
 
-      const business = getValues(`${namePrefix}business`) ?? false
+      const business = watch(`${namePrefix}business`) ?? false
 
       const isNameVisible =
         !showNameOrCompany || (showNameOrCompany && business === false)

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -56,11 +56,10 @@ export const ResourceAddressFormFields =
           </FieldRow>
 
           <FieldRow columns='1'>
-            <HookedInput name={`${namePrefix}line_1`} label='Address line 1' />
-          </FieldRow>
-
-          <FieldRow columns='1'>
-            <HookedInput name={`${namePrefix}line_2`} label='Address line 2' />
+            <div className='flex flex-col gap-2'>
+              <HookedInput name={`${namePrefix}line_1`} label='Address' />
+              <HookedInput name={`${namePrefix}line_2`} />
+            </div>
           </FieldRow>
 
           <FieldRow columns='1'>

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -36,11 +36,12 @@ export const resourceAddressFormFieldsSchema = z.object({
 export interface ResourceAddressFormFieldsProps {
   name?: string
   showBillingInfo?: boolean
+  showNotes?: boolean
 }
 
 export const ResourceAddressFormFields =
   withSkeletonTemplate<ResourceAddressFormFieldsProps>(
-    ({ name, showBillingInfo = false }) => {
+    ({ name, showBillingInfo = false, showNotes = true }) => {
       const namePrefix = name == null ? '' : `${name}.`
 
       return (
@@ -90,13 +91,15 @@ export const ResourceAddressFormFields =
             </FieldRow>
           )}
 
-          <FieldRow columns='1'>
-            <HookedInputTextArea
-              name={`${namePrefix}notes`}
-              label='Notes'
-              rows={2}
-            />
-          </FieldRow>
+          {showNotes && (
+            <FieldRow columns='1'>
+              <HookedInputTextArea
+                name={`${namePrefix}notes`}
+                label='Notes'
+                rows={2}
+              />
+            </FieldRow>
+          )}
         </>
       )
     }

--- a/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
@@ -9,11 +9,13 @@ export const useResourceAddressOverlay = ({
   title = 'Edit address',
   address,
   showBillingInfo,
+  showNotes,
   onUpdate
 }: {
   title?: string
   address: Address
   showBillingInfo?: boolean
+  showNotes?: boolean
   onUpdate?: (updatedAddress: Address) => void
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 }) => {
@@ -43,6 +45,7 @@ export const useResourceAddressOverlay = ({
             <ResourceAddressForm
               address={address}
               showBillingInfo={showBillingInfo}
+              showNotes={showNotes}
               onChange={(updatedAddress: Address) => {
                 onUpdate?.(updatedAddress)
                 close()
@@ -52,7 +55,7 @@ export const useResourceAddressOverlay = ({
         </Overlay>
       )
     )
-  }, [Overlay, close, canUser, address, showBillingInfo, onUpdate])
+  }, [Overlay, close, canUser, address, showBillingInfo, showNotes, onUpdate])
 
   return { ResourceAddressOverlay, openAddressOverlay }
 }

--- a/packages/docs/src/mocks/data/addresses.js
+++ b/packages/docs/src/mocks/data/addresses.js
@@ -51,4 +51,61 @@ const restPatch = ['aaZYuDJVXW', 'bbZYuDJVXW', 'ccZYuDJVXW'].map((id) =>
   })
 )
 
-export default [...restPatch]
+const apiErrorPatch = http.patch(
+  `https://mock.localhost/api/addresses/ddZYuDJVXW`,
+  async () => {
+    return HttpResponse.json(
+      {
+        errors: [
+          {
+            title: "can't be blank",
+            detail: "first_name - can't be blank",
+            code: 'VALIDATION_ERROR',
+            source: {
+              pointer: '/data/attributes/first_name'
+            },
+            status: '422',
+            meta: {
+              error: 'blank'
+            }
+          },
+          {
+            title: "can't be blank",
+            detail: "last_name - can't be blank",
+            code: 'VALIDATION_ERROR',
+            source: {
+              pointer: '/data/attributes/last_name'
+            },
+            status: '422',
+            meta: {
+              error: 'blank'
+            }
+          }
+        ]
+      },
+      { status: 422 }
+    )
+  }
+)
+
+// const restPatch = ['aaZYuDJVXW', 'bbZYuDJVXW', 'ccZYuDJVXW'].map((id) =>
+//   http.patch(
+//     `https://mock.localhost/api/addresses/${id}`,
+//     async ({ request }) => {
+//       const json = await request.json()
+//       console.log(json.data.attributes)
+//       return HttpResponse.json({
+//         data: {
+//           ...mockedAddress,
+//           id,
+//           attributes: {
+//             ...mockedAddress.attributes,
+//             ...json.data.attributes
+//           }
+//         }
+//       })
+//     }
+//   )
+// )
+
+export default [...restPatch, apiErrorPatch]

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -103,6 +103,18 @@ export const ListedAddresses: StoryFn = () => {
   )
 }
 
+export const ApiError: StoryFn = () => {
+  return (
+    <Stack>
+      <ResourceAddress
+        resource={presetAddresses.withErrors}
+        title='Billing address'
+        editable
+      />
+    </Stack>
+  )
+}
+
 export const UseResourceAddressOverlay: StoryFn = () => {
   const [address, setAddress] = useState(presetAddresses.withName)
 
@@ -159,7 +171,7 @@ export const ReuseTheAddressForm: StoryFn = () => {
     <>
       <HookedForm
         {...methods}
-        onSubmit={(formValues) => {
+        onSubmit={(formValues): void => {
           console.log(formValues)
         }}
       >

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -1,11 +1,13 @@
 import { CoreSdkProvider } from '#providers/CoreSdkProvider'
 import { MockTokenProvider as TokenProvider } from '#providers/TokenProvider/MockTokenProvider'
 import { Button } from '#ui/atoms/Button'
+import { Section } from '#ui/atoms/Section'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Stack } from '#ui/atoms/Stack'
 import { ListItem } from '#ui/composite/ListItem'
 import { HookedForm } from '#ui/forms/Form'
 import { HookedInput } from '#ui/forms/Input'
+import { InputCheckbox } from '#ui/forms/InputCheckbox'
 import {
   ResourceAddress,
   useResourceAddressOverlay
@@ -190,11 +192,13 @@ export const ReuseTheAddressForm: StoryFn = () => {
 }
 
 export const ShowNameOrCompany: StoryFn = () => {
+  const defaultBusiness = true
+
   const methods = useForm({
     defaultValues: {
       name: 'John Doe Inc.',
       address: {
-        business: true,
+        business: defaultBusiness,
         country_code: 'IT'
       }
     },
@@ -215,22 +219,43 @@ export const ShowNameOrCompany: StoryFn = () => {
 
   return (
     <>
-      <HookedForm
-        {...methods}
-        onSubmit={(formValues): void => {
-          console.log(formValues)
-        }}
+      <Section
+        title='Address'
+        actionButton={
+          <div style={{ display: 'inline-block' }}>
+            <InputCheckbox
+              defaultChecked={defaultBusiness}
+              onChange={(event) => {
+                methods.setValue(
+                  'address.business',
+                  event.currentTarget.checked
+                )
+              }}
+            >
+              Business
+            </InputCheckbox>
+          </div>
+        }
       >
-        <Spacer bottom='8'>
-          <HookedInput name='name' label='Name' />
+        <Spacer top='6'>
+          <HookedForm
+            {...methods}
+            onSubmit={(formValues): void => {
+              console.log(formValues)
+            }}
+          >
+            <Spacer bottom='8'>
+              <HookedInput name='name' label='Name' />
+            </Spacer>
+            <ResourceAddressFormFields name='address' showNameOrCompany />
+            <Spacer top='14'>
+              <Button type='submit' className='w-full'>
+                Create merchant
+              </Button>
+            </Spacer>
+          </HookedForm>
         </Spacer>
-        <ResourceAddressFormFields name='address' showNameOrCompany />
-        <Spacer top='14'>
-          <Button type='submit' className='w-full'>
-            Create merchant
-          </Button>
-        </Spacer>
-      </HookedForm>
+      </Section>
     </>
   )
 }

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -149,7 +149,7 @@ export const ReuseTheAddressForm: StoryFn = () => {
       name: 'John Doe Inc.',
       address: {
         first_name: 'John',
-        last_name: 'Doe'
+        country_code: 'IT'
       }
     },
     resolver: zodResolver(
@@ -179,6 +179,52 @@ export const ReuseTheAddressForm: StoryFn = () => {
           <HookedInput name='name' label='Name' />
         </Spacer>
         <ResourceAddressFormFields name='address' />
+        <Spacer top='14'>
+          <Button type='submit' className='w-full'>
+            Create merchant
+          </Button>
+        </Spacer>
+      </HookedForm>
+    </>
+  )
+}
+
+export const ShowNameOrCompany: StoryFn = () => {
+  const methods = useForm({
+    defaultValues: {
+      name: 'John Doe Inc.',
+      address: {
+        business: true,
+        country_code: 'IT'
+      }
+    },
+    resolver: zodResolver(
+      z.object({
+        name: z
+          .string({
+            required_error: 'Required field',
+            invalid_type_error: 'Invalid format'
+          })
+          .min(1, {
+            message: 'Required field'
+          }),
+        address: resourceAddressFormFieldsSchema
+      })
+    )
+  })
+
+  return (
+    <>
+      <HookedForm
+        {...methods}
+        onSubmit={(formValues): void => {
+          console.log(formValues)
+        }}
+      >
+        <Spacer bottom='8'>
+          <HookedInput name='name' label='Name' />
+        </Spacer>
+        <ResourceAddressFormFields name='address' showNameOrCompany />
         <Spacer top='14'>
           <Button type='submit' className='w-full'>
             Create merchant


### PR DESCRIPTION
## What I did

I made a few changes to the ResourceAddress component:
- add the `showNotes` prop to ResourceAddress
- move `line_1` and `line_2` under the same "Address" label
- show error messages when using the input field `name` prefix
- add `showOnlyNameOrCompany` to mutually exclusive show business and non-business fields

## How to test

https://deploy-preview-660--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceaddress--docs
