### PR TITLE
Add creatable InputSelect

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/CreatableComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/CreatableComponent.tsx
@@ -1,0 +1,40 @@
+import { forwardRef } from 'react'
+import {
+  type GroupBase,
+  type SelectInstance,
+  type StylesConfig
+} from 'react-select'
+import CreatableSelect from 'react-select/creatable'
+import { type InputSelectProps, type InputSelectValue } from './InputSelect'
+import components from './overrides'
+
+interface CreatableComponentProps
+  extends Omit<InputSelectProps, 'loadAsyncValues' | 'label' | 'hint'> {
+  styles: StylesConfig<InputSelectValue>
+}
+
+export const CreatableComponent = forwardRef<
+  SelectInstance<InputSelectValue, boolean, GroupBase<InputSelectValue>>,
+  CreatableComponentProps
+>(
+  (
+    { onSelect, noOptionsMessage, isOptionDisabled, initialValues, ...rest },
+    ref
+  ) => {
+    return (
+      <CreatableSelect
+        {...rest}
+        ref={ref}
+        isOptionDisabled={isOptionDisabled}
+        options={initialValues}
+        onChange={onSelect}
+        closeMenuOnSelect={rest.isMulti !== true}
+        noOptionsMessage={() => noOptionsMessage}
+        components={components}
+        formatCreateLabel={(v) => v} // to override default `Create "${value}"`
+      />
+    )
+  }
+)
+
+CreatableComponent.displayName = 'CreatableComponent'

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -11,6 +11,7 @@ import {
   type SingleValue
 } from 'react-select'
 import { AsyncSelectComponent } from './AsyncComponent'
+import { CreatableComponent } from './CreatableComponent'
 import { SelectComponent } from './SelectComponent'
 import { getSelectStyles } from './styles'
 
@@ -117,6 +118,11 @@ export interface InputSelectProps extends InputWrapperBaseProps {
    * It only works when `loadAsyncValues` is provided
    */
   debounceMs?: number
+  /**
+   * Allows to create new options on the fly when no option is found.
+   * It does not work with `loadAsyncValues`.
+   */
+  isCreatable?: boolean
 }
 
 /**
@@ -159,6 +165,7 @@ export const InputSelect = forwardRef<
       debounceMs,
       noOptionsMessage = 'No results found',
       menuFooterText,
+      isCreatable,
       ...rest
     },
     ref
@@ -191,6 +198,25 @@ export const InputSelect = forwardRef<
             styles={getSelectStyles(feedback?.variant)}
             debounceMs={debounceMs}
             isOptionDisabled={isOptionDisabled}
+            menuFooterText={menuFooterText}
+          />
+        ) : isCreatable === true ? (
+          <CreatableComponent
+            ref={ref}
+            menuIsOpen={menuIsOpen}
+            initialValues={initialValues}
+            defaultValue={defaultValue}
+            value={value}
+            isClearable={isClearable}
+            placeholder={isLoading === true ? loadingText : placeholder}
+            isDisabled={isLoading === true || isDisabled === true}
+            isSearchable={isSearchable}
+            onSelect={onSelect}
+            isMulti={isMulti}
+            isOptionDisabled={isOptionDisabled}
+            onBlur={onBlur}
+            name={name}
+            styles={getSelectStyles(feedback?.variant)}
             menuFooterText={menuFooterText}
           />
         ) : (

--- a/packages/app-elements/src/ui/forms/InputSelect/utils.test.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/utils.test.ts
@@ -144,14 +144,17 @@ describe('getDefaultValueFromFlatten', () => {
     ).toStrictEqual({ value: 'MI', label: 'Milan', meta: { zipCode: '20100' } })
   })
 
-  test('should return `undefined` when single value is not matched', () => {
+  test('should return a new option generated from `currentValue` when this is not included in `initialValues`', () => {
     expect(
       getDefaultValueFromFlatten({
         initialValues,
         currentValue: '000000',
         pathToValue: 'meta.zipCode'
       })
-    ).toBe(undefined)
+    ).toStrictEqual({
+      value: '000000',
+      label: '000000'
+    })
   })
 
   test('should return an array when working as multi select', () => {
@@ -163,13 +166,18 @@ describe('getDefaultValueFromFlatten', () => {
     ).toStrictEqual(initialValues.slice(0, 2))
   })
 
-  test('should return empty array when current value is not matched', () => {
+  test('should return an array with the new option generated from `currentValue` when this is not included in `initialValues` (isMulti)', () => {
     expect(
       getDefaultValueFromFlatten({
         initialValues,
         currentValue: ['TO']
       })
-    ).toStrictEqual([])
+    ).toStrictEqual([
+      {
+        value: 'TO',
+        label: 'TO'
+      }
+    ])
   })
 
   test('should undefined when current value does not exist', () => {

--- a/packages/app-elements/src/ui/forms/InputSelect/utils.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/utils.ts
@@ -95,13 +95,24 @@ export function getDefaultValueFromFlatten({
     : initialValues
 
   if (Array.isArray(currentValue)) {
-    return options.filter((v) => {
+    // in case of creatable the value is not in the options list
+    const newOptions: InputSelectValue[] = currentValue
+      .filter((v) => !options.map((o) => o.value).includes(v))
+      .map((o) => ({ value: o, label: o.toString() }))
+
+    return options.concat(newOptions).filter((v) => {
       const valueToCompare: string | number = get(v, pathToValue)
       return currentValue.includes(valueToCompare)
     })
   }
 
-  return options.find((v) => {
-    return currentValue === get(v, pathToValue)
-  })
+  return (
+    options.find((v) => {
+      return currentValue === get(v, pathToValue)
+    }) ?? {
+      // in case of creatable the value is not in the options list
+      value: currentValue,
+      label: currentValue.toString()
+    }
+  )
 }

--- a/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedInputSelect.stories.tsx
@@ -120,6 +120,28 @@ MultiSelect.args = {
   }
 }
 
+/**
+ * This example shows a multi select with the `isCreatable` prop enabled.
+ */
+export const MultiSelectCreatable = Template.bind({})
+MultiSelectCreatable.args = {
+  label: 'City',
+  name: 'city',
+  isMulti: true,
+  isCreatable: true,
+  placeholder: 'Type to create a new city that is not in the list...',
+  initialValues: [
+    {
+      value: 'paris',
+      label: 'Paris'
+    },
+    {
+      value: 'new york',
+      label: 'New York'
+    }
+  ]
+}
+
 export const Clear: StoryFn<typeof HookedInputSelect> = () => {
   const methods = useForm({
     defaultValues: { city: ['paris'] }

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -148,6 +148,20 @@ Multi.args = {
 }
 
 /**
+ * `isCreatable` allows to add custom value to the list simply by typing it.
+ */
+export const Creatable = Template.bind({})
+Creatable.args = {
+  label: 'Search resource or type for new value',
+  initialValues: fullList,
+  placeholder: 'Type something...',
+  isMulti: true,
+  isSearchable: true,
+  isClearable: false,
+  isCreatable: true
+}
+
+/**
  * Options can be grouped by passing an array of objects with `label` and `options` properties.
  */
 export const GroupedOptions = Template.bind({})


### PR DESCRIPTION
## What I did

I've added support to input-select creatable: 
https://react-select.com/creatable

When `isCreatable` prop is added to our `InputSelect` component, it will load the `Creatable` component that works as the default select, but also accepts the selection of values not present in the options.

https://deploy-preview-683--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputselect--docs#creatable


https://github.com/commercelayer/app-elements/assets/30926550/f829cf12-e7a3-4258-bb82-3fd309315d84


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
