### PR TITLE
Tweak `useResourceFilters` for metrics api

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
@@ -136,9 +136,6 @@ export function ResourceList<TResource extends ListableResourceType>({
 
   const fetchMore = useCallback(
     async ({ query }: { query?: QueryParamsList }): Promise<void> => {
-      if (sdkClient == null) {
-        return
-      }
       dispatch({ type: 'prepare' })
       try {
         const listResponse = await infiniteFetcher({
@@ -167,16 +164,10 @@ export function ResourceList<TResource extends ListableResourceType>({
 
   useEffect(
     function initialFetch() {
-      if (sdkClient != null) {
-        void fetchMore({ query })
-      }
+      void fetchMore({ query })
     },
     [sdkClient]
   )
-
-  if (sdkClient == null) {
-    return <div />
-  }
 
   const isApiError = data != null && error != null
   if (isApiError) {
@@ -203,6 +194,7 @@ export function ResourceList<TResource extends ListableResourceType>({
   return (
     <Section
       isLoading={isFirstLoading}
+      delayMs={0}
       title={
         typeof title === 'function'
           ? title(recordCount)
@@ -261,11 +253,7 @@ export function ResourceList<TResource extends ListableResourceType>({
           Array(isFirstLoading ? 8 : 2) // we want more elements as skeleton on first mount
             .fill(null)
             .map((_, idx) => (
-              <props.ItemTemplate
-                isLoading
-                delayMs={!isFirstLoading ? 0 : undefined}
-                key={idx}
-              />
+              <props.ItemTemplate isLoading delayMs={0} key={idx} />
             ))
         ) : (
           <VisibilityTrigger

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
@@ -89,7 +89,7 @@ function FiltersSearchBar({
       initialValue={safeInitialValue}
       onClear={updateTextFilter}
       onSearch={updateTextFilter}
-      autoFocus={safeInitialValue !== undefined && safeInitialValue.length > 0}
+      autoFocus
       debounceMs={debounceMs}
     />
   )

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.test.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.test.ts
@@ -87,6 +87,20 @@ describe('adaptSdkToMetrics', () => {
     expect(metricsFilters.order?.date_field).toBe('updated_at')
   })
 
+  test('Should set a default 5-year date range when text search is defined', () => {
+    const metricsFilters = adaptSdkToMetrics({
+      sdkFilters: {
+        aggregated_details: 'Commerce Layer'
+      },
+      predicateWhitelist: ['aggregated_details'],
+      resourceType: 'orders',
+      instructions
+    })
+    expect(metricsFilters.order?.date_from).toBe('2018-04-05T15:20:01Z')
+    expect(metricsFilters.order?.date_to).toBe('2023-04-05T15:20:00Z')
+    expect(metricsFilters.order?.date_field).toBe('updated_at')
+  })
+
   test('Should handle amount range and currency', () => {
     const sdkFilters = {
       total_amount_cents_lteq: '3010',

--- a/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/adaptSdkToMetrics.ts
@@ -251,8 +251,9 @@ export function adaptSdkToMetrics({
             now: new Date(),
             showMilliseconds: false,
             yearsAgo:
-              'archived' in filterValueMainResource &&
-              filterValueMainResource.archived === true
+              ('archived' in filterValueMainResource &&
+                filterValueMainResource.archived === true) ||
+              regroupedFilters.aggregatedDetails != null
                 ? 5
                 : 1
           }),

--- a/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
@@ -116,7 +116,7 @@ export interface FilterItemTextSearch extends Omit<BaseFilterItem, 'sdk'> {
      */
     component: 'searchBar' | 'input'
   }
-  sdk: Pick<BaseFilterItem['sdk'], 'predicate'>
+  sdk: Pick<BaseFilterItem['sdk'], 'predicate' | 'parseFormValue'>
 }
 
 export interface FilterItemTime extends Omit<BaseFilterItem, 'sdk'> {


### PR DESCRIPTION
Closes commercelayer/issues-app#208

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Allow to use `parseFormValue` also for text search
- Text search in metrics API (aggregated details) now set a default date range of 5 years (was 1)
- focus on FilterSearchBar is always on


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
