### PR TITLE
Add overlay behavior to `ListItem` padding

### DIFF
--- a/packages/app-elements/src/ui/composite/ListItem.tsx
+++ b/packages/app-elements/src/ui/composite/ListItem.tsx
@@ -77,12 +77,18 @@ export const ListItem: FC<ListItemProps> = ({
     'px-2': paddingSize === '2'
   })
 
+  const overlayPxSize = cn({
+    '[.overlay-container_&]:px-6': paddingSize === '6',
+    '[.overlay-container_&]:px-4': paddingSize === '4',
+    '[.overlay-container_&]:px-2': paddingSize === '2'
+  })
   return (
     <JsxTag
       className={cn(
         'flex gap-4 w-full',
         'text-gray-800 hover:text-gray-800', // keep default text color also when used as `<a>` tag
         {
+          [overlayPxSize]: padding === 'y',
           [pySize]: padding !== 'none' && padding !== 'x',
           [pxSize]: padding !== 'none' && padding !== 'y',
           'border-b': borderStyle !== 'none',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Forced overlay behavior to `ListItem` horizontal padding to have it always defined in the idea of `ListItem`s always used inside Cards or Boxed ResourceLists inside `overlay`s.

<img width="500" alt="Screenshot 2024-09-11 alle 17 30 08" src="https://github.com/user-attachments/assets/55f97281-5a35-472b-9b09-1527b09676f4">


This enforcement became necessary after the introduction of the new padding behavior in `ResourceListItem` to remove side padding for non clickable items.

This is just a little example about how it would be important to have a more robust ruling about how to deal with lists and list items in their multiple use cases.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
