### PR TITLE
Add optional footer in `InputSelect` menu

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/HookedInputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/HookedInputSelect.tsx
@@ -34,7 +34,8 @@ export interface HookedInputSelectProps
   pathToValue?: string
   /**
    * Optional callback executed when a value is selected to allow custom behavior and re-use the selected value.
-   * This does not effect the field value neither the form state.
+   * This does not effect the field value neither the form state that always contains the value defined by `pathToValue`.
+   * It's useful when you need to perform some action when a value is selected and accessing the `meta` key of the `InputSelectValue`
    */
   onSelect?: (value: PossibleSelectValue) => void
 }

--- a/packages/app-elements/src/ui/forms/InputSelect/HookedInputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/HookedInputSelect.tsx
@@ -5,7 +5,8 @@ import { useValidationFeedback } from '../ReactHookForm'
 import {
   InputSelect,
   type InputSelectProps,
-  type InputSelectValue
+  type InputSelectValue,
+  type PossibleSelectValue
 } from './InputSelect'
 import { flatSelectValues, getDefaultValueFromFlatten } from './utils'
 
@@ -31,6 +32,11 @@ export interface HookedInputSelectProps
    * ```
    */
   pathToValue?: string
+  /**
+   * Optional callback executed when a value is selected to allow custom behavior and re-use the selected value.
+   * This does not effect the field value neither the form state.
+   */
+  onSelect?: (value: PossibleSelectValue) => void
 }
 
 /**
@@ -41,6 +47,7 @@ export interface HookedInputSelectProps
 export const HookedInputSelect: React.FC<HookedInputSelectProps> = ({
   name,
   pathToValue = 'value',
+  onSelect,
   ...props
 }: HookedInputSelectProps) => {
   const { control, watch, getValues } = useFormContext()
@@ -95,6 +102,7 @@ export const HookedInputSelect: React.FC<HookedInputSelectProps> = ({
           }
           onSelect={(values) => {
             onChange(flatSelectValues(values, pathToValue))
+            onSelect?.(values)
           }}
           feedback={feedback}
         />

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -109,6 +109,10 @@ export interface InputSelectProps extends InputWrapperBaseProps {
     inputValue: string
   ) => Promise<GroupedSelectValues | InputSelectValue[]>
   /**
+   * Optional text to display at the bottom of the dropdown menu
+   */
+  menuFooterText?: string
+  /**
    * Debounce time in milliseconds for async search.
    * It only works when `loadAsyncValues` is provided
    */
@@ -154,6 +158,7 @@ export const InputSelect = forwardRef<
       loadAsyncValues,
       debounceMs,
       noOptionsMessage = 'No results found',
+      menuFooterText,
       ...rest
     },
     ref
@@ -186,6 +191,7 @@ export const InputSelect = forwardRef<
             styles={getSelectStyles(feedback?.variant)}
             debounceMs={debounceMs}
             isOptionDisabled={isOptionDisabled}
+            menuFooterText={menuFooterText}
           />
         ) : (
           <SelectComponent
@@ -204,6 +210,7 @@ export const InputSelect = forwardRef<
             onBlur={onBlur}
             name={name}
             styles={getSelectStyles(feedback?.variant)}
+            menuFooterText={menuFooterText}
           />
         )}
       </InputWrapper>

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -9,6 +9,7 @@ import {
   type DropdownIndicatorProps,
   type GroupBase,
   type GroupHeadingProps,
+  type MenuListProps,
   type MultiValueGenericProps
 } from 'react-select'
 import { type InputSelectValue } from '.'
@@ -126,6 +127,22 @@ function GroupHeading(
   return <components.GroupHeading {...props} />
 }
 
+function MenuList(props: MenuListProps<InputSelectValue>): JSX.Element {
+  // @ts-expect-error `isLoading` is missing in type definitions
+  const isLoading = Boolean(props.isLoading)
+  // @ts-expect-error I found no way to enhance `props.selectProps` definitions with custom ones specified in our wrapped `InputSelect` component
+  const menuFooterText = props.selectProps.menuFooterText as string | undefined
+
+  return (
+    <components.MenuList {...props}>
+      {props.children}
+      {menuFooterText != null && !isLoading && props.options.length > 0 ? (
+        <div className='px-4 py-2 text-sm text-gray-500'>{menuFooterText}</div>
+      ) : null}
+    </components.MenuList>
+  )
+}
+
 const selectComponentOverrides = {
   DropdownIndicator,
   IndicatorSeparator: () => null,
@@ -133,7 +150,8 @@ const selectComponentOverrides = {
   MultiValueContainer,
   MultiValueLabel,
   MultiValueRemove,
-  GroupHeading
+  GroupHeading,
+  MenuList
 }
 
 export default selectComponentOverrides

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
@@ -114,7 +114,10 @@ MultiSelect.args = {
         cityCode: 'US_NY'
       }
     }
-  ]
+  ],
+  onSelect: (value) => {
+    alert(JSON.stringify(value))
+  }
 }
 
 export const Clear: StoryFn<typeof HookedInputSelect> = () => {

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -110,6 +110,31 @@ Async.args = {
 }
 
 /**
+ * It's possible to specify a footer text that will be rendered at the bottom of the dropdown list.
+ */
+export const MenuFooterText = Template.bind({})
+MenuFooterText.args = {
+  label: 'Search resource',
+  placeholder: 'Type to search async...',
+  isSearchable: true,
+  isClearable: false,
+  debounceMs: 200,
+  hint: {
+    icon: 'lightbulbFilament',
+    text: 'Try to search some of the following values: customer, SKU, price, tax'
+  },
+  initialValues: fullList.slice(0, 5),
+  loadAsyncValues: async (hint) => {
+    return await new Promise<InputSelectValue[]>((resolve) => {
+      setTimeout(() => {
+        resolve(fakeSearch(hint))
+      }, 1000)
+    })
+  },
+  menuFooterText: 'Type to search for more options.'
+}
+
+/**
  * `isMulti` allows to select more than one value
  */
 export const Multi = Template.bind({})


### PR DESCRIPTION
## What I did

I've added a new `menuFooterText` prop to show an optional text at the bottom of the select menu.
The footer text will be shown in both standard and async select, but not while fetching options (async)

https://deploy-preview-666--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputselect--docs#menu-footer-text

<img width="462" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/c021f5f2-4b96-47c9-9b4f-e72135fdfb6f">

<img width="477" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/1a285d66-aaab-4ca3-9911-86868f82a91f">


I've also exposed the `onSelect` prop in `HookedInputSelect` to access the selected item without affecting the form state.
In the following example (HookedInputSelect -> multi select) when selecting values, an alert will show the full selected item(s)
https://deploy-preview-666--commercelayer-app-elements.netlify.app/?path=/docs/forms-react-hook-form-hookedinputselect--docs#multi-select


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
