### PR TITLE
Manage the `async-creatable` component from react-select

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/AsyncCreatableComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/AsyncCreatableComponent.tsx
@@ -1,13 +1,13 @@
 import { forwardRef } from 'react'
 import { type GroupBase, type SelectInstance } from 'react-select'
-import AsyncSelect from 'react-select/async'
+import AsyncCreatableSelect from 'react-select/async-creatable'
 import {
   GenericAsyncSelectComponent,
   type GenericAsyncSelectComponentProps
 } from './GenericAsyncComponent'
 import { type InputSelectValue } from './InputSelect'
 
-export const AsyncSelectComponent = forwardRef<
+export const AsyncCreatableSelectComponent = forwardRef<
   SelectInstance<InputSelectValue, boolean, GroupBase<InputSelectValue>>,
   GenericAsyncSelectComponentProps
 >((props, ref) => {
@@ -15,9 +15,9 @@ export const AsyncSelectComponent = forwardRef<
     <GenericAsyncSelectComponent
       {...props}
       ref={ref}
-      SelectComponent={AsyncSelect}
+      SelectComponent={AsyncCreatableSelect}
     />
   )
 })
 
-AsyncSelectComponent.displayName = 'AsyncSelectComponent'
+AsyncCreatableSelectComponent.displayName = 'AsyncCreatableSelectComponent'

--- a/packages/app-elements/src/ui/forms/InputSelect/CreatableComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/CreatableComponent.tsx
@@ -8,7 +8,7 @@ import CreatableSelect from 'react-select/creatable'
 import { type InputSelectProps, type InputSelectValue } from './InputSelect'
 import components from './overrides'
 
-interface CreatableComponentProps
+export interface CreatableComponentProps
   extends Omit<InputSelectProps, 'loadAsyncValues' | 'label' | 'hint'> {
   styles: StylesConfig<InputSelectValue>
 }

--- a/packages/app-elements/src/ui/forms/InputSelect/GenericAsyncComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/GenericAsyncComponent.tsx
@@ -1,0 +1,92 @@
+import debounce from 'lodash/debounce'
+import isEmpty from 'lodash/isEmpty'
+import { type AsyncAdditionalProps } from 'node_modules/react-select/dist/declarations/src/useAsync'
+import { forwardRef, useCallback, useEffect } from 'react'
+import {
+  type GroupBase,
+  type SelectInstance,
+  type StylesConfig
+} from 'react-select'
+import type AsyncSelect from 'react-select/async'
+import type AsyncCreatableSelect from 'react-select/async-creatable'
+import { type SetRequired } from 'type-fest'
+import { type InputSelectProps, type InputSelectValue } from './InputSelect'
+import components from './overrides'
+
+export interface GenericAsyncSelectComponentProps
+  extends Omit<
+    SetRequired<InputSelectProps, 'loadAsyncValues'>,
+    'label' | 'hint'
+  > {
+  styles: StylesConfig<InputSelectValue>
+}
+
+// extracting loadOptions signature from react-select async types
+type ReactSelectLoadOptions = Exclude<
+  AsyncAdditionalProps<
+    InputSelectValue,
+    GroupBase<InputSelectValue>
+  >['loadOptions'],
+  undefined
+>
+
+export const GenericAsyncSelectComponent = forwardRef<
+  SelectInstance<InputSelectValue, boolean, GroupBase<InputSelectValue>>,
+  GenericAsyncSelectComponentProps & {
+    SelectComponent: AsyncSelect | AsyncCreatableSelect
+  }
+>(
+  (
+    {
+      onSelect,
+      noOptionsMessage,
+      initialValues,
+      isOptionDisabled,
+      loadAsyncValues,
+      SelectComponent,
+      debounceMs = 500,
+      ...rest
+    },
+    ref
+  ) => {
+    const loadOptions = useCallback(
+      debounce<ReactSelectLoadOptions>((inputText, callback) => {
+        void loadAsyncValues(inputText).then((options) => {
+          callback(options)
+        })
+      }, debounceMs),
+      [debounceMs]
+    )
+
+    useEffect(() => {
+      return () => {
+        loadOptions.cancel()
+      }
+    }, [debounceMs])
+
+    return (
+      <SelectComponent
+        {...rest}
+        ref={ref}
+        defaultOptions={initialValues}
+        onChange={onSelect}
+        closeMenuOnSelect={rest.isMulti !== true}
+        noOptionsMessage={({ inputValue }) =>
+          isEmpty(inputValue) &&
+          (initialValues === undefined || initialValues.length === 0)
+            ? null
+            : noOptionsMessage
+        }
+        loadOptions={loadOptions}
+        components={{
+          ...components,
+          DropdownIndicator: null
+        }}
+        isOptionDisabled={isOptionDisabled}
+        formatCreateLabel={(v) => v} // to override default `Create "${value}"`
+      />
+    )
+  }
+)
+
+GenericAsyncSelectComponent.displayName = 'GenericAsyncSelectComponent'

--- a/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/InputSelect.tsx
@@ -11,8 +11,13 @@ import {
   type SingleValue
 } from 'react-select'
 import { AsyncSelectComponent } from './AsyncComponent'
-import { CreatableComponent } from './CreatableComponent'
-import { SelectComponent } from './SelectComponent'
+import { AsyncCreatableSelectComponent } from './AsyncCreatableComponent'
+import {
+  CreatableComponent,
+  type CreatableComponentProps
+} from './CreatableComponent'
+import { type GenericAsyncSelectComponentProps } from './GenericAsyncComponent'
+import { SelectComponent, type SelectComponentProps } from './SelectComponent'
 import { getSelectStyles } from './styles'
 
 export type GroupedSelectValues = Array<{
@@ -170,6 +175,26 @@ export const InputSelect = forwardRef<
     },
     ref
   ) => {
+    const commonProps:
+      | GenericAsyncSelectComponentProps
+      | CreatableComponentProps
+      | SelectComponentProps = {
+      menuIsOpen,
+      initialValues,
+      defaultValue,
+      value,
+      isClearable,
+      placeholder: isLoading === true ? loadingText : placeholder,
+      isDisabled: isLoading === true || isDisabled === true,
+      onSelect,
+      isMulti,
+      isOptionDisabled,
+      onBlur,
+      name,
+      styles: getSelectStyles(feedback?.variant),
+      menuFooterText
+    }
+
     return (
       <InputWrapper
         className={className}
@@ -179,64 +204,33 @@ export const InputSelect = forwardRef<
         name={name}
         {...rest}
       >
-        {loadAsyncValues != null ? (
-          <AsyncSelectComponent
+        {loadAsyncValues != null && isCreatable === true ? (
+          <AsyncCreatableSelectComponent
+            {...commonProps}
             ref={ref}
-            menuIsOpen={menuIsOpen}
-            initialValues={initialValues}
-            defaultValue={defaultValue}
-            value={value}
-            isClearable={isClearable}
-            placeholder={isLoading === true ? loadingText : placeholder}
-            isDisabled={isLoading === true || isDisabled === true}
-            onSelect={onSelect}
-            isMulti={isMulti}
-            onBlur={onBlur}
-            name={name}
-            noOptionsMessage={noOptionsMessage}
             loadAsyncValues={loadAsyncValues}
-            styles={getSelectStyles(feedback?.variant)}
             debounceMs={debounceMs}
-            isOptionDisabled={isOptionDisabled}
-            menuFooterText={menuFooterText}
+            noOptionsMessage={noOptionsMessage}
+          />
+        ) : loadAsyncValues != null ? (
+          <AsyncSelectComponent
+            {...commonProps}
+            ref={ref}
+            loadAsyncValues={loadAsyncValues}
+            debounceMs={debounceMs}
+            noOptionsMessage={noOptionsMessage}
           />
         ) : isCreatable === true ? (
           <CreatableComponent
+            {...commonProps}
             ref={ref}
-            menuIsOpen={menuIsOpen}
-            initialValues={initialValues}
-            defaultValue={defaultValue}
-            value={value}
-            isClearable={isClearable}
-            placeholder={isLoading === true ? loadingText : placeholder}
-            isDisabled={isLoading === true || isDisabled === true}
             isSearchable={isSearchable}
-            onSelect={onSelect}
-            isMulti={isMulti}
-            isOptionDisabled={isOptionDisabled}
-            onBlur={onBlur}
-            name={name}
-            styles={getSelectStyles(feedback?.variant)}
-            menuFooterText={menuFooterText}
           />
         ) : (
           <SelectComponent
+            {...commonProps}
             ref={ref}
-            menuIsOpen={menuIsOpen}
-            initialValues={initialValues}
-            defaultValue={defaultValue}
-            value={value}
-            isClearable={isClearable}
-            placeholder={isLoading === true ? loadingText : placeholder}
-            isDisabled={isLoading === true || isDisabled === true}
             isSearchable={isSearchable}
-            onSelect={onSelect}
-            isMulti={isMulti}
-            isOptionDisabled={isOptionDisabled}
-            onBlur={onBlur}
-            name={name}
-            styles={getSelectStyles(feedback?.variant)}
-            menuFooterText={menuFooterText}
           />
         )}
       </InputWrapper>

--- a/packages/app-elements/src/ui/forms/InputSelect/SelectComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/SelectComponent.tsx
@@ -7,7 +7,7 @@ import Select, {
 import { type InputSelectProps, type InputSelectValue } from './InputSelect'
 import components from './overrides'
 
-interface SelectComponentProps
+export interface SelectComponentProps
   extends Omit<InputSelectProps, 'loadAsyncValues' | 'label' | 'hint'> {
   styles: StylesConfig<InputSelectValue>
 }

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -162,6 +162,30 @@ Creatable.args = {
 }
 
 /**
+ * It's possible to combine the `loadAsyncValues` prop with the `isCreatable` prop.
+ */
+export const AsyncCreatable = Template.bind({})
+AsyncCreatable.args = {
+  label: 'Search resource',
+  placeholder: 'Type to search async...',
+  isSearchable: true,
+  isCreatable: true,
+  isClearable: false,
+  debounceMs: 200,
+  hint: {
+    icon: 'lightbulbFilament',
+    text: 'Try to search some of the following values: customer, SKU, price, tax or any other text'
+  },
+  loadAsyncValues: async (hint) => {
+    return await new Promise<InputSelectValue[]>((resolve) => {
+      setTimeout(() => {
+        resolve(fakeSearch(hint))
+      }, 1000)
+    })
+  }
+}
+
+/**
  * Options can be grouped by passing an array of objects with `label` and `options` properties.
  */
 export const GroupedOptions = Template.bind({})


### PR DESCRIPTION
## What I did

I managed the `async-creatable` component from react-select directly inside the `InputSelect`.

https://github.com/user-attachments/assets/89451353-6855-42d7-8556-8f30d93d26f3

## How to test

https://deploy-preview-716--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputselect--docs#async%20creatable
