### PR TITLE
Keep order number as string when converting from metrics order shape to core

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceList/adaptMetricsOrderToCore.test.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/adaptMetricsOrderToCore.test.ts
@@ -73,7 +73,7 @@ describe('adaptMetricsOrderToCore', () => {
       type: 'orders',
       created_at: '2024-08-28T09:01:01.253Z',
       updated_at: '2024-08-28T09:01:02.245Z',
-      number: 2579416,
+      number: '2579416',
       status: 'placed',
       payment_status: 'authorized',
       fulfillment_status: 'unfulfilled',

--- a/packages/app-elements/src/ui/resources/ResourceList/adaptMetricsOrderToCore.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/adaptMetricsOrderToCore.ts
@@ -91,8 +91,7 @@ export function adaptMetricsOrderToCore(
     type: 'orders',
     created_at: metricsOrder.created_at ?? '',
     updated_at: metricsOrder.updated_at ?? '',
-    // @ts-expect-error: wrong type from SDK
-    number: metricsOrder.number != null ? parseInt(metricsOrder.number) : '',
+    number: metricsOrder.number ?? '',
     status: metricsOrder.status as Order['status'],
     payment_status: metricsOrder.payment_status as Order['payment_status'],
     fulfillment_status:


### PR DESCRIPTION
## What I did

Since `order.number` can be a custom string, we don't need to parse it as an integer when converting metrics order into core API order

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
