### PR TITLE
Remove `defaultChecked`  in `<HookedInputCheckbox>`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
@@ -50,7 +50,14 @@ export function HookedInputCheckbox({
     }
   }, [isChecked])
 
-  return <InputCheckbox {...props} {...register(name)} feedback={feedback} />
+  return (
+    <InputCheckbox
+      {...props}
+      {...register(name)}
+      checked={isChecked}
+      feedback={feedback}
+    />
+  )
 }
 
 HookedInputCheckbox.displayName = 'HookedInputCheckbox'

--- a/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/HookedInputCheckbox.tsx
@@ -24,7 +24,7 @@ export function HookedInputCheckbox({
   name,
   ...props
 }: HookedInputCheckboxProps): JSX.Element {
-  const { register, getValues, watch, resetField, setValue } = useFormContext()
+  const { register, watch, resetField, setValue } = useFormContext()
   const feedback = useValidationFeedback(name)
   const isChecked = Boolean(watch(name))
 
@@ -50,14 +50,7 @@ export function HookedInputCheckbox({
     }
   }, [isChecked])
 
-  return (
-    <InputCheckbox
-      {...props}
-      defaultChecked={getValues(name)}
-      {...register(name)}
-      feedback={feedback}
-    />
-  )
+  return <InputCheckbox {...props} {...register(name)} feedback={feedback} />
 }
 
 HookedInputCheckbox.displayName = 'HookedInputCheckbox'


### PR DESCRIPTION
## What I did

When the form `reset()` method was called, the checkbox was not updated with the proper default value (checked yes/no).

This was due to the fact we should not rely on `defaultValue` when working the with react-hook-form version of the checkbox component, as described here:
https://react-hook-form.com/docs/useform#defaultValues

> The defaultValues prop populates the entire form with default values. It supports both synchronous and asynchronous assignment of default values. While you can set an input's default value using defaultValue or defaultChecked as detailed in the official React documentation, it is recommended to use defaultValues for the entire form.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
