### PR TITLE
Allow to pass extra info from `createApp.init()` to make them available within `TokenProvider` context

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -104,6 +104,14 @@ export interface TokenProviderProps {
    * This methods will also be returned within the context as part of `TokenProviderValue` object.
    */
   onAppClose?: () => void
+  /**
+   * Optional. Extra data to pass from the dashboard or when the app is initialized.
+   * They will be received on app init and make available in the TokenProvider > settings context.
+   */
+  extras?: {
+    /** List of applications to be used inside the app. */
+    salesChannels?: Array<{ name: string; client_id: string }>
+  }
 }
 
 export const AuthContext = createContext<TokenProviderValue>({
@@ -131,7 +139,8 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
   errorElement,
   accessToken: accessTokenFromProp,
   onAppClose,
-  isInDashboard = false
+  isInDashboard = false,
+  extras
 }) => {
   const [_state, dispatch] = useReducer(reducer, initialTokenProviderState)
   domain = isProductionHostname() ? 'commercelayer.io' : domain
@@ -232,7 +241,8 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
               domain,
               dashboardUrl,
               onAppClose,
-              isInDashboard
+              isInDashboard,
+              extras
             },
             user: tokenInfo.user,
             organization,

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -142,6 +142,13 @@ export interface TokenProviderAuthSettings {
    * This is defined only if it has been declared when TokenProvider has been initialized.
    */
   onAppClose?: () => void
+
+  /**
+   * Extra data received from the outside and made available in the app.
+   */
+  extras?: {
+    salesChannels?: Array<{ name: string; client_id: string }>
+  }
 }
 
 export interface TokenProviderAuthUser {

--- a/packages/app-elements/src/providers/createApp.tsx
+++ b/packages/app-elements/src/providers/createApp.tsx
@@ -2,6 +2,7 @@ import isEmpty from 'lodash/isEmpty'
 import { type FC } from 'react'
 import ReactDOM, { type Root } from 'react-dom/client'
 import { type TokenProviderAllowedApp } from './TokenProvider'
+import { type TokenProviderProps } from './TokenProvider/TokenProvider'
 
 export type ClAppKey = `clApp_${TokenProviderAllowedApp}`
 
@@ -31,33 +32,20 @@ declare global {
   }
 }
 
-export interface ClAppProps {
+export interface ClAppProps
+  extends Pick<
+    TokenProviderProps,
+    'organizationSlug' | 'domain' | 'onAppClose' | 'isInDashboard' | 'extras'
+  > {
   /**
    * Base path for internal routing.
    * Example: `my-app` if you want to serve the app at `https://my-domain.com/my-app/`.
    */
   routerBase?: string
   /**
-   * Organization slug to use for Commerce Layer API requests.
-   */
-  organizationSlug?: string
-  /**
    * Callback to be called when the user is not authenticated or the token is invalid/expired.
    */
   onInvalidAuth?: () => void
-  /**
-   * Callback to be called when the app is closed (when go-back button from the app home page is clicked)
-   */
-  onAppClose?: () => void
-  /**
-   * Handle some UI elements to be hidden when the app is loaded in the dashboard.
-   */
-  isInDashboard?: boolean
-  /**
-   * Domain used for Core API requests
-   * @default 'commercelayer.io'
-   */
-  domain?: string
 }
 
 /**


### PR DESCRIPTION
## What I did

Now it's possible to pass some data when the app is initialized and have them available within the TokenProvider context.

This means it is possible to do this on app init:
```
window.clApp_orders( node, { ...props, metadata })
```

and access the metadata object later
```
const { settings } = useTokenProvider()
console.log(settings.metedata)
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
