### PR TITLE
restore `queryString` prop in FilterSearchBar

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.test.tsx
@@ -5,30 +5,17 @@ import { FiltersNav } from './FiltersNav'
 import { instructions } from './mockedInstructions'
 
 describe('FiltersNav', () => {
-  const { location } = window
-  beforeEach(() => {
-    localStorage.clear()
-  })
-  beforeAll(function clearLocation() {
-    delete (window as any).location
-    ;(window as any).location = {
-      ...location,
-      hostname: ''
-    }
-  })
-  afterAll(function resetLocation() {
-    window.location = location
+  afterEach(() => {
     vi.resetAllMocks()
   })
 
   test('should render filter nav buttons', () => {
-    window.location.search =
-      '?status_in=placed&status_in=approved&payment_status_eq=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
     const { container, getByText } = render(
       <FiltersNav
         instructions={instructions}
         onFilterClick={() => {}}
         onUpdate={() => {}}
+        queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized&market_id_in=abc123&market_id_in=zxy456&market_id_in=xxx789'
         predicateWhitelist={[]}
       />
     )
@@ -43,7 +30,6 @@ describe('FiltersNav', () => {
   })
 
   test('should render single resource name (relationship) when there is only 1 filter for relationship selected (InputResourceGroup component)', async () => {
-    window.location.search = '?market_id_in=AlRevhXQga'
     const { container, getByText } = render(
       <TokenProvider kind='integration' appSlug='orders' devMode>
         <CoreSdkProvider>
@@ -51,6 +37,7 @@ describe('FiltersNav', () => {
             instructions={instructions}
             onFilterClick={() => {}}
             onUpdate={() => {}}
+            queryString='?market_id_in=AlRevhXQga' // mocked in msw as Europe
             predicateWhitelist={[]}
           />
         </CoreSdkProvider>
@@ -66,14 +53,13 @@ describe('FiltersNav', () => {
 
   test('should handle onFilterClick callback, returning current query string and clicked filter id', () => {
     const onFilterClick = vi.fn()
-    window.location.search =
-      '?status_in=placed&status_in=approved&payment_status_eq=authorized'
 
     const { getByText } = render(
       <FiltersNav
         instructions={instructions}
         onFilterClick={onFilterClick}
         onUpdate={() => {}}
+        queryString='?status_in=placed&status_in=approved&payment_status_eq=authorized'
         predicateWhitelist={[]}
       />
     )
@@ -87,13 +73,13 @@ describe('FiltersNav', () => {
 
   test('should handle onUpdate callback, returning current query string and clicked filter id', () => {
     const onUpdate = vi.fn()
-    window.location.search = '?status_in=placed&payment_status_eq=authorized'
 
     const { getAllByTestId } = render(
       <FiltersNav
         instructions={instructions}
         onFilterClick={() => {}}
         onUpdate={onUpdate}
+        queryString='?status_in=placed&payment_status_eq=authorized'
         predicateWhitelist={[]}
       />
     )

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersNav.tsx
@@ -12,7 +12,6 @@ import castArray from 'lodash/castArray'
 import isDate from 'lodash/isDate'
 import isEmpty from 'lodash/isEmpty'
 import { useCallback, useMemo } from 'react'
-import { useSearch } from 'wouter'
 import { makeFilterAdapters } from './adapters'
 import {
   getDefaultBrowserTimezone,
@@ -35,6 +34,11 @@ export interface FiltersNavProps {
    * Array of instruction items to build the filters behaviors
    */
   instructions: FiltersInstructions
+  /**
+   * Url query string to be parsed.
+   * It must be "reactive", so most of the time it should come for router.
+   */
+  queryString: string
   /**
    * Callback function triggered when user interacts with the filters buttons.
    * Implemented function should update the url query string / search params,
@@ -65,11 +69,10 @@ export function FiltersNav({
   instructions,
   onFilterClick: onBtnLabelClick,
   onUpdate,
-
+  queryString,
   predicateWhitelist
 }: FiltersNavProps): JSX.Element {
   const { user } = useTokenProvider()
-  const queryString = useSearch()
 
   const {
     adaptUrlQueryToFormValues,

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FiltersSearchBar.tsx
@@ -1,7 +1,6 @@
 import { SearchBar, type SearchBarProps } from '#ui/composite/SearchBar'
 import castArray from 'lodash/castArray'
 import isEmpty from 'lodash/isEmpty'
-import { useSearch } from 'wouter'
 import { makeFilterAdapters } from './adapters'
 import { type FiltersInstructions } from './types'
 
@@ -17,6 +16,11 @@ export interface FilterSearchBarProps
    * based on the new queryString received as argument.
    */
   onUpdate: (queryString: string) => void
+  /**
+   * Url query string to be parsed.
+   * It must be "reactive", so most of the time it should come for router.
+   */
+  queryString: string
   /**
    * By default, we strip out all filters that are not part of the `instructions` array.
    * The option `predicateWhitelist` is used to whitelist a set of predicates that you want to use as filters.
@@ -36,6 +40,7 @@ function FiltersSearchBar({
   instructions,
   placeholder,
   onUpdate,
+  queryString,
   predicateWhitelist,
   debounceMs
 }: FilterSearchBarProps): JSX.Element {
@@ -44,8 +49,6 @@ function FiltersSearchBar({
       instructions,
       predicateWhitelist
     })
-
-  const queryString = useSearch()
 
   const textPredicate = instructions.find(
     (item) =>

--- a/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
@@ -47,7 +47,7 @@ interface UseResourceFiltersHook {
    * Search bar component with filters navigation buttons
    */
   SearchWithNav: (
-    props: Pick<FiltersNavProps, 'onFilterClick'> & {
+    props: Pick<FiltersNavProps, 'onFilterClick' | 'queryString'> & {
       /**
        * Callback triggered when user interact with search bar or remove a filter from the buttons
        */
@@ -188,7 +188,10 @@ export function useResourceFilters({
       searchBarPlaceholder,
       searchBarDebounceMs,
       hideSearchBar,
-      hideFiltersNav
+      hideFiltersNav,
+      // we need this value as prop to avoid re-rendering the component and losing the focus on searchbar
+      // so we can't reuse the `queryString` variable we have in the hook scope
+      queryString: queryStringProp
     }): JSX.Element => {
       if (hideSearchBar === true && hideFiltersNav === true) {
         return <></>
@@ -199,6 +202,7 @@ export function useResourceFilters({
           {hideSearchBar === true ? null : (
             <Spacer bottom='2'>
               <FiltersSearchBar
+                queryString={queryStringProp}
                 placeholder={searchBarPlaceholder ?? 'Search...'}
                 debounceMs={searchBarDebounceMs}
                 instructions={validInstructions}
@@ -210,6 +214,7 @@ export function useResourceFilters({
 
           {hideFiltersNav === true ? null : (
             <FiltersNav
+              queryString={queryStringProp}
               instructions={validInstructions}
               onFilterClick={onFilterClick}
               onUpdate={onUpdate}

--- a/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
+++ b/packages/docs/src/stories/resources/useResourceFilters.stories.tsx
@@ -222,6 +222,7 @@ export const SearchWithNav: StoryFn = () => {
             navigate(`?${qs}`)
           }}
           searchBarPlaceholder='Type to search...'
+          queryString='?name_eq=Ehi there&status_in=placed&status_in=approved&payment_status_eq=authorized&fulfillment_status_in=unfulfilled&timeFrom=2023-09-03T22%3A00%3A00.000Z&timePreset=custom&timeTo=2023-09-05T22%3A00%3A00.000Z'
         />
       </CoreSdkProvider>
     </TokenProvider>


### PR DESCRIPTION
## What I did

This restore the `queryString` prop in FilterSearchBar wrongly removed in #755 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
