### PR TITLE
Show and edit `numbers` and `booleans` in `ResourceMetadata`

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -38,6 +38,13 @@ export interface ResourceMetadataProps {
   overlay: ResourceMetadataOverlay
 }
 
+export const updatableTypes = ['string', 'number', 'boolean'] as const
+export type UpdatableType = (typeof updatableTypes)[number]
+
+export const isUpdatableType = (value: any): value is UpdatableType => {
+  return updatableTypes.includes(typeof value as UpdatableType)
+}
+
 /**
  * This component provides an all-in-one visualization and editing interface for the `metadata` attribute of a given resource.
  * More in detail the `metadata` attribute is a JSON object, customizable for several purposes, and this component will allow to show and manage its keys with a simple (string kind) values.
@@ -59,19 +66,19 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
       ]
     )
 
-    const hasStringMetadata =
-      Object.entries(resourceData?.metadata ?? []).filter(
-        ([, metadataValue]) => typeof metadataValue === 'string'
+    const isUpdatable =
+      Object.entries(resourceData?.metadata ?? []).filter(([, metadataValue]) =>
+        isUpdatableType(metadataValue)
       ).length > 0
 
-    if (!hasStringMetadata || isLoading) return <></>
+    if (!isUpdatable || isLoading) return <></>
 
     return (
       <div>
         <Section
           title='Metadata'
           actionButton={
-            hasStringMetadata &&
+            isUpdatable &&
             canUser('update', resourceType) && (
               <Button
                 variant='secondary'
@@ -89,7 +96,7 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
         >
           {Object.entries(resourceData?.metadata ?? []).map(
             ([metadataKey, metadataValue], idx) => {
-              if (typeof metadataValue !== 'string') return null
+              if (!isUpdatableType(metadataValue)) return null
 
               return (
                 <ListItem
@@ -106,7 +113,7 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
                     weight='semibold'
                     data-testid={`ResourceMetadata-value-${metadataKey}`}
                   >
-                    {metadataValue}
+                    {metadataValue.toString()}
                   </Text>
                 </ListItem>
               )

--- a/packages/docs/src/mocks/data/customers.js
+++ b/packages/docs/src/mocks/data/customers.js
@@ -9,6 +9,7 @@ export default [
     first_name: 'John',
     last_name: 'Doe',
     age: 35,
+    is_vip: true,
     other: { pet: 'cat' }
   }),
   ...mockCustomer('ASEYfdNrwa', {


### PR DESCRIPTION
linked to commercelayer/issues-app#83

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for showing and editing `metadata` values of type `number` and `boolean` in `ResourceMetadata` component.
Values of type `number` will be managed by using an `<HookedInput type="number" ... />`.
Values of type `boolean` will be managed by using an `<HookedInputCheckbox ... />`.

<img src="https://github.com/commercelayer/app-elements/assets/105653649/ff8e55a7-9965-418e-9903-96cc426a6bcb" width="500" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
