### PR TITLE
Tune anchors style

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -50,7 +50,7 @@ a:not(.button):not(:has(*)) {
 }
 
 a:not([class]) {
-  @apply rounded whitespace-nowrap leading-5 inline w-fit text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer;
+  @apply rounded whitespace-nowrap leading-5 inline w-fit text-primary hover:text-primary-light border-primary-light cursor-pointer;
 }
 
 a,

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -76,7 +76,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
         aria-haspopup
         aria-expanded={isExpanded}
         className={cn('m-0 p-0 align-top', {
-          '!text-black': typeof dropdownLabel !== 'string'
+          '!text-black': typeof dropdownLabel !== 'string',
+          '!no-underline hover:!underline': typeof dropdownLabel === 'string'
         })}
         onClick={() => {
           toggle()

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top !no-underline hover:!underline rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -53,7 +53,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top !no-underline hover:!underline rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -98,7 +98,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top !no-underline hover:!underline rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg
@@ -143,7 +143,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
     <button
       aria-expanded="true"
       aria-haspopup="true"
-      class="m-0 p-0 align-top rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+      class="m-0 p-0 align-top !no-underline hover:!underline rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
     >
       open dropdown
       <svg

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -120,7 +120,7 @@ function getVariantCss(
     circle:
       'font-semibold bg-white text-black hover:opacity-80 hover:bg-gray-50 rounded-full',
     danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
-    link: 'text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer',
+    link: 'text-primary hover:text-primary-light border-primary-light cursor-pointer',
     relationship: 'font-bold text-primary border border-gray-300 border-dashed'
   } satisfies Record<NonNullable<InteractiveElementProps['variant']>, string>
 

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -156,7 +156,7 @@ exports[`ResourceLineItems > should disable the remove action when \`onSwap\` is
               >
                 <button
                   aria-label="Swap"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"
@@ -182,7 +182,7 @@ exports[`ResourceLineItems > should disable the remove action when \`onSwap\` is
                 >
                   <button
                     aria-label="Delete"
-                    class="flex items-center rounded whitespace-nowrap leading-5 opacity-50 pointer-events-none touch-none inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                    class="flex items-center rounded whitespace-nowrap leading-5 opacity-50 pointer-events-none touch-none inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                     disabled=""
                   >
                     <svg
@@ -594,7 +594,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
               >
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"
@@ -1268,7 +1268,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
               >
                 <button
                   aria-label="Swap"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"
@@ -1289,7 +1289,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                 </button>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"
@@ -1527,7 +1527,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
               >
                 <button
                   aria-label="Swap"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"
@@ -1548,7 +1548,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                 </button>
                 <button
                   aria-label="Delete"
-                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary font-bold hover:text-primary-light border-primary-light cursor-pointer"
+                  class="flex items-center rounded whitespace-nowrap leading-5 inline w-fit underline text-primary hover:text-primary-light border-primary-light cursor-pointer"
                 >
                   <svg
                     fill="currentColor"

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -309,7 +309,30 @@ export const WithinASection: StoryFn<typeof Dropdown> = (args) => {
     </Section>
   )
 }
-WithinASection.args = DropdownLabelAsString.args
+WithinASection.args = {
+  dropdownLabel: (
+    <Button variant='secondary' size='mini' alignItems='center'>
+      <Icon name='plus' />
+      Add
+    </Button>
+  ),
+  dropdownItems: (
+    <>
+      <DropdownItem
+        onClick={() => {
+          alert('Add a SKU clicked!')
+        }}
+        label='Add a SKU'
+      />
+      <DropdownItem
+        onClick={() => {
+          alert('Add a bundle clicked!')
+        }}
+        label='Add a bundle'
+      />
+    </>
+  )
+}
 WithinASection.parameters = {
   layout: 'padded'
 }


### PR DESCRIPTION
## What I did

Anchors have default font-weight (no more bold):
https://deploy-preview-749--commercelayer-app-elements.netlify.app/?path=/docs/atoms-a--docs


Dropdown labels as strings have no underline when not hovered
https://deploy-preview-749--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#dropdown%20label%20as%20string

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
