### PR TITLE
Add `onCancel` prop to `useInputResourceGroupOverlay`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputResourceGroup/FullList.tsx
+++ b/packages/app-elements/src/ui/forms/InputResourceGroup/FullList.tsx
@@ -46,6 +46,11 @@ export interface FullListProps {
    */
   onChange: (values: string[]) => void
   /**
+   * Optional callback to be triggered when cancel button is pressed.
+   * If missing, the local history will be used to go back (`history.back()`).
+   */
+  onCancel?: () => void
+  /**
    * Value to be used as search predicate when SearchBar is used.
    * If missing the search bar will not be shown.
    * It must match the format described in the Core APIs documentation.
@@ -81,6 +86,7 @@ export function FullList({
   defaultValues,
   fieldForLabel,
   fieldForValue,
+  onCancel,
   onChange,
   resource,
   searchBy,
@@ -119,8 +125,13 @@ export function FullList({
               }}
             />
             <button
+              type='button'
               onClick={() => {
-                history.back()
+                if (onCancel != null) {
+                  onCancel()
+                } else {
+                  history.back()
+                }
               }}
               className='text-primary font-bold rounded px-1 shadow-none !outline-0 !border-0 !ring-0 focus:shadow-focus'
             >

--- a/packages/docs/src/stories/forms/ui/InputResourceGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputResourceGroup.stories.tsx
@@ -67,6 +67,7 @@ export const UseInputResourceGroupOverlay: StoryFn = () => {
         <InputResourceGroupOverlay
           defaultValues={values}
           onChange={setValues}
+          onCancel={closeInputResourceGroupOverlay}
           resource='markets'
           fieldForLabel='name'
           fieldForValue='id'
@@ -111,6 +112,7 @@ export const HideSelected: StoryFn = () => {
         <InputResourceGroupOverlay
           defaultValues={values}
           onChange={setValues}
+          onCancel={closeInputResourceGroupOverlay}
           resource='markets'
           fieldForLabel='name'
           fieldForValue='id'


### PR DESCRIPTION
closes https://github.com/commercelayer/issues-app/issues/166

## What I did

I've added `onCancel` prop to close the `InputResourceGroupOverlay` instead of being redirected to the previous URL in the history.




## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
