### PR TITLE
Add clickable related padding behavior to `ResourceListItem`

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -49,6 +49,8 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
     onClick,
     showRightContent = false
   }) => {
+    const isClickable = href != null || onClick != null
+
     return (
       <ListItem
         icon={icon}
@@ -56,6 +58,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
         data-testid='ResourceListItem'
         href={href}
         onClick={onClick}
+        padding={isClickable ? 'xy' : 'y'}
       >
         <div>
           <Text
@@ -78,7 +81,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
         <div>
           {showRightContent
             ? rightContent
-            : onClick != null && <StatusIcon name='caretRight' />}
+            : isClickable && <StatusIcon name='caretRight' />}
         </div>
       </ListItem>
     )


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

According to design I introduced a new behavior of `ResourceListItem` to automate the padding setup of its `ListItem` based on whether the component is clickable or not.

Clickable items will have both horizontal and vertical padding:

<img width="600" alt="Screenshot 2024-09-09 alle 10 00 00" src="https://github.com/user-attachments/assets/af5a1c2c-5291-4f0b-a64f-62496127cc77">

Non clickable items will have just vertical padding:

<img width="600" alt="Screenshot 2024-09-09 alle 10 00 38" src="https://github.com/user-attachments/assets/6c3708c7-91a2-4312-81f9-54eca8563411">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
