### PR TITLE
TokenProvider: exposed parsed scopes found in access token

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -242,6 +242,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
               dashboardUrl,
               onAppClose,
               isInDashboard,
+              scopes: tokenInfo.scopes,
               extras
             },
             user: tokenInfo.user,

--- a/packages/app-elements/src/providers/TokenProvider/getInfoFromJwt.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/getInfoFromJwt.test.ts
@@ -2,7 +2,6 @@ import { getInfoFromJwt } from './getInfoFromJwt'
 
 const jwtSalesChannelOrgAcme =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJ0ZXN0Ijp0cnVlLCJleHAiOjE2NTI3OTUxMDIsInJhbmQiOjAuMzE0NTUwMDUwMTg4ODYzOH0.mX4A08-f_vdab6_dDpA1eDdGri91kR0erP8X7obZr1M'
-
 describe('Get info from JWT', () => {
   test('Parsing a valid token', () => {
     const { appKind, orgSlug, exp } = getInfoFromJwt(jwtSalesChannelOrgAcme)
@@ -17,5 +16,87 @@ describe('Get info from JWT', () => {
     )
     expect(appKind).toBe(undefined)
     expect(orgSlug).toBe(undefined)
+  })
+})
+
+//   "scope": ""
+const tokenWithEmptyStringScope =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJzY29wZSI6IiIsInRlc3QiOnRydWUsImV4cCI6MTY1Mjc5NTEwMiwicmFuZCI6MC4zMTQ1NTAwNTAxODg4NjM4fQ.5VjX9oK2pkMHxZ-O4pSS2YyAAmfGWulpz_ii5ZvF0T0'
+
+// "scope": "market:id:qaoeabcdoJ stock_location:id:zdMabcdVbb"
+const tokenWithScopeIds =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJzY29wZSI6Im1hcmtldDppZDpxYW9lYWJjZG9KIHN0b2NrX2xvY2F0aW9uOmlkOnpkTWFiY2RWYmIiLCJ0ZXN0Ijp0cnVlLCJleHAiOjE2NTI3OTUxMDIsInJhbmQiOjAuMzE0NTUwMDUwMTg4ODYzOH0.u_D63no4nbizAwQGUR4j6WTybAW_dP6OIV7gRokX60A'
+
+// "scope": "market:id:qaoeabcdoJ stock_location:id:zdMabcdVbb market:code:EUROPE stock_location:code:MAIN"
+const tokenWithScopeCodesAndIds =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJzY29wZSI6Im1hcmtldDppZDpxYW9lYWJjZG9KIHN0b2NrX2xvY2F0aW9uOmlkOnpkTWFiY2RWYmIgbWFya2V0OmNvZGU6RVVST1BFIHN0b2NrX2xvY2F0aW9uOmNvZGU6TUFJTiIsInRlc3QiOnRydWUsImV4cCI6MTY1Mjc5NTEwMiwicmFuZCI6MC4zMTQ1NTAwNTAxODg4NjM4fQ.q-Gub7C5IkmNNK9QjttXvDxNZhwHqxh7ocO9471Br0c'
+
+//  "scope": "market:id:qaoeabcdoJ market:id:qakufEcdoJ"
+const tokenWithScopeMultiMarketIds =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJzY29wZSI6Im1hcmtldDppZDpxYW9lYWJjZG9KIG1hcmtldDppZDpxYWt1ZkVjZG9KIiwidGVzdCI6dHJ1ZSwiZXhwIjoxNjUyNzk1MTAyLCJyYW5kIjowLjMxNDU1MDA1MDE4ODg2Mzh9.r_az60tlatjL5ZAsdKu0Hyxgw7Ijo_xMHE9vbbG0ZtU'
+
+// "scope": "stock_location:code:EU1 stock_location:code:EU2"
+const tokenWithScopeMultiStockLocationCodes =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJhYmMxMjM0Iiwic2x1ZyI6ImFjbWUifSwiYXBwbGljYXRpb24iOnsiaWQiOiJiY2Q0NDIxIiwia2luZCI6InNhbGVzX2NoYW5uZWwiLCJwdWJsaWMiOnRydWV9LCJzY29wZSI6InN0b2NrX2xvY2F0aW9uOmNvZGU6RVUxIHN0b2NrX2xvY2F0aW9uOmNvZGU6RVUyIiwidGVzdCI6dHJ1ZSwiZXhwIjoxNjUyNzk1MTAyLCJyYW5kIjowLjMxNDU1MDA1MDE4ODg2Mzh9.bmcfynHE5IZSqdRDqdN_PxZrZA7JkpS6H8034K0hKhc'
+
+describe('Get scopes from token', () => {
+  test('should return empty values when token has no scope key', () => {
+    const { scopes } = getInfoFromJwt(jwtSalesChannelOrgAcme)
+    expect(scopes).toEqual({
+      market: {},
+      stock_location: {}
+    })
+  })
+  test('should return empty values when token has empty string as scope', () => {
+    const { scopes } = getInfoFromJwt(tokenWithEmptyStringScope)
+    expect(scopes).toEqual({
+      market: {},
+      stock_location: {}
+    })
+  })
+
+  test('should return valid ids as scope', () => {
+    const { scopes } = getInfoFromJwt(tokenWithScopeIds)
+    expect(scopes).toEqual({
+      market: {
+        ids: ['qaoeabcdoJ']
+      },
+      stock_location: {
+        ids: ['zdMabcdVbb']
+      }
+    })
+  })
+
+  test('should return valid ids and codes as scope', () => {
+    const { scopes } = getInfoFromJwt(tokenWithScopeCodesAndIds)
+    expect(scopes).toEqual({
+      market: {
+        ids: ['qaoeabcdoJ'],
+        codes: ['EUROPE']
+      },
+      stock_location: {
+        ids: ['zdMabcdVbb'],
+        codes: ['MAIN']
+      }
+    })
+  })
+
+  test('should return valid ids when is multi markets', () => {
+    const { scopes } = getInfoFromJwt(tokenWithScopeMultiMarketIds)
+    expect(scopes).toEqual({
+      market: {
+        ids: ['qaoeabcdoJ', 'qakufEcdoJ']
+      },
+      stock_location: {}
+    })
+  })
+  test('should return valid codes when is multi stock locations', () => {
+    const { scopes } = getInfoFromJwt(tokenWithScopeMultiStockLocationCodes)
+    expect(scopes).toEqual({
+      market: {},
+      stock_location: {
+        codes: ['EU1', 'EU2']
+      }
+    })
   })
 })

--- a/packages/app-elements/src/providers/TokenProvider/getInfoFromJwt.ts
+++ b/packages/app-elements/src/providers/TokenProvider/getInfoFromJwt.ts
@@ -1,4 +1,5 @@
 import { jwtDecode } from 'jwt-decode'
+import isEmpty from 'lodash/isEmpty'
 import { type Mode } from './types'
 
 interface JWTProps {
@@ -12,6 +13,7 @@ interface JWTProps {
   }
   exp: number
   test: boolean
+  scope?: string
 }
 
 export const getInfoFromJwt = (
@@ -22,9 +24,10 @@ export const getInfoFromJwt = (
   appId?: string
   exp?: number
   mode?: Mode
+  scopes?: ParsedScopes
 } => {
   try {
-    const { organization, application, exp, test } =
+    const { organization, application, exp, test, scope } =
       jwtDecode<JWTProps>(accessToken)
 
     return {
@@ -32,9 +35,63 @@ export const getInfoFromJwt = (
       appKind: application.kind,
       appId: application.id,
       mode: test ? 'test' : 'live',
+      scopes: parseScope(scope),
       exp
     }
   } catch (e) {
     return {}
   }
+}
+
+export interface ParsedScopes {
+  market: {
+    ids?: string[]
+    codes?: string[]
+  }
+  stock_location: {
+    ids?: string[]
+    codes?: string[]
+  }
+}
+
+const parseScope = (scope?: string): ParsedScopes => {
+  const defaultData: ParsedScopes = {
+    market: {},
+    stock_location: {}
+  }
+
+  if (isEmpty(scope) || scope == null) {
+    return defaultData
+  }
+
+  const scopeParts = scope.split(' ')
+
+  const data = scopeParts.reduce((acc, part) => {
+    const [type, attribute, id] = part.split(':')
+
+    if (type !== 'market' && type !== 'stock_location') {
+      return acc
+    }
+
+    const key:
+      | keyof ParsedScopes['market']
+      | keyof ParsedScopes['stock_location']
+      | null =
+      attribute === 'id' ? 'ids' : attribute === 'code' ? 'codes' : null
+    if (key == null) {
+      return acc
+    }
+
+    const existingValues = acc[type][key] ?? []
+
+    return {
+      ...acc,
+      [type]: {
+        ...acc[type],
+        [key]: [...existingValues, id]
+      }
+    }
+  }, defaultData)
+
+  return data
 }

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -1,3 +1,4 @@
+import { type ParsedScopes } from '#providers/TokenProvider/getInfoFromJwt'
 import { type ListableResourceType } from '@commercelayer/sdk'
 
 export type TokenProviderAllowedApp =
@@ -142,7 +143,10 @@ export interface TokenProviderAuthSettings {
    * This is defined only if it has been declared when TokenProvider has been initialized.
    */
   onAppClose?: () => void
-
+  /**
+   * If token has a scope, it will be parsed and made available here in the keys of `markets` and `stock_locations`
+   */
+  scopes?: ParsedScopes
   /**
    * Extra data received from the outside and made available in the app.
    */

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.ts
@@ -6,7 +6,7 @@ import {
 import { type ListableResourceType } from '@commercelayer/sdk'
 import fetch from 'cross-fetch'
 import isEmpty from 'lodash/isEmpty'
-import { getInfoFromJwt } from './getInfoFromJwt'
+import { getInfoFromJwt, type ParsedScopes } from './getInfoFromJwt'
 import {
   type Mode,
   type TokenProviderAuthUser,
@@ -40,6 +40,7 @@ interface ValidToken {
   permissions?: TokenProviderRolePermissions
   accessibleApps?: TokenProviderAllowedApp[]
   user: TokenProviderAuthUser | null
+  scopes?: ParsedScopes
 }
 interface InvalidToken {
   isValidToken: false
@@ -139,7 +140,8 @@ export async function isValidTokenForCurrentApp({
                 tokenInfo.owner.last_name
               )
             }
-          : null
+          : null,
+      scopes: jwtInfo.scopes
     }
   } catch {
     return {


### PR DESCRIPTION
## What I did

I've updated TokenProvider component to return `scopes` inside the `settings` object.
Scopes are parsed from the `scope` string found inside the access token (if set).

examples:
```ts
const { settings } = useTokenProvider()

settings.scopes.market?.ids   // array of market ids found in scope
settings.scopes.market?.codes   // array of market codes found in scope
settings.scopes.stock_location?.ids   // array of stock_location ids found in scope
settings.scopes.stock_location?.codes  // array of stock_location codes found in scope
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
