### PR TITLE
Show order total amount and status in the list

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -74,7 +74,7 @@ describe('formatDate', () => {
         isoDate: '2023-02-22T10:32:47.284Z',
         format: 'full'
       })
-    ).toBe('Feb 22 · 10:32')
+    ).toBe('Feb 22, 10:32')
 
     // PM
     expect(
@@ -82,7 +82,7 @@ describe('formatDate', () => {
         isoDate: '2022-10-26T16:16:31.279Z',
         format: 'full'
       })
-    ).toBe('Oct 26, 2022 · 16:16')
+    ).toBe('Oct 26, 2022, 16:16')
   })
 
   test('Should return a date with time and seconds', () => {
@@ -92,7 +92,7 @@ describe('formatDate', () => {
         isoDate: '2023-02-22T10:32:47.284Z',
         format: 'fullWithSeconds'
       })
-    ).toBe('Feb 22 · 10:32:47')
+    ).toBe('Feb 22, 10:32:47')
 
     // PM
     expect(
@@ -100,7 +100,7 @@ describe('formatDate', () => {
         isoDate: '2022-10-26T16:16:31.279Z',
         format: 'fullWithSeconds'
       })
-    ).toBe('Oct 26, 2022 · 16:16:31')
+    ).toBe('Oct 26, 2022, 16:16:31')
   })
 
   test('Should return only the time', () => {
@@ -156,7 +156,7 @@ describe('formatDate', () => {
         timezone: 'Europe/Rome',
         format: 'full'
       })
-    ).toBe('Oct 26, 2022 · 18:16')
+    ).toBe('Oct 26, 2022, 18:16')
   })
 
   test('Should return the distance to now', () => {
@@ -231,7 +231,7 @@ describe('formatDateWithPredicate', () => {
         predicate: 'Created',
         isoDate: '2022-10-14T14:32:00.000Z'
       })
-    ).toBe('Created on Oct 14, 2022 · 14:32')
+    ).toBe('Created on Oct 14, 2022, 14:32')
   })
 
   test('Should return the predicate followed by `on` and the date without the year when current year', () => {
@@ -261,7 +261,7 @@ describe('formatDateWithPredicate', () => {
         isoDate: '2023-02-22T10:32:47.284Z',
         format: 'full'
       })
-    ).toBe('Updated on Feb 22 · 10:32')
+    ).toBe('Updated on Feb 22, 10:32')
   })
 
   test('Should return the predicate followed by `on` and the date with time and seconds', () => {
@@ -271,7 +271,7 @@ describe('formatDateWithPredicate', () => {
         isoDate: '2023-02-22T10:32:47.284Z',
         format: 'fullWithSeconds'
       })
-    ).toBe('Updated on Feb 22 · 10:32:47')
+    ).toBe('Updated on Feb 22, 10:32:47')
   })
 
   test('Should return the predicate followed by `at` and the time', () => {

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -43,6 +43,11 @@ interface FormatDateOptions {
    * @default date
    */
   format?: Format
+  /**
+   * Whether to show or not the current year.
+   * @default false
+   */
+  showCurrentYear?: boolean
 }
 
 /**
@@ -53,6 +58,7 @@ interface FormatDateOptions {
 export function formatDate({
   isoDate,
   timezone = 'UTC',
+  showCurrentYear = false,
   ...opts
 }: FormatDateOptions): string {
   if (isoDate == null) {
@@ -65,7 +71,8 @@ export function formatDate({
     const formatTemplate = getPresetFormatTemplate(
       zonedDate,
       timezone,
-      opts.format
+      opts.format,
+      showCurrentYear
     )
 
     return format(zonedDate, formatTemplate)
@@ -122,43 +129,48 @@ export function formatDateWithPredicate({
   return `${predicate} ${separator}${formattedDate}`
 }
 
-export const timeSeparator = '·'
+export const timeSeparator = ', '
 
 function getPresetFormatTemplate(
   zonedDate: Date,
   timezone: string,
-  format: Format = 'date'
+  format: Format = 'date',
+  showCurrentYear: boolean
 ): string {
   switch (format) {
     case 'date':
       return isToday(zonedDate)
         ? "'Today'"
-        : isThisYear(zonedDate)
+        : isThisYear(zonedDate) && !showCurrentYear
           ? 'LLL dd'
           : 'LLL dd, yyyy'
     case 'time':
       return 'kk:mm'
     case 'timeWithSeconds':
-      return `${getPresetFormatTemplate(zonedDate, timezone, 'time')}:ss`
+      return `${getPresetFormatTemplate(zonedDate, timezone, 'time', showCurrentYear)}:ss`
     case 'full':
       return `${getPresetFormatTemplate(
         zonedDate,
         timezone,
-        'date'
-      )} ${timeSeparator} ${getPresetFormatTemplate(
+        'date',
+        showCurrentYear
+      )}${timeSeparator}${getPresetFormatTemplate(
         zonedDate,
         timezone,
-        'time'
+        'time',
+        showCurrentYear
       )}`
     case 'fullWithSeconds':
       return `${getPresetFormatTemplate(
         zonedDate,
         timezone,
-        'date'
-      )} ${timeSeparator} ${getPresetFormatTemplate(
+        'date',
+        showCurrentYear
+      )}${timeSeparator}${getPresetFormatTemplate(
         zonedDate,
         timezone,
-        'timeWithSeconds'
+        'timeWithSeconds',
+        showCurrentYear
       )}`
     case 'distanceToNow':
       return `'${formatDistance(zonedDate, toZonedTime(new Date(), timezone), {

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
@@ -44,6 +44,7 @@ export const orderToProps: ResourceToProps<Order> = ({ resource, user }) => {
       ) : (
         <ListItemIcon icon={displayStatus.icon} color={displayStatus.color} />
       ),
+    showRightContent: true,
     rightContent: (
       <>
         <Text

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
@@ -31,7 +31,7 @@ export const orderToProps: ResourceToProps<Order> = ({ resource, user }) => {
       <ListItemDescription
         displayStatus={displayStatus}
         date={formatDate({
-          format: 'date',
+          format: 'full',
           isoDate: resource.placed_at ?? resource.updated_at,
           timezone: user?.timezone
         })}

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/returns.tsx
@@ -21,7 +21,7 @@ export const returnToProps: ResourceToProps<Return> = ({ resource, user }) => {
       <ListItemDescription
         displayStatus={displayStatus}
         date={formatDate({
-          format: 'date',
+          format: 'full',
           isoDate: resource.updated_at,
           timezone: user?.timezone
         })}

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
@@ -37,7 +37,7 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
       <ListItemDescription
         displayStatus={displayStatus}
         date={formatDate({
-          format: 'date',
+          format: 'full',
           isoDate: resource.updated_at,
           timezone: user?.timezone
         })}

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/stockTransfers.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/stockTransfers.tsx
@@ -28,7 +28,7 @@ export const stockTransferToProps: ResourceToProps<StockTransfer> = ({
       <ListItemDescription
         displayStatus={displayStatus}
         date={formatDate({
-          format: 'date',
+          format: 'full',
           isoDate: resource.updated_at,
           timezone: user?.timezone
         })}

--- a/packages/docs/src/stories/utility/Date.data.tsx
+++ b/packages/docs/src/stories/utility/Date.data.tsx
@@ -30,6 +30,21 @@ export const formatDateExamples: CodeSampleProps[] = [
   },
   {
     fn: () => {
+      // This is to avoid name mangling.
+      // eslint-disable-next-line no-eval
+      eval('')
+
+      const currentYear = new Date().getFullYear()
+
+      return formatDate({
+        isoDate: `${currentYear}-10-14T14:32:00.000Z`,
+        format: 'date',
+        showCurrentYear: true
+      })
+    }
+  },
+  {
+    fn: () => {
       return formatDate({
         isoDate: new Date().toString(),
         format: 'date'


### PR DESCRIPTION
## Related to

- commercelayer/issues-app#58
- commercelayer/issues-app#140
- commercelayer/issues-app#143


<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- I added a `showCurrentYear: boolean` to the `formatDate` helper. ([test](https://deploy-preview-685--commercelayer-app-elements.netlify.app/?path=/docs/utility-date--docs))
- I replaced the `·` time separator with `,`. ([test](https://deploy-preview-685--commercelayer-app-elements.netlify.app/?path=/docs/utility-date--docs))
- I added the time in the resource list item. ([test](https://deploy-preview-685--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelistitem--docs))
- Show the order total amount and status in the list. ([test](https://deploy-preview-685--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelistitem--docs))
