### PR TITLE
Improve `Input` behaviors with `suffix` prop set

### DIFF
--- a/packages/app-elements/src/ui/forms/Input/Input.tsx
+++ b/packages/app-elements/src/ui/forms/Input/Input.tsx
@@ -58,7 +58,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               'block w-full px-4 py-2.5 font-medium',
               'rounded outline-0',
               {
-                '[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none':
+                '[appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none !pr-12':
                   suffix != null,
                 '!bg-white': rest.autoComplete === 'off'
               },


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Increased right padding of input field in `Input` component if `suffix` prop is set.
This was made to prevent any kind of overlap or hidden/unreadable text below the suffix.

### Actual behavior

<img width="700" alt="Screenshot 2024-09-26 alle 11 03 46" src="https://github.com/user-attachments/assets/9aef33e9-6717-45be-8972-0c4a1ca55b73">

### Wanted behavior

<img width="700" alt="Screenshot 2024-09-26 alle 11 03 15" src="https://github.com/user-attachments/assets/c9e50adb-b7db-4e28-98a5-7db33507ea63">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
