### PR TITLE
Add new `delivered` status to shipments

### DIFF
--- a/packages/app-elements/src/dictionaries/shipments.ts
+++ b/packages/app-elements/src/dictionaries/shipments.ts
@@ -74,6 +74,14 @@ export function getShipmentDisplayStatus(
     case 'shipped':
       return {
         label: 'Shipped',
+        icon: 'arrowUpRight',
+        color: 'green'
+      }
+
+    // @ts-expect-error waiting for SDK types
+    case 'delivered':
+      return {
+        label: 'Delivered',
         icon: 'check',
         color: 'green'
       }

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -319,6 +319,16 @@ export const presetResourceListItem = {
     status: 'shipped',
     stock_location: originStockLocation
   },
+  shipmentDelivered: {
+    type: 'shipments',
+    id: '',
+    created_at: '',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    number: '30817130/S/0001',
+    // @ts-expect-error waiting for SDK types
+    status: 'delivered',
+    stock_location: originStockLocation
+  },
   shipmentWithStockTransfer: {
     type: 'shipments',
     id: '',

--- a/packages/docs/src/stories/resources/ResourceListItem.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceListItem.stories.tsx
@@ -40,6 +40,7 @@ const Template: StoryFn<Props> = ({ preset, resource, ...args }) => {
           <ResourceListItem
             key={idx}
             {...args}
+            // @ts-expect-error waiting for SDK types (shipments.status delivered)
             resource={typeof p === 'string' ? presetResourceListItem[p] : p}
           />
         )
@@ -70,6 +71,7 @@ const ItemsByTypeTemplate: StoryFn<ListProps> = (args) => {
       {Object.values(presetResourceListItem)
         .filter((preset) => args.type.includes(preset.type))
         .map((preset, idx) => (
+          // @ts-expect-error waiting for SDK types (shipments.status delivered)
           <ResourceListItem key={idx} resource={preset} />
         ))}
     </>


### PR DESCRIPTION
## What I did

I've added a new status for shipments (`delivered`) and updated the icon for the `shipped` status, to match recent design updates.

<img width="687" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/09e5e7b7-c65a-44f5-bf18-e22a7a2ea44c">



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
