### PR TITLE
Add props to control each single input in date range component

### DIFF
--- a/packages/app-elements/src/ui/forms/InputDateRange/HookedInputDateRange.tsx
+++ b/packages/app-elements/src/ui/forms/InputDateRange/HookedInputDateRange.tsx
@@ -1,5 +1,6 @@
+import get from 'lodash/get'
 import { Controller, useFormContext } from 'react-hook-form'
-import { useValidationFeedback } from '../ReactHookForm'
+import { type InputFeedbackProps } from '../InputFeedback'
 import { InputDateRange, type InputDateRangeProps } from './InputDateRange'
 
 export interface HookedInputDateRangeProps
@@ -20,8 +21,37 @@ export function HookedInputDateRange({
   name,
   ...props
 }: HookedInputDateRangeProps): JSX.Element {
-  const { control } = useFormContext()
-  const feedback = useValidationFeedback(name)
+  const { control, formState } = useFormContext()
+
+  const errors = get(formState.errors, name)
+  const feedbackVariant: InputFeedbackProps['variant'] = 'danger'
+
+  // Since the component value is a tuple, you could end up to receive an array of validation errors.
+  // Especially when only one of the two dates is invalid.
+  const errorMessageFrom =
+    Array.isArray(errors) && typeof errors[0]?.message === 'string'
+      ? {
+          message: errors[0]?.message as string,
+          variant: feedbackVariant
+        }
+      : undefined
+  const errorMessageTo =
+    Array.isArray(errors) && typeof errors[1]?.message === 'string'
+      ? {
+          message: errors[1]?.message as string,
+          variant: feedbackVariant
+        }
+      : undefined
+
+  // When the value is nullish, the error is single object and not an array.
+  // In this case we handle it as single error message shared between the two inputs and displayed at the bottom.
+  const errorMessageGeneric =
+    typeof errors?.message === 'string'
+      ? {
+          message: errors.message,
+          variant: feedbackVariant
+        }
+      : undefined
 
   return (
     <Controller
@@ -33,7 +63,9 @@ export function HookedInputDateRange({
           onChange={onChange}
           value={value}
           ref={ref}
-          feedback={feedback}
+          fromFeedback={errorMessageFrom}
+          toFeedback={errorMessageTo}
+          feedback={errorMessageGeneric}
         />
       )}
     />

--- a/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
+++ b/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
@@ -3,6 +3,7 @@ import {
   type InputWrapperBaseProps
 } from '#ui/internals/InputWrapper'
 import { ArrowRight } from '@phosphor-icons/react'
+import classNames from 'classnames'
 import { forwardRef, useEffect } from 'react'
 import { InputDate } from '../InputDate'
 import {
@@ -11,24 +12,33 @@ import {
 } from '../InputDate/InputDateComponent'
 
 export interface InputDateRangeProps
-  extends Pick<InputDateProps, 'isClearable' | 'format' | 'autoPlaceholder'>,
+  extends Pick<
+      InputDateProps,
+      'isClearable' | 'format' | 'autoPlaceholder' | 'showTimeSelect'
+    >,
     InputWrapperBaseProps {
-  /**
-   * a tuple that represents the [from, to] dates
-   */
+  /** a tuple that represents the [from, to] dates */
   value: [MaybeDate, MaybeDate]
-  /**
-   * callback triggered when one of the two dates changes
-   */
+  /** callback triggered when one of the two dates changes */
   onChange: (dates: [MaybeDate, MaybeDate]) => void
-  /**
-   * optional placeholder text for the `from` date
-   */
+
+  /** label to be displayed on the `from` date input. */
+  fromLabel?: string
+  /** optional placeholder text for the `from` date  */
   fromPlaceholder?: string
-  /**
-   * optional placeholder text for the `to` date
-   */
+  /** optional hint text for the `from` date  */
+  fromHint?: InputWrapperBaseProps['hint']
+  /** label to be displayed on the `to` date input */
+  /** optional feedback message for the `from` date  */
+  fromFeedback?: InputWrapperBaseProps['feedback']
+
+  toLabel?: string
+  /** optional placeholder text for the `to` date */
   toPlaceholder?: string
+  /** optional hint text for the `to` date  */
+  toHint?: InputWrapperBaseProps['hint']
+  /** optional feedback message for the `to` date  */
+  toFeedback?: InputWrapperBaseProps['feedback']
 }
 
 export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
@@ -44,6 +54,13 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
       onChange,
       hint,
       feedback,
+      showTimeSelect,
+      fromLabel,
+      toLabel,
+      fromHint,
+      toHint,
+      fromFeedback,
+      toFeedback,
       ...rest
     },
     ref
@@ -63,9 +80,16 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
       [fromDate]
     )
 
+    const hasSingleLabels = fromLabel != null || toLabel != null
+
     return (
       <InputWrapper label={label} hint={hint} feedback={feedback} {...rest}>
-        <div className='flex items-center'>
+        <div
+          className={classNames('flex', {
+            'items-center': !hasSingleLabels,
+            'items-start': hasSingleLabels
+          })}
+        >
           <InputDate
             value={fromDate}
             onChange={(newDate) => {
@@ -76,10 +100,13 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
             wrapperClassName='flex-1'
             isClearable={isClearable}
             autoPlaceholder={autoPlaceholder}
-            feedback={feedback}
+            feedback={fromFeedback}
+            showTimeSelect={showTimeSelect}
+            label={fromLabel}
+            hint={fromHint}
           />
-          <div className='px-2 text-gray-300'>
-            <ArrowRight size={24} />
+          <div className='px-4 text-gray-300'>
+            {hasSingleLabels ? null : <ArrowRight size={24} />}
           </div>
           <InputDate
             value={toDate}
@@ -92,7 +119,10 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
             wrapperClassName='flex-1'
             isClearable={isClearable}
             autoPlaceholder={autoPlaceholder}
-            feedback={feedback}
+            feedback={toFeedback}
+            showTimeSelect={showTimeSelect}
+            label={toLabel}
+            hint={toHint}
           />
         </div>
       </InputWrapper>

--- a/packages/docs/src/stories/forms/ui/InputDateRange.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputDateRange.stories.tsx
@@ -51,3 +51,23 @@ WithHint.args = {
   fromPlaceholder: 'Start date...',
   hint: { text: 'Please enter a valid date range' }
 }
+
+/**
+ * When passing specific labels for the two fields (from and to), the component will be rendered without the middle arrow icon.
+ * And each field will have its own label.
+ */
+export const WithIndividualLabels = Template.bind({})
+WithIndividualLabels.args = {
+  fromLabel: 'Start date',
+  fromHint: { text: 'Please enter the start date' },
+  toLabel: 'End date',
+  toHint: { text: 'Please enter the end date' }
+}
+
+export const WithIndividualErrors = Template.bind({})
+WithIndividualErrors.args = {
+  fromLabel: 'Start date',
+  toLabel: 'End date',
+  fromFeedback: { message: 'Invalid start date', variant: 'danger' },
+  toFeedback: { message: 'Invalid end date', variant: 'danger' }
+}


### PR DESCRIPTION
## What I did

Now it's possible to set single labels for start and end date of the `InputDateRange` component.

Preview:
https://deploy-preview-721--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputdaterange--docs#with%20individual%20labels

By default you can pass a single (shared) `label` and the component renders as it always rendered
<img width="695" alt="image" src="https://github.com/user-attachments/assets/02bf89a8-46aa-4ea0-89be-d5d04dc0f070">

But now it's possible to specify different labels, hints and validation messages:

<img width="692" alt="image" src="https://github.com/user-attachments/assets/15b0856d-27ce-48a6-924b-7105c69f7cdf">

<img width="670" alt="image" src="https://github.com/user-attachments/assets/c5b9e125-ce22-4bc2-b29e-554f4257f79f">

 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
