### PR TITLE
Add quantity to line item options

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -381,14 +381,22 @@ ResourceLineItems.displayName = 'ResourceLineItems'
 
 const LineItemOptionsWrapper = withSkeletonTemplate<{
   title?: string
+  quantity?: number
   children: React.ReactNode
-}>(({ title, children }) => (
+}>(({ title, quantity, children }) => (
   <Spacer top='4' className='pb-2 last:pb-0'>
-    {title != null && (
-      <Text tag='div' weight='bold' size='small' className='mb-1'>
-        {title}
-      </Text>
-    )}
+    <div className='flex gap-1'>
+      {title != null && (
+        <Text tag='div' weight='bold' size='small' className='mb-1'>
+          {title}
+        </Text>
+      )}
+      {quantity != null && (
+        <Text tag='div' size='small' weight='bold'>
+          x {quantity}
+        </Text>
+      )}
+    </div>
     {children}
   </Spacer>
 ))
@@ -414,7 +422,11 @@ const LineItemOptions = withSkeletonTemplate<{
   return (
     <Spacer top='4'>
       {lineItemOptions.map((item) => (
-        <LineItemOptionsWrapper key={item.id} title={item.name ?? undefined}>
+        <LineItemOptionsWrapper
+          key={item.id}
+          title={item.name ?? undefined}
+          quantity={item.quantity}
+        >
           {Object.entries(item.options).map(([optionName, optionValue]) => (
             <LineItemOptionsItem
               key={optionName}

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -643,9 +643,19 @@ exports[`ResourceLineItems > should render the list item options 1`] = `
               class="pb-2 last:pb-0"
             >
               <div
-                class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                class="flex gap-1"
               >
-                Front Text
+                <div
+                  class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  Front Text
+                </div>
+                <div
+                  class="font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  x 
+                  1
+                </div>
               </div>
               <div
                 class="flex items-center gap-1 mb-1"
@@ -700,9 +710,19 @@ exports[`ResourceLineItems > should render the list item options 1`] = `
               class="pb-2 last:pb-0"
             >
               <div
-                class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                class="flex gap-1"
               >
-                Rear Text
+                <div
+                  class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  Rear Text
+                </div>
+                <div
+                  class="font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  x 
+                  1
+                </div>
               </div>
               <div
                 class="flex items-center gap-1 mb-1"
@@ -757,9 +777,19 @@ exports[`ResourceLineItems > should render the list item options 1`] = `
               class="pb-2 last:pb-0"
             >
               <div
-                class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                class="flex gap-1"
               >
-                Special
+                <div
+                  class="mb-1 font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  Special
+                </div>
+                <div
+                  class="font-bold text-sm [overflow-wrap:anywhere]"
+                >
+                  x 
+                  1
+                </div>
               </div>
               <div
                 class="flex items-center gap-1 mb-1"


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added quantity information to line item options. It will be shown next to the line option title.

<img width="600" alt="Line item options with quantity" src="https://github.com/commercelayer/app-elements/assets/105653649/a05bf74d-9d62-4047-813c-14789a13bfe0">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
