### PR TITLE
Expose `removeItem` method in ResourceList children prop

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
@@ -99,6 +99,7 @@ export type ResourceListProps<TResource extends ListableResourceType> = Pick<
           isLoading: boolean
           data?: FetcherResponse<Resource<TResource>>
           isFirstLoading: boolean
+          removeItem: (resourceId: string) => void
         }) => React.ReactNode
       }
   )
@@ -235,7 +236,19 @@ export function ResourceList<TResource extends ListableResourceType>({
           })}
 
         {'children' in props &&
-          props.children({ isLoading, data, isFirstLoading })}
+          props.children({
+            isLoading,
+            data,
+            isFirstLoading,
+            removeItem: (resourceId) => {
+              dispatch({
+                type: 'removeItem',
+                payload: {
+                  resourceId
+                }
+              })
+            }
+          })}
 
         {error != null ? (
           <ErrorLine


### PR DESCRIPTION
## What I did

I have exposed the `removeItem` method in `ResourceList` component when used with `children` prop.

We can already use `removeItem` when using the standard `ItemTemplate` prop, but this method was unavailable when the component is used with `children`.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
