### PR TITLE
Add violet palette to be used as dropdown item hover background

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -53,7 +53,7 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
           'w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none',
           className,
           {
-            'hover:bg-primary cursor-pointer focus:bg-primary':
+            'hover:bg-violet cursor-pointer focus:bg-violet':
               onClick != null || href != null,
             'cursor-default': onClick == null && href == null,
             'opacity-50 pointer-events-none': isDisabled

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
         >
           <button
             aria-label="Payments"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
           >
             <div
               class="mr-2"
@@ -200,7 +200,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </button>
           <button
             aria-label="Items"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
           >
             <div
               class="mr-2"
@@ -225,7 +225,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </div>
           <button
             aria-label="Delete"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-primary cursor-pointer focus:bg-primary"
+            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
           >
             <div
               class="mr-2"

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -53,6 +53,19 @@ module.exports = {
       transparent: 'transparent',
       black: '#101111',
       white: '#fff',
+      violet: {
+        DEFAULT: '#666EFF',
+        50: '#ECF2FF',
+        100: '#DDE6FF',
+        200: '#C2D1FF',
+        300: '#9CB1FF',
+        400: '#7586FF',
+        500: '#666EFF',
+        600: '#3B36F5',
+        700: '#322AD8',
+        800: '#2925AE',
+        900: '#181650'
+      },
       gray: {
         50: '#F8F8F8',
         100: '#EDEEEE',


### PR DESCRIPTION
## What I did

I've added the violet color palette and used its default color for dropdown items

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
