### PR TITLE
Replace old `focus` color with new `primary` color

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/styles.ts
+++ b/packages/app-elements/src/ui/forms/InputSelect/styles.ts
@@ -31,7 +31,7 @@ export const getSelectStyles = (
     fontWeight: 500,
     cursor: 'pointer',
     '&:active': {
-      backgroundColor: isSelected ? '#666EFF' : 'rgb(248 248 248)'
+      backgroundColor: isSelected ? '#101111' : 'rgb(248 248 248)'
     },
     '&:first-of-type': {
       borderTopLeftRadius: 5,
@@ -95,7 +95,7 @@ export const getSelectStyles = (
     '> button:focus-within': {
       color: 'black',
       outline: 'none',
-      boxShadow: '0 0 0 2px #666EFF'
+      boxShadow: '0 0 0 2px #101111'
     }
   }),
   control: (style) => {
@@ -143,7 +143,7 @@ export const getSelectStyles = (
     },
     '> button:focus-within': {
       outline: 'none',
-      boxShadow: '0 0 0 2px #666EFF'
+      boxShadow: '0 0 0 2px #101111'
     }
   })
 })

--- a/packages/app-elements/src/ui/forms/InputSpinner/InputSpinner.tsx
+++ b/packages/app-elements/src/ui/forms/InputSpinner/InputSpinner.tsx
@@ -77,7 +77,7 @@ export const InputSpinner = forwardRef<HTMLInputElement, InputSpinnerProps>(
             className,
             'flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white',
             'shadow-[0_0_0_1px_#e6e7e7_inset]',
-            'focus-within:shadow-[0_0_0_2px_#666eff_inset]'
+            'focus-within:shadow-[0_0_0_2px_#101111_inset]'
           )}
         >
           <ButtonSpin

--- a/packages/app-elements/src/ui/internals/InputWrapper.tsx
+++ b/packages/app-elements/src/ui/internals/InputWrapper.tsx
@@ -158,7 +158,7 @@ export function getFeedbackCssInJs(
       return {
         boxShadow: 'inset 0 0 0 1px #E6E7E7',
         '&:focus-within': {
-          boxShadow: 'inset 0 0 0 2px #666EFF'
+          boxShadow: 'inset 0 0 0 2px #101111'
         }
       }
   }

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -98,7 +98,7 @@ exports[`ResourceLineItems > should disable the remove action when \`onSwap\` is
                     class="justify-self-end"
                   >
                     <div
-                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#666eff_inset]"
+                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
                     >
                       <button
                         class="p-2 mx-1 text-xl relative bg-white rounded !outline-offset-0 active:top-[1px]"
@@ -532,7 +532,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
                     class="justify-self-end"
                   >
                     <div
-                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#666eff_inset]"
+                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
                     >
                       <button
                         class="p-2 mx-1 text-xl relative bg-white rounded !outline-offset-0 active:top-[1px]"
@@ -1206,7 +1206,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                     class="justify-self-end"
                   >
                     <div
-                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#666eff_inset]"
+                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
                     >
                       <button
                         class="p-2 mx-1 text-xl relative bg-white rounded !outline-offset-0 active:top-[1px]"
@@ -1463,7 +1463,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                     class="justify-self-end"
                   >
                     <div
-                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#666eff_inset]"
+                      class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
                     >
                       <button
                         class="p-2 mx-1 text-xl relative bg-white rounded !outline-offset-0 text-gray-300"

--- a/packages/app-elements/src/utils/text.test.ts
+++ b/packages/app-elements/src/utils/text.test.ts
@@ -9,7 +9,7 @@ describe('getDeterministicValue', () => {
   it('should return the same value for the same text', () => {
     const colors = [
       '#101111',
-      '#666EFF',
+      '#101111',
       '#055463',
       '#F40009',
       '#FF656B',

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -31,8 +31,8 @@ module.exports = {
     },
     boxShadow: {
       hover: '0 0 0 1px #101111',
-      focus: '0 0 0 2px #666EFF',
-      inputfocus: 'inset 0 0 0 2px #666EFF'
+      focus: '0 0 0 2px #101111',
+      inputfocus: 'inset 0 0 0 2px #101111'
     },
     colors: {
       inherit: 'inherit',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Replaced the old `focus` color to use new `primary` color: `#101111`.

<img width="500" alt="Screenshot 2024-09-16 alle 18 43 16" src="https://github.com/user-attachments/assets/779d2d30-d163-47e3-9656-436c19ee4402">

<img width="500" alt="Screenshot 2024-09-16 alle 18 42 40" src="https://github.com/user-attachments/assets/9ddf77e6-9d6d-4032-b0ad-5093583507a6">

<img width="500" alt="Screenshot 2024-09-16 alle 18 43 41" src="https://github.com/user-attachments/assets/7a89d715-6aec-4f0e-ad97-b0a60f1066df">


## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
