### PR TITLE
Allow custom alignments for Th component

### DIFF
--- a/packages/app-elements/src/ui/atoms/Table/Th.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Th.tsx
@@ -9,7 +9,10 @@ function Th({ children, className, ...rest }: ThProps): JSX.Element {
     <th
       className={cn(
         className,
-        'p-4 text-xs uppercase border-b border-gray-100 bg-gray-50 text-gray-400 text-left first-of-type:rounded-ss last-of-type:rounded-se'
+        'p-4 text-xs uppercase border-b border-gray-100 bg-gray-50 text-gray-400 first-of-type:rounded-ss last-of-type:rounded-se',
+        {
+          'text-left': rest.align !== 'right' && rest.align !== 'center'
+        }
       )}
       {...rest}
     >

--- a/packages/docs/src/stories/atoms/Table.stories.tsx
+++ b/packages/docs/src/stories/atoms/Table.stories.tsx
@@ -73,3 +73,37 @@ export const WithoutThead = Default.bind({})
 WithoutThead.args = {
   tbody: baseProps.tbody
 }
+
+/** By default all columns are left aligned, but we support native HTML `align` attribute */
+export const CustomColumnsAlignments: StoryFn = () => {
+  return (
+    <Table
+      thead={
+        <Tr>
+          <Th>Left</Th>
+          <Th align='center'>Center</Th>
+          <Th align='right'>Right</Th>
+        </Tr>
+      }
+      tbody={
+        <>
+          <Tr>
+            <Td>Left</Td>
+            <Td align='center'>Center</Td>
+            <Td align='right'>right</Td>
+          </Tr>
+          <Tr>
+            <Td>Left</Td>
+            <Td align='center'>Center</Td>
+            <Td align='left'>left</Td>
+          </Tr>
+          <Tr>
+            <Td align='center'>Center</Td>
+            <Td align='left'>Left</Td>
+            <Td align='right'>right</Td>
+          </Tr>
+        </>
+      }
+    />
+  )
+}


### PR DESCRIPTION
## What I did

I fixed a wrong behavior due to the fact we forced `text-left` classname in `<Th>` component.
It was not possible to align the content to the right.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/3665623f-4dec-4af9-b441-4da2be449c38">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
