### PR TITLE
Set toolbar icons weight to regular

### DIFF
--- a/packages/app-elements/src/ui/composite/Toolbar.tsx
+++ b/packages/app-elements/src/ui/composite/Toolbar.tsx
@@ -77,9 +77,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
                 className={item.className}
                 data-testid='toolbar-dropdown-button'
               >
-                {item.icon != null && (
-                  <Icon name={item.icon} size={16} weight='bold' />
-                )}
+                {item.icon != null && <Icon name={item.icon} size={16} />}
                 {item.label}
               </Button>
             }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I fixed an unseen behavior of toolbar by setting its icons weight to `regular` instead of `bold`.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
