### PR TITLE
Allow to set a disabled button on Toolbar

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -17,6 +17,7 @@ export type DropdownItemProps = React.HTMLAttributes<HTMLElement> & {
       }
     | {
         href?: never
+        disabled?: boolean
       }
   )
 
@@ -37,10 +38,16 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
       [href, onClick]
     )
 
+    const isDisabled = Boolean('disabled' in rest && rest.disabled)
+
     return (
       <JsxTag
         {...rest}
-        onClick={onClick}
+        onClick={(e) => {
+          if (!isDisabled) {
+            onClick?.(e)
+          }
+        }}
         href={href}
         className={cn(
           'w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none',
@@ -48,7 +55,8 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
           {
             'hover:bg-primary cursor-pointer focus:bg-primary':
               onClick != null || href != null,
-            'cursor-default': onClick == null && href == null
+            'cursor-default': onClick == null && href == null,
+            'opacity-50 pointer-events-none': isDisabled
           }
         )}
         aria-label={label}

--- a/packages/app-elements/src/ui/composite/Toolbar.tsx
+++ b/packages/app-elements/src/ui/composite/Toolbar.tsx
@@ -15,6 +15,7 @@ export interface ToolbarItem {
   variant?: ButtonProps['variant']
   className?: ButtonProps['className']
   onClick?: ButtonProps['onClick']
+  disabled?: ButtonProps['disabled']
   /**
    * Dropdown items nested into current item.
    * If they are set, the current item will be rendered as a `Dropdown` that can be opened by clicking the `Button` configure using current item's props.
@@ -57,6 +58,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
               className={dropdownItem.className}
               onClick={dropdownItemHandleClick}
               data-testid='toolbar-dropdown-item'
+              disabled={dropdownItem.href == null && dropdownItem.disabled}
             />
           )
         })
@@ -72,6 +74,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
                 key={`button-${idx}`}
                 size={item.size}
                 variant={item.variant}
+                disabled={item.disabled}
                 onClick={handleClick}
                 alignItems='center'
                 className={item.className}
@@ -94,6 +97,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
           key={`button-${idx}`}
           size={item.size}
           variant={item.variant}
+          disabled={item.disabled}
           onClick={handleClick}
           alignItems='center'
           className={item.className}

--- a/packages/docs/src/stories/composite/Toolbar.stories.tsx
+++ b/packages/docs/src/stories/composite/Toolbar.stories.tsx
@@ -30,6 +30,16 @@ Simple.args = {
       }
     },
     {
+      label: 'Disabled',
+      icon: 'pulse',
+      variant: 'secondary',
+      size: 'small',
+      disabled: true,
+      onClick: () => {
+        console.log('Cannot click me')
+      }
+    },
+    {
       icon: 'dotsThree',
       size: 'small',
       variant: 'secondary',
@@ -45,6 +55,13 @@ Simple.args = {
             label: 'Set metadata',
             onClick: () => {
               console.log('Set metadata')
+            }
+          },
+          {
+            label: 'Disabled item',
+            disabled: true,
+            onClick: () => {
+              console.log('Cannot click me')
             }
           }
         ],


### PR DESCRIPTION
## What I did

A toolbar button can now have the `disabled` prop set as true as a regular `<Button>`.
<img width="435" alt="image" src="https://github.com/user-attachments/assets/86cd7564-7c7c-49a2-bba5-4744ca35cd7b">

Also a dropdown item can be set as disabled, but this is just for consistency since every click on the dropdown now closes the menu (if this behavior needs to be changed, it should be addressed in a different PR)

<img width="173" alt="image" src="https://github.com/user-attachments/assets/5551654a-f366-44c9-891c-9924ff0bad02">



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
