### PR TITLE
Replace `getLastYearIsoRange` with `getLastYearIsoRange`

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -1,5 +1,5 @@
 import {
-  getLastYearIsoRange,
+  makeDateYearsRange,
   removeMillisecondsFromIsoDate
 } from '#helpers/date'
 import {
@@ -589,10 +589,14 @@ describe('formatDateRange should return the proper date format', () => {
   })
 })
 
-describe('getLastYearIsoRange', () => {
+describe('makeDateYearsRange', () => {
   test('should return last year range with milliseconds', () => {
     const now = new Date('2023-04-24T13:45:00.000Z')
-    const result = getLastYearIsoRange({ now, showMilliseconds: true })
+    const result = makeDateYearsRange({
+      now,
+      showMilliseconds: true,
+      yearsAgo: 1
+    })
 
     expect(result).toEqual({
       date_from: '2022-04-24T13:45:01.000Z',
@@ -602,10 +606,28 @@ describe('getLastYearIsoRange', () => {
 
   test('should return last year range without milliseconds', () => {
     const now = new Date('2023-04-24T13:45:00.538Z')
-    const result = getLastYearIsoRange({ now, showMilliseconds: false })
+    const result = makeDateYearsRange({
+      now,
+      showMilliseconds: false,
+      yearsAgo: 1
+    })
 
     expect(result).toEqual({
       date_from: '2022-04-24T13:45:01Z',
+      date_to: '2023-04-24T13:45:00Z'
+    })
+  })
+
+  test('should return 5 years range without milliseconds', () => {
+    const now = new Date('2023-04-24T13:45:00.538Z')
+    const result = makeDateYearsRange({
+      now,
+      showMilliseconds: false,
+      yearsAgo: 5
+    })
+
+    expect(result).toEqual({
+      date_from: '2018-04-24T13:45:01Z',
       date_to: '2023-04-24T13:45:00Z'
     })
   })

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -384,34 +384,48 @@ export function removeMillisecondsFromIsoDate(isoDate: string): string {
 }
 
 /**
- * Returns one year date range (minus 1 second) from the specified now date.
+ * Creates a date range spanning a specified number of years back from a given reference date.
+ * The range includes the start date and ends exactly one second before the reference date to form a precise interval.
  *
- * If `showMilliseconds` is false will remove milliseconds from the Date ISO strings,
- * ready to be used, for instance, in Metrics APIs requests.
+ * @param now The reference date from which the range is calculated. Typically the current date.
+ * @param yearsAgo The number of years to go back from the reference date to determine the start of the range.
+ * @param showMilliseconds If set to false, the resulting date strings are formatted to exclude milliseconds.
+ * @returns An object containing `date_from` and `date_to` properties. `date_from` is the calculated start date of the range,
+ *          going back the specified number of years from `now`. `date_to` is adjusted to be one second before `now`,
+ *          effectively marking the end of the range. Both dates are returned as ISO 8601 formatted strings, with an option
+ *          to include or exclude milliseconds.
  *
- * Example:
+ * Example usage:
  * ```
- * // with showMilliseconds = true
- * { date_from: '2022-04-24T13:44:59:452Z', date_to: '2023-04-24T13:45:452Z' }
- * // with showMilliseconds = false
- * { date_from: '2022-04-24T13:44:59Z', date_to: '2023-04-24T13:45Z' }
+ * const range = makeDateYearsRange(new Date(), 1, false);
+ * console.log(range);
+ * // Output when showMilliseconds is false:
+ * // { date_from: '2022-04-24T13:45:01Z, date_to: '2023-04-24T13:45:00Z' }
+ * // Output when showMilliseconds is true:
+ * // { date_from: '2022-04-24T13:45:01.000Z, date_to: '2023-04-24T13:45:00.000Z' }
  * ```
  */
-export function getLastYearIsoRange({
+export function makeDateYearsRange({
   now,
+  yearsAgo,
   showMilliseconds = true
 }: {
   now: Date
+  yearsAgo: number
   showMilliseconds: boolean
 }): {
   date_from: string
   date_to: string
 } {
+  if (yearsAgo < 1) {
+    throw new Error('Years ago must be greater than 0')
+  }
+
   const to = now.toISOString()
 
   // same day, one year ago
   const lastYearDate = new Date(
-    new Date(now).setFullYear(now.getFullYear() - 1)
+    new Date(now).setFullYear(now.getFullYear() - yearsAgo)
   )
   // remove 1 second to avoid overlapping with the current year
   lastYearDate.setSeconds(lastYearDate.getSeconds() + 1)

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -15,7 +15,7 @@ export {
   getEventDateInfo,
   getIsoDateAtDayEdge,
   getIsoDateAtDaysBefore,
-  getLastYearIsoRange,
+  makeDateYearsRange,
   removeMillisecondsFromIsoDate,
   sortAndGroupByDate,
   timeSeparator
@@ -58,6 +58,7 @@ export {
   useCoreApi,
   useCoreSdkProvider
 } from '#providers/CoreSdkProvider'
+export { createApp, type ClAppKey, type ClAppProps } from '#providers/createApp'
 export { ErrorBoundary } from '#providers/ErrorBoundary'
 export { GTMProvider, useTagManager } from '#providers/GTMProvider'
 export {
@@ -70,7 +71,6 @@ export {
   type TokenProviderRolePermissions,
   type TokenProviderTokenApplicationKind
 } from '#providers/TokenProvider'
-export { createApp, type ClAppKey, type ClAppProps } from '#providers/createApp'
 
 // Atoms
 export { A, type AProps } from '#ui/atoms/A'

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.ts
@@ -1,5 +1,5 @@
 import {
-  getLastYearIsoRange,
+  makeDateYearsRange,
   removeMillisecondsFromIsoDate
 } from '#helpers/date'
 import { type FiltersInstructions } from '#ui/resources/useResourceFilters/types'
@@ -246,9 +246,15 @@ export function adaptSdkToMetrics({
         }
       : {
           // default date range for metrics, when no custom date range is set, is 1 year
-          ...getLastYearIsoRange({
+          // for archived orders we use 5 years
+          ...makeDateYearsRange({
             now: new Date(),
-            showMilliseconds: false
+            showMilliseconds: false,
+            yearsAgo:
+              'archived' in filterValueMainResource &&
+              filterValueMainResource.archived === true
+                ? 5
+                : 1
           }),
           date_field: defaultDatePredicate
         }

--- a/packages/docs/src/stories/utility/Date.stories.tsx
+++ b/packages/docs/src/stories/utility/Date.stories.tsx
@@ -2,7 +2,7 @@ import {
   formatDate,
   formatDateRange,
   getEventDateInfo,
-  getLastYearIsoRange
+  makeDateYearsRange
 } from '#helpers/date'
 import { Description, Stories, Subtitle, Title } from '@storybook/addon-docs'
 import { type Meta, type StoryFn } from '@storybook/react'
@@ -262,15 +262,16 @@ export const GetEventDateInfo: StoryFn = () => {
 }
 
 /**
- *  Returns one year date range (minus 1 second) from the specified `now` date.
+ *  Returns the specified `yearsAgo` date range (minus 1 second) from the specified `now` date.
  */
-export const GetLastYearIsoRange: StoryFn = () => {
+export const MakeDateYearsRange: StoryFn = () => {
   return (
     <>
       <CodeSample
         fn={() =>
-          getLastYearIsoRange({
+          makeDateYearsRange({
             now: new Date('2024-01-01T14:30:00.000Z'),
+            yearsAgo: 1,
             showMilliseconds: true
           })
         }


### PR DESCRIPTION
## What I did

I've added a new logic to set a 5-year date range when searching/filtering archived orders with Metrics API.
To do so I've enhanced and renamed  `getLastYearIsoRange` as `getLastYearIsoRange` since now it accepts the `yearsAgo` parameter.

Example: 
```js
 makeDateYearsRange({
      now: new Date(),
      yearsAgo: 5,
      showMilliseconds: false
 })
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
