### PR TITLE
Enforce support for `float` values in `ResourceMetadata`

### DIFF
--- a/packages/docs/src/mocks/data/customers.js
+++ b/packages/docs/src/mocks/data/customers.js
@@ -9,6 +9,7 @@ export default [
     first_name: 'John',
     last_name: 'Doe',
     age: 35,
+    height: 1.8,
     is_vip: true,
     other: { pet: 'cat' }
   }),


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Enforced the calculation of wanted input kind by checking the type of the original metadata value instead of the watched value from the form context
- Added `step="any"` property to the `input type="number"` input kind to enable free management of decimal values
- Parsed to float the values with an original value type `number` to fill correctly the `metadata` object sent to the `onSubmit` callback

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
