### PR TITLE
Manage word break in `InputReadonly`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputReadonly.tsx
+++ b/packages/app-elements/src/ui/forms/InputReadonly.tsx
@@ -52,7 +52,7 @@ export const InputReadonly = withSkeletonTemplate<InputReadonlyProps>(
     ...rest
   }) => {
     const cssBase =
-      'block w-full rounded bg-gray-50 text-teal text-sm font-mono font-medium marker:font-bold border-none'
+      'block w-full rounded bg-gray-50 text-teal text-sm font-mono font-medium marker:font-bold border-none break-all'
 
     const [hideValue, setHideValue] = useState(secret)
 


### PR DESCRIPTION
Closes https://github.com/commercelayer/issues-app/issues/123

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I added the proper TW classname (`break-all`) to avoid unwanted behavior of long texts in the multiline usage of `InputReadonly`. The enforcement was also a fix to avoid in general any related unwanted behavior in mobile / small viewports.

This improvement should fix the regex visualization in `sku_lists` app and also many other usages of this kind of input for example during the dashboard onboarding (wrong behavior spotted on mobile devices).

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
