### PR TITLE
Improve type of `query` prop of `ResourceList` component

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -37,7 +37,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
-    "@commercelayer/sdk": "6.15.0",
+    "@commercelayer/sdk": "6.19.1",
     "@types/lodash": "^4.17.7",
     "@types/react": "^18.3.5",
     "@types/react-datepicker": "^6.2.0",

--- a/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
@@ -12,7 +12,8 @@ import { useMetricsSdkProvider } from '#ui/resources/ResourceList/metricsApiClie
 import {
   CommerceLayerStatic,
   type ListableResourceType,
-  type QueryParamsList
+  type QueryParamsList,
+  type ResourceFields
 } from '@commercelayer/sdk'
 import React, { useCallback, useEffect, useReducer, type FC } from 'react'
 import { VisibilityTrigger } from './VisibilityTrigger'
@@ -56,7 +57,7 @@ export type ResourceListProps<TResource extends ListableResourceType> = Pick<
   /**
    * SDK query object to be used to fetch the list, excluding the pageNumber that is handled internally for infinite scrolling.
    */
-  query?: Omit<QueryParamsList, 'pageNumber'>
+  query?: Omit<QueryParamsList<ResourceFields[TResource]>, 'pageNumber'>
   /**
    * When set the component will fetch data from the Metrics API, and automatically use the returned cursor for infinite scrolling.
    */
@@ -135,7 +136,11 @@ export function ResourceList<TResource extends ListableResourceType>({
   })
 
   const fetchMore = useCallback(
-    async ({ query }: { query?: QueryParamsList }): Promise<void> => {
+    async ({
+      query
+    }: {
+      query?: Omit<QueryParamsList<ResourceFields[TResource]>, 'pageNumber'>
+    }): Promise<void> => {
       dispatch({ type: 'prepare' })
       try {
         const listResponse = await infiniteFetcher({

--- a/packages/app-elements/src/ui/resources/ResourceList/infiniteFetcher.ts
+++ b/packages/app-elements/src/ui/resources/ResourceList/infiniteFetcher.ts
@@ -6,7 +6,8 @@ import {
 import type {
   CommerceLayerClient,
   ListableResourceType,
-  QueryParamsList
+  QueryParamsList,
+  ResourceFields
 } from '@commercelayer/sdk'
 import uniqBy from 'lodash/uniqBy'
 
@@ -41,7 +42,7 @@ export async function infiniteFetcher<TResource extends ListableResourceType>({
   | {
       client: CommerceLayerClient
       clientType: 'coreSdkClient'
-      query?: Omit<QueryParamsList, 'pageNumber'>
+      query?: Omit<QueryParamsList<ResourceFields[TResource]>, 'pageNumber'>
     }
   | {
       client: MetricsApiClient

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
   packages/app-elements:
     dependencies:
       '@commercelayer/sdk':
-        specifier: 6.15.0
-        version: 6.15.0
+        specifier: 6.19.1
+        version: 6.19.1
       '@types/lodash':
         specifier: ^4.17.7
         version: 4.17.7
@@ -207,7 +207,7 @@ importers:
         version: 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(webpack-sources@3.2.3)
       '@storybook/addon-interactions':
         specifier: ^8.2.9
-        version: 8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))
+        version: 8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))
       '@storybook/addon-links':
         specifier: ^8.2.9
         version: 8.2.9(react@18.3.1)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
@@ -975,8 +975,8 @@ packages:
       eslint: '>=8.0'
       typescript: '>=5.0'
 
-  '@commercelayer/sdk@6.15.0':
-    resolution: {integrity: sha512-XltoTkA+LBOIA93jGDvNsBkchvM4f8iL4Cm+O3cUOFIS9aE+S/eHm9RtSRbcrAl6iyYbLmePUf+by6KF54PzXA==}
+  '@commercelayer/sdk@6.19.1':
+    resolution: {integrity: sha512-/OZz6Z0F/djESxwMfxKmjlcGk0ufT1KUs5eR8WJ/TJ4udbbZadvvf0ZRL6l+yTkd84Sn4h9Ba694uxIWcF7xZg==}
     engines: {node: '>=20'}
 
   '@emnapi/core@1.2.0':
@@ -7764,7 +7764,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  '@commercelayer/sdk@6.15.0': {}
+  '@commercelayer/sdk@6.19.1': {}
 
   '@emnapi/core@1.2.0':
     dependencies:
@@ -8697,11 +8697,11 @@ snapshots:
       '@storybook/global': 5.0.0
       storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
 
-  '@storybook/addon-interactions@8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))':
+  '@storybook/addon-interactions@8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/instrumenter': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
-      '@storybook/test': 8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))
+      '@storybook/test': 8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))
       polished: 4.3.1
       storybook: 8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2))
       ts-dedent: 2.2.0
@@ -8936,12 +8936,12 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
-  '@storybook/test@8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))':
+  '@storybook/test@8.2.9(@types/jest@29.5.12)(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/instrumenter': 8.2.9(storybook@8.2.9(@babel/preset-env@7.25.4(@babel/core@7.25.2)))
       '@testing-library/dom': 10.1.0
-      '@testing-library/jest-dom': 6.4.5(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))
+      '@testing-library/jest-dom': 6.4.5(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.1.0)
       '@vitest/expect': 1.6.0
       '@vitest/spy': 1.6.0
@@ -8974,7 +8974,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.4.5(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.16.4)(terser@5.31.6))':
+  '@testing-library/jest-dom@6.4.5(@types/jest@29.5.12)(vitest@2.0.5(@types/node@20.16.4)(jsdom@24.1.3)(terser@5.31.6))':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.25.6


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Improved typing of `query` prop of `ResourceList` component to follow given resource `type`.
This improvement enable the `query` prop to set for example resource dedicated sort fields.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
