### PR TITLE
Allow to pass encoded `extras` to TokenProvider from URL query

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -64,8 +64,10 @@ export { GTMProvider, useTagManager } from '#providers/GTMProvider'
 export {
   MetaTags,
   TokenProvider,
+  encodeExtras,
   useTokenProvider,
   type TokenProviderAllowedApp,
+  type TokenProviderExtras,
   type TokenProviderPermissionItem,
   type TokenProviderRoleActions,
   type TokenProviderRolePermissions,

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -19,7 +19,7 @@ import {
 } from './getAccessTokenFromUrl'
 import { getOrganization } from './getOrganization'
 import { initialTokenProviderState, reducer } from './reducer'
-import { getPersistentAccessToken, savePersistentAccessToken } from './storage'
+import { getPersistentJWT, savePersistentJWT } from './storage'
 import type {
   TokenProviderAllowedApp,
   TokenProviderAuthSettings,
@@ -144,7 +144,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
   const accessToken =
     accessTokenFromProp ??
     getAccessTokenFromUrl() ??
-    getPersistentAccessToken({ appSlug, organizationSlug })
+    getPersistentJWT({ appSlug, organizationSlug, itemType: 'accessToken' })
 
   const extras = extrasFromProp ?? decodeExtras(getExtrasFromUrl())
 
@@ -221,10 +221,11 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
             : null
 
         // all good
-        savePersistentAccessToken({
+        savePersistentJWT({
           appSlug,
-          accessToken,
-          organizationSlug
+          jwt: accessToken,
+          organizationSlug,
+          itemType: 'accessToken'
         })
         removeAuthParamsFromUrl()
 

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -146,7 +146,10 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
     getAccessTokenFromUrl() ??
     getPersistentJWT({ appSlug, organizationSlug, itemType: 'accessToken' })
 
-  const extras = extrasFromProp ?? decodeExtras(getExtrasFromUrl())
+  const encodeExtras =
+    getExtrasFromUrl() ??
+    getPersistentJWT({ appSlug, organizationSlug, itemType: 'extras' })
+  const extras = extrasFromProp ?? decodeExtras(encodeExtras)
 
   const dashboardUrl = makeDashboardUrl({
     domain,
@@ -227,6 +230,16 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
           organizationSlug,
           itemType: 'accessToken'
         })
+
+        if (encodeExtras != null) {
+          savePersistentJWT({
+            appSlug,
+            jwt: encodeExtras,
+            organizationSlug,
+            itemType: 'extras'
+          })
+        }
+
         removeAuthParamsFromUrl()
 
         dispatch({

--- a/packages/app-elements/src/providers/TokenProvider/extras.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/extras.test.ts
@@ -17,7 +17,7 @@ describe('TokenProviderExtras encoding and decoding', () => {
 
   test('should encode extras to a Base64 string', () => {
     expect(encodeExtras(extras)).toBe(
-      'JTdCJTIyc2FsZXNDaGFubmVscyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJDaGFubmVsMSUyMiUyQyUyMmNsaWVudF9pZCUyMiUzQSUyMmNsaWVudDElMjIlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyQ2hhbm5lbDIlMjIlMkMlMjJjbGllbnRfaWQlMjIlM0ElMjJjbGllbnQyJTIyJTdEJTVEJTJDJTIybGltaXRzJTIyJTNBJTdCJTIybWFya2V0cyUyMiUzQTUlMkMlMjJtZW1iZXJzaGlwcyUyMiUzQTEwJTJDJTIyb3JnYW5pemF0aW9ucyUyMiUzQTMlMkMlMjJza3VzJTIyJTNBMTAwMCU3RCU3RA=='
+      'eyJzYWxlc0NoYW5uZWxzIjpbeyJuYW1lIjoiQ2hhbm5lbDEiLCJjbGllbnRfaWQiOiJjbGllbnQxIn0seyJuYW1lIjoiQ2hhbm5lbDIiLCJjbGllbnRfaWQiOiJjbGllbnQyIn1dLCJsaW1pdHMiOnsibWFya2V0cyI6NSwibWVtYmVyc2hpcHMiOjEwLCJvcmdhbml6YXRpb25zIjozLCJza3VzIjoxMDAwfX0'
     )
   })
 
@@ -72,8 +72,8 @@ describe('getExtrasFromUrl', () => {
   })
 
   test('accessToken exists in URL params', () => {
-    window.location.search = '?extras=JTdCJTIyc2FsZXNDaGFubmVscyUy'
-    expect(getExtrasFromUrl()).toBe('JTdCJTIyc2FsZXNDaGFubmVscyUy')
+    window.location.search = '?extras=eyJzYWxlc0NoYW5uZWxzIjpbeyJuYW1lIjoiQ'
+    expect(getExtrasFromUrl()).toBe('eyJzYWxlc0NoYW5uZWxzIjpbeyJuYW1lIjoiQ')
   })
 })
 

--- a/packages/app-elements/src/providers/TokenProvider/extras.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/extras.test.ts
@@ -1,0 +1,118 @@
+import { decodeExtras, encodeExtras, getExtrasFromUrl } from './extras'
+import type { TokenProviderExtras } from './types'
+
+describe('TokenProviderExtras encoding and decoding', () => {
+  const extras: TokenProviderExtras = {
+    salesChannels: [
+      { name: 'Channel1', client_id: 'client1' },
+      { name: 'Channel2', client_id: 'client2' }
+    ],
+    limits: {
+      markets: 5,
+      memberships: 10,
+      organizations: 3,
+      skus: 1000
+    }
+  }
+
+  test('should encode extras to a Base64 string', () => {
+    expect(encodeExtras(extras)).toBe(
+      'JTdCJTIyc2FsZXNDaGFubmVscyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJDaGFubmVsMSUyMiUyQyUyMmNsaWVudF9pZCUyMiUzQSUyMmNsaWVudDElMjIlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyQ2hhbm5lbDIlMjIlMkMlMjJjbGllbnRfaWQlMjIlM0ElMjJjbGllbnQyJTIyJTdEJTVEJTJDJTIybGltaXRzJTIyJTNBJTdCJTIybWFya2V0cyUyMiUzQTUlMkMlMjJtZW1iZXJzaGlwcyUyMiUzQTEwJTJDJTIyb3JnYW5pemF0aW9ucyUyMiUzQTMlMkMlMjJza3VzJTIyJTNBMTAwMCU3RCU3RA=='
+    )
+  })
+
+  test('should decode a Base64 string back to the original extras object', () => {
+    const encoded = encodeExtras(extras)
+    const decoded = decodeExtras(encoded)
+    expect(decoded).toEqual(extras)
+  })
+
+  test('should handle empty extras object', () => {
+    const encoded = encodeExtras({})
+    const decoded = decodeExtras(encoded)
+    expect(decoded).toEqual({})
+  })
+
+  test('should handle extras with only salesChannels', () => {
+    const salesChannelsOnly: TokenProviderExtras = {
+      salesChannels: [{ name: 'Channel1', client_id: 'client1' }]
+    }
+    const encoded = encodeExtras(salesChannelsOnly)
+    const decoded = decodeExtras(encoded)
+    expect(decoded).toEqual(salesChannelsOnly)
+  })
+
+  test('should handle extras with only limits', () => {
+    const limitsOnly: TokenProviderExtras = {
+      limits: {
+        markets: 5,
+        memberships: 10,
+        organizations: 3,
+        skus: 1000
+      }
+    }
+    const encoded = encodeExtras(limitsOnly)
+    const decoded = decodeExtras(encoded)
+    expect(decoded).toEqual(limitsOnly)
+  })
+})
+
+describe('getExtrasFromUrl', () => {
+  const { location } = window
+  beforeAll(function clearLocation() {
+    delete (window as any).location
+    ;(window as any).location = {
+      ...location,
+      href: 'http://domain.com',
+      search: ''
+    }
+  })
+  afterAll(function resetLocation() {
+    window.location = location
+  })
+
+  test('accessToken exists in URL params', () => {
+    window.location.search = '?extras=JTdCJTIyc2FsZXNDaGFubmVscyUy'
+    expect(getExtrasFromUrl()).toBe('JTdCJTIyc2FsZXNDaGFubmVscyUy')
+  })
+})
+
+describe('Encode object > Add in URL query string > Decode it from URL', () => {
+  const { location } = window
+  beforeAll(function clearLocation() {
+    delete (window as any).location
+    ;(window as any).location = {
+      ...location,
+      href: 'http://domain.com',
+      search: ''
+    }
+  })
+  afterAll(function resetLocation() {
+    window.location = location
+  })
+
+  test('extras exists in URL params', () => {
+    const extras: TokenProviderExtras = {
+      salesChannels: [
+        { name: 'Channel1', client_id: 'client1' },
+        { name: 'Channel2', client_id: 'client2' }
+      ],
+      limits: {
+        markets: 5,
+        memberships: 10,
+        organizations: 3,
+        skus: 1000
+      }
+    }
+
+    const encoded = encodeExtras(extras)
+    window.location.search = `?extras=${encoded}&foo=bar`
+    const decoded = decodeExtras(getExtrasFromUrl())
+    expect(decoded).toEqual(extras)
+  })
+
+  test('extras does not exists in URL params', () => {
+    window.location.search = '?foo=bar'
+    expect(decodeExtras(getExtrasFromUrl())).toEqual(undefined)
+  })
+})

--- a/packages/app-elements/src/providers/TokenProvider/extras.ts
+++ b/packages/app-elements/src/providers/TokenProvider/extras.ts
@@ -1,0 +1,50 @@
+import isEmpty from 'lodash/isEmpty'
+import type { TokenProviderExtras } from './types'
+
+/**
+ * Encodes the given extras object into a Base64 string.
+ * This ensures that the encoded string is safe for use in URLs.
+ *
+ * @param extras - The extras object to encode.
+ * @returns The Base64 encoded string representation of the extras object.
+ */
+export function encodeExtras(extras: TokenProviderExtras): string {
+  const jsonString = encodeURIComponent(JSON.stringify(extras))
+
+  return typeof window !== 'undefined'
+    ? window.btoa(jsonString)
+    : Buffer.from(jsonString).toString('base64')
+}
+
+/**
+ * Decodes the given Base64 string back into the original extras object,
+ * which was encoded using `encodeExtras`.
+ *
+ * @param encodedExtras - The Base64 encoded string representation of the extras object.
+ * @returns The decoded extras object.
+ */
+export function decodeExtras(
+  encodedExtras?: string
+): TokenProviderExtras | undefined {
+  if (encodedExtras == null) {
+    return undefined
+  }
+
+  const jsonString =
+    typeof window !== 'undefined'
+      ? window.atob(encodedExtras)
+      : Buffer.from(encodedExtras, 'base64').toString('utf-8')
+
+  return JSON.parse(decodeURIComponent(jsonString))
+}
+
+/**
+ * Try to get the extras value from the URL params.
+ */
+export const getExtrasFromUrl = (): string | undefined => {
+  if (typeof window !== 'undefined') {
+    const params = new URLSearchParams(window.location.search)
+    const extras = params.get('extras')
+    return isEmpty(extras) || extras == null ? undefined : extras
+  }
+}

--- a/packages/app-elements/src/providers/TokenProvider/extras.ts
+++ b/packages/app-elements/src/providers/TokenProvider/extras.ts
@@ -57,9 +57,9 @@ const base64URLSafe = {
           .replaceAll('/', '_')
       )
     }
-
     return Buffer.from(stringToEncode, 'binary').toString('base64url')
   },
+
   decode: (encodedData: string): string => {
     if (typeof atob !== 'undefined') {
       return atob(
@@ -69,7 +69,6 @@ const base64URLSafe = {
           .replaceAll('_', '/')
       )
     }
-
     return Buffer.from(encodedData, 'base64url').toString('binary')
   }
 }

--- a/packages/app-elements/src/providers/TokenProvider/extras.ts
+++ b/packages/app-elements/src/providers/TokenProvider/extras.ts
@@ -20,7 +20,7 @@ export function encodeExtras(extras: TokenProviderExtras): string {
  * @returns The decoded extras object.
  */
 export function decodeExtras(
-  encodedExtras?: string
+  encodedExtras?: string | null
 ): TokenProviderExtras | undefined {
   if (encodedExtras == null) {
     return undefined

--- a/packages/app-elements/src/providers/TokenProvider/getAccessTokenFromUrl.ts
+++ b/packages/app-elements/src/providers/TokenProvider/getAccessTokenFromUrl.ts
@@ -44,6 +44,7 @@ export const removeAuthParamsFromUrl = (): void => {
   if (typeof window !== 'undefined') {
     const url = new URL(window.location.href)
     url.searchParams.delete('accessToken')
+    url.searchParams.delete('extras')
     url.searchParams.delete('mode')
     window.history.replaceState({}, '', url.toString())
   }

--- a/packages/app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/index.tsx
@@ -1,10 +1,12 @@
+export { encodeExtras } from './extras'
 export { MetaTags } from './MetaTags'
 export { TokenProvider, useTokenProvider } from './TokenProvider'
-export {
-  type TokenProviderAllowedApp,
-  type TokenProviderPermissionItem,
-  type TokenProviderRoleActions,
-  type TokenProviderRolePermissions,
-  type TokenProviderTokenApplicationKind
+export type {
+  TokenProviderAllowedApp,
+  TokenProviderExtras,
+  TokenProviderPermissionItem,
+  TokenProviderRoleActions,
+  TokenProviderRolePermissions,
+  TokenProviderTokenApplicationKind
 } from './types'
 //

--- a/packages/app-elements/src/providers/TokenProvider/storage.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/storage.test.ts
@@ -1,23 +1,34 @@
-import { getPersistentAccessToken } from '#providers/TokenProvider/storage'
-import { makeStorageKey, savePersistentAccessToken } from './storage'
+import { getPersistentJWT, makeStorageKey, savePersistentJWT } from './storage'
 
 describe('makeStorageKey', () => {
-  test('should return the storage key for clientId', () => {
+  test('should return the storage key for access token', () => {
     const key = makeStorageKey({
       appSlug: 'imports',
-      organizationSlug: 'myorg'
+      organizationSlug: 'myorg',
+      itemType: 'accessToken'
     })
 
     expect(key).to.equal('imports:myorg:accessToken')
   })
+
+  test('should return the storage key for extras', () => {
+    const key = makeStorageKey({
+      appSlug: 'imports',
+      organizationSlug: 'myorg',
+      itemType: 'extras'
+    })
+
+    expect(key).to.equal('imports:myorg:extras')
+  })
 })
 
-describe('getPersistentAccessToken', () => {
+describe('getPersistentJWT', () => {
   test('should retrieve the access token by inferring organization slug from URL', () => {
     localStorage.setItem('orders:commercelayer:accessToken', 'pre-saved-token')
     expect(
-      getPersistentAccessToken({
-        appSlug: 'orders'
+      getPersistentJWT({
+        appSlug: 'orders',
+        itemType: 'accessToken'
       })
     ).toBe('pre-saved-token')
   })
@@ -25,9 +36,10 @@ describe('getPersistentAccessToken', () => {
   test('should retrieve the access token by using specific organization slug, ignoring URL', () => {
     localStorage.setItem('orders:the-red-store:accessToken', 'pre-saved-token2')
     expect(
-      getPersistentAccessToken({
+      getPersistentJWT({
         appSlug: 'orders',
-        organizationSlug: 'the-red-store'
+        organizationSlug: 'the-red-store',
+        itemType: 'accessToken'
       })
     ).toBe('pre-saved-token2')
   })
@@ -35,10 +47,11 @@ describe('getPersistentAccessToken', () => {
 
 describe('savePersistentAccessToken', () => {
   test('should save the access token by using specific organization slug', () => {
-    savePersistentAccessToken({
-      accessToken: 'myAccessToken2',
+    savePersistentJWT({
+      jwt: 'myAccessToken2',
       appSlug: 'shipments',
-      organizationSlug: 'blue-store'
+      organizationSlug: 'blue-store',
+      itemType: 'accessToken'
     })
     expect(localStorage.getItem('shipments:demo-store:accessToken')).toBe(null)
     expect(localStorage.getItem('shipments:blue-store:accessToken')).toBe(

--- a/packages/app-elements/src/providers/TokenProvider/storage.ts
+++ b/packages/app-elements/src/providers/TokenProvider/storage.ts
@@ -1,23 +1,30 @@
 import { type TokenProviderAllowedApp } from './types'
 
+type ItemType = 'accessToken' | 'extras'
+
 export function makeStorageKey({
   appSlug,
-  organizationSlug
+  organizationSlug,
+  itemType
 }: {
   appSlug: TokenProviderAllowedApp
   organizationSlug: string
+  itemType: ItemType
 }): string {
-  return `${appSlug}:${organizationSlug}:accessToken`
+  return `${appSlug}:${organizationSlug}:${itemType}`
 }
 
-export function getPersistentAccessToken({
+export function getPersistentJWT({
   appSlug,
-  organizationSlug = 'commercelayer'
+  organizationSlug = 'commercelayer',
+  itemType
 }: {
   /** The app for which to get the token. */
   appSlug: TokenProviderAllowedApp
   /** The organization slug for the token we want to retrieve. */
   organizationSlug?: string
+  /** The JWT item type you want to retrieve. */
+  itemType: ItemType
 }): string | null {
   if (typeof window === 'undefined') {
     return null
@@ -26,23 +33,27 @@ export function getPersistentAccessToken({
   const storedAccessToken = window.localStorage.getItem(
     makeStorageKey({
       appSlug,
-      organizationSlug
+      organizationSlug,
+      itemType
     })
   )
   return storedAccessToken
 }
 
-export function savePersistentAccessToken({
+export function savePersistentJWT({
   appSlug,
-  accessToken,
-  organizationSlug = 'commercelayer'
+  jwt,
+  organizationSlug = 'commercelayer',
+  itemType
 }: {
   /** The app for which to get the token. */
   appSlug: TokenProviderAllowedApp
   /** The token to save. */
-  accessToken: string
+  jwt: string
   /** The organization slug for the token we want to store. */
   organizationSlug?: string
+  /** The JWT item type you want to store. */
+  itemType: ItemType
 }): void {
   if (typeof window === 'undefined') {
     return
@@ -51,8 +62,9 @@ export function savePersistentAccessToken({
   window.localStorage.setItem(
     makeStorageKey({
       appSlug,
-      organizationSlug
+      organizationSlug,
+      itemType
     }),
-    accessToken
+    jwt
   )
 }

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -1,5 +1,5 @@
-import { type ParsedScopes } from '#providers/TokenProvider/getInfoFromJwt'
-import { type ListableResourceType } from '@commercelayer/sdk'
+import type { ParsedScopes } from '#providers/TokenProvider/getInfoFromJwt'
+import type { ListableResourceType } from '@commercelayer/sdk'
 
 export type TokenProviderAllowedApp =
   | 'bundles'
@@ -150,9 +150,7 @@ export interface TokenProviderAuthSettings {
   /**
    * Extra data received from the outside and made available in the app.
    */
-  extras?: {
-    salesChannels?: Array<{ name: string; client_id: string }>
-  }
+  extras?: TokenProviderExtras
 }
 
 export interface TokenProviderAuthUser {
@@ -163,4 +161,16 @@ export interface TokenProviderAuthUser {
   displayName: string
   fullName: string
   timezone: string
+}
+
+export interface TokenProviderExtras {
+  /** List of sales channel to be used inside the app. */
+  salesChannels?: Array<{ name: string; client_id: string }>
+  /** Current user plan limits, received from provisioning API subscription, when available. */
+  limits?: {
+    markets?: number
+    memberships?: number
+    organizations?: number
+    skus?: number
+  }
 }


### PR DESCRIPTION
Closes commercelayer/issues-app#168

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did


TokenProvider `extras` can now also be passed to the app as an encoded (base64) string in URL parameters.
To do so I've added a `encodeExtras` helper method that can be used to prepare the encoded string

Example:
```ts
encodeExtras({
  salesChannels: [
    { name: 'Channel1', client_id: 'client1' },
    { name: 'Channel2', client_id: 'client2' }
  ],
  limits: {
    markets: 5,
    memberships: 10,
    organizations: 3,
    skus: 1000
  }
})

// will output eyJzYWxlc0NoYW5uZ...uYW1lIjoiQ2hhbm
```

When an `extras` is present, it will adopt a similar persistent behavior as done for the access token: 
- saved in a local storage key (in the format of `sku_lsits:demo-store:extras` )
- removed from URL

When TokenProvider is initialized it will check if extras are present in the following order:
- from init prop (as object with the shape of `TokenProviderExtras`)
- from URL query string param (as encoded string)
- from local storage (as encoded string)

If `extras` are found, they will be made available within the Token Provider context.



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
