### PR TITLE
Prevent content overlapping in `InputReadonly`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputReadonly.tsx
+++ b/packages/app-elements/src/ui/forms/InputReadonly.tsx
@@ -70,7 +70,8 @@ export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
               className={cn(
                 cssBase,
                 inputClassName,
-                'px-4 h-[44px] outline-0 !ring-0'
+                'px-4 h-[44px] outline-0 !ring-0',
+                { 'pr-12': !secret, 'pr-20': secret }
               )}
               value={
                 isLoading === true
@@ -112,7 +113,7 @@ export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
                   data-testid='toggle-secret'
                 >
                   <Icon
-                    name={hideValue ? 'eyeSlash' : 'eye'}
+                    name={hideValue ? 'eye' : 'eyeSlash'}
                     className='text-gray-500 hover:text-gray-300'
                     size={20}
                   />

--- a/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputReadonly.stories.tsx
@@ -27,6 +27,14 @@ Default.args = {
   showCopyAction: true
 }
 
+export const LongContent = Template.bind({})
+LongContent.args = {
+  label: 'Full URL',
+  value:
+    'https://demo-store.commercelayer.io/api/v1/orders/1234567890/line_items/0987654321',
+  showCopyAction: true
+}
+
 /**
  * This component can be used to hide (from the screen) sensitive information like API keys or secrets.
  */


### PR DESCRIPTION
## What I did

I've added some extra right padding to prevent long content overlapping the buttons

Example:
<img width="681" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/16df2a43-43bc-4ed6-bd01-4446e9a26a31">

Now:
<img width="680" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/38fac955-5b3b-4ce0-bf0c-d7b9b1df6d3e">



I've also inverted the show/hide icon when the component is used for secrets since they were set the other way around.
<img width="659" alt="image" src="https://github.com/commercelayer/app-elements/assets/30926550/82c197a2-d065-4018-aa6f-53e97be7f3a8">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
