### PR TITLE
Add `CodeEditor` component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Vite
+vite.config.*.timestamp-*

--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@commercelayer/sdk": "6.22.0",
+    "@monaco-editor/react": "4.6.0",
     "@types/lodash": "^4.17.10",
     "@types/react": "^18.3.11",
     "@types/react-datepicker": "^7.0.0",

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -185,7 +185,12 @@ export {
 } from '#ui/composite/Timeline'
 export { Toolbar, type ToolbarProps } from '#ui/composite/Toolbar'
 // Forms
-export { CodeEditor, type CodeEditorProps } from '#ui/forms/CodeEditor'
+export {
+  CodeEditor,
+  HookedCodeEditor,
+  type CodeEditorProps,
+  type HookedCodeEditorProps
+} from '#ui/forms/CodeEditor'
 export { HookedForm } from '#ui/forms/Form'
 export {
   HookedInput,

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -185,6 +185,7 @@ export {
 } from '#ui/composite/Timeline'
 export { Toolbar, type ToolbarProps } from '#ui/composite/Toolbar'
 // Forms
+export { CodeEditor, type CodeEditorProps } from '#ui/forms/CodeEditor'
 export { HookedForm } from '#ui/forms/Form'
 export {
   HookedInput,

--- a/packages/app-elements/src/mocks/setup.ts
+++ b/packages/app-elements/src/mocks/setup.ts
@@ -2,7 +2,19 @@ import { AssertionError } from 'assert'
 import { server } from './server'
 
 beforeAll(() => {
-  server.listen({ onUnhandledRequest: 'error' })
+  server.listen({
+    onUnhandledRequest(request, print) {
+      const url = new URL(request.url)
+
+      // Ignore requests to fetch static assets.
+      if (url.href === 'https://core.commercelayer.io/api/public/resources') {
+        return
+      }
+
+      // Otherwise, print a warning for any unhandled request.
+      print.error()
+    }
+  })
 })
 afterAll(() => {
   server.close()

--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditor.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditor.tsx
@@ -1,0 +1,22 @@
+import { SkeletonItem } from '#ui/atoms/Skeleton'
+import { forwardRef, lazy, Suspense } from 'react'
+import type { CodeEditorProps } from './CodeEditorComponent'
+
+const LazyCodeEditor = lazy(
+  async () =>
+    await import('./CodeEditorComponent').then((module) => ({
+      default: module.CodeEditor
+    }))
+)
+
+export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
+  (props, ref): JSX.Element => {
+    return (
+      <Suspense fallback={<SkeletonItem className='h-11 w-full' />}>
+        <LazyCodeEditor {...props} ref={ref} />
+      </Suspense>
+    )
+  }
+)
+
+CodeEditor.displayName = 'CodeEditor'

--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -14,7 +14,21 @@ import { type SetOptional } from 'type-fest'
 export interface CodeEditorProps
   extends InputWrapperBaseProps,
     SetOptional<Pick<HTMLInputElement, 'id' | 'name'>, 'id' | 'name'>,
-    Pick<EditorProps, 'defaultValue' | 'value' | 'language' | 'height'> {
+    Pick<EditorProps, 'defaultValue' | 'value'> {
+  /**
+   * Height of the editor wrapper
+   * @default "200px"
+   */
+  height?: number | string
+  /**
+   * Language of the current model
+   * @default plaintext
+   */
+  language?: 'plaintext' | 'json'
+  /**
+   * JSON Schema to be used when writing JSON
+   * @default none
+   */
   jsonSchema?: 'none' | 'promotions-rules'
   /**
    * Trigger on every update.
@@ -40,7 +54,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
       label,
       defaultValue,
       value,
-      language,
+      language = 'plaintext',
       height = '220px',
       jsonSchema = 'none',
       onValidate,

--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -131,7 +131,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
 
               disposeCompletionItemProvider.current =
                 monaco.languages.registerCompletionItemProvider('json', {
-                  // triggerCharacters: ['"', ':', '.'],
+                  triggerCharacters: ['"', ':', '.'],
                   provideCompletionItems: async function (model, position) {
                     if (model.uri.toString() !== uri.toString()) {
                       return {

--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -31,7 +31,7 @@ export interface CodeEditorProps
    * JSON Schema to be used when writing JSON
    * @default none
    */
-  jsonSchema?: 'none' | 'order-rules' | 'price-rules' | 'organization-config'
+  jsonSchema?: 'none' | 'order-rules' | 'price-rules'
   /**
    * Trigger on every update.
    * @param markers List of markers (errors). `null` when there're no errors.
@@ -110,27 +110,6 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
             case 'none': {
               break
             }
-
-            case 'organization-config': {
-              break
-            }
-
-            // case 'organization-config': {
-            //   console.log('here', jsonSchema, uri)
-            //   schemas.push({
-            //     schema: await fetch(
-            //       'http://localhost:6006/organization_config.json'
-            //     )
-            //       .then<JsonValue>(async (res) => await res.json())
-            //       .then((json) => {
-            //         return clearExamples(json)
-            //       }),
-            //     uri: `file:///json-schema--${jsonSchema}.json`,
-            //     fileMatch: [uri]
-            //   })
-
-            //   break
-            // }
 
             case 'order-rules': {
               schemas.push({

--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -9,10 +9,11 @@ import Editor, {
   type OnValidate
 } from '@monaco-editor/react'
 import { forwardRef, useEffect, useState } from 'react'
+import { type SetOptional } from 'type-fest'
 
 export interface CodeEditorProps
   extends InputWrapperBaseProps,
-    Pick<HTMLInputElement, 'id' | 'name'>,
+    SetOptional<Pick<HTMLInputElement, 'id' | 'name'>, 'id' | 'name'>,
     Pick<EditorProps, 'defaultValue' | 'value' | 'language' | 'height'> {
   jsonSchema?: 'none' | 'promotions-rules'
   /**
@@ -24,6 +25,7 @@ export interface CodeEditorProps
   /**
    * Trigger on every update only when there are **no** errors.
    */
+  onValid?: (value: string) => void
   onChange?: (value: string) => void
 }
 
@@ -42,6 +44,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
       height = '220px',
       jsonSchema = 'none',
       onValidate,
+      onValid,
       onChange,
       ...rest
     },
@@ -67,9 +70,10 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
 
         defer(() => {
           onValidate?.(markers.length > 0 ? markers : null)
+          onChange?.(editorValue)
 
           if (markers.length === 0) {
-            onChange?.(editorValue)
+            onValid?.(editorValue)
           }
         })
       })

--- a/packages/app-elements/src/ui/forms/CodeEditor/HookedCodeEditor.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/HookedCodeEditor.tsx
@@ -26,10 +26,12 @@ export function HookedCodeEditor({
       name={name}
       control={control}
       rules={{
-        validate: (asd) => {
+        validate: () => {
           return isValid == null || isValid.length === 0
             ? true
-            : isValid[0]?.message
+            : isValid[0]?.message.includes('Valid values: ') === true
+              ? 'Value is not accepted.'
+              : isValid[0]?.message
         }
       }}
       render={({ field }) => (

--- a/packages/app-elements/src/ui/forms/CodeEditor/HookedCodeEditor.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/HookedCodeEditor.tsx
@@ -1,0 +1,51 @@
+import type { OnValidate } from '@monaco-editor/react'
+import { useState } from 'react'
+import { Controller, useFormContext } from 'react-hook-form'
+import { useValidationFeedback } from '../ReactHookForm'
+import { CodeEditor } from './CodeEditor'
+import { type CodeEditorProps } from './CodeEditorComponent'
+
+export interface HookedCodeEditorProps
+  extends Omit<CodeEditorProps, 'name'>,
+    Required<Pick<CodeEditorProps, 'name'>> {}
+
+/**
+ * `Input` component ready to be used with the `react-hook-form` context.
+ * @see InputSelect
+ */
+export function HookedCodeEditor({
+  name,
+  ...props
+}: HookedCodeEditorProps): JSX.Element {
+  const { control } = useFormContext()
+  const feedback = useValidationFeedback(name)
+  const [isValid, setIsValid] = useState<Parameters<OnValidate>[0] | null>(null)
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={{
+        validate: (asd) => {
+          return isValid == null || isValid.length === 0
+            ? true
+            : isValid[0]?.message
+        }
+      }}
+      render={({ field }) => (
+        <CodeEditor
+          {...props}
+          name={name}
+          feedback={feedback}
+          defaultValue={field.value}
+          onValidate={(markers) => {
+            setIsValid(markers)
+          }}
+          onChange={(values) => {
+            field.onChange(values)
+          }}
+        />
+      )}
+    />
+  )
+}

--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
@@ -438,6 +438,10 @@ const orderSuggestionsSnapshot = `
     },
     {
       "type": "field",
+      "value": "order.affiliate_code",
+    },
+    {
+      "type": "field",
       "value": "order.autorefresh",
     },
     {

--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
@@ -347,8 +347,8 @@ describe('fetchCoreResourcesSuggestions', () => {
 })
 
 describe('atPath', () => {
-  it('should handle known resourceId', () => {
-    expect(atPath('order')).toEqual(
+  it('should handle known resourceId', async () => {
+    expect(await atPath('order')).toEqual(
       expect.objectContaining({
         obj: expect.objectContaining({
           fields: expect.arrayContaining([
@@ -365,8 +365,8 @@ describe('atPath', () => {
     )
   })
 
-  it('should handle unknown resourceId', () => {
-    expect(atPath('ore')).toEqual(
+  it('should handle unknown resourceId', async () => {
+    expect(await atPath('ore')).toEqual(
       expect.objectContaining({
         obj: undefined,
         path: ''
@@ -374,8 +374,8 @@ describe('atPath', () => {
     )
   })
 
-  it('should handle fields', () => {
-    expect(atPath('order.number')).toEqual(
+  it('should handle fields', async () => {
+    expect(await atPath('order.number')).toEqual(
       expect.objectContaining({
         obj: expect.objectContaining({
           fields: expect.arrayContaining([
@@ -392,8 +392,10 @@ describe('atPath', () => {
     )
   })
 
-  it('should handle nested relationships', () => {
-    expect(atPath('price.jwt_markets.price_list.prices.currency_code')).toEqual(
+  it('should handle nested relationships', async () => {
+    expect(
+      await atPath('price.jwt_markets.price_list.prices.currency_code')
+    ).toEqual(
       expect.objectContaining({
         obj: expect.objectContaining({
           fields: expect.arrayContaining([
@@ -411,8 +413,8 @@ describe('atPath', () => {
     )
   })
 
-  it('should hide polymorphic relationships', () => {
-    expect(atPath('order.attachments.attachable')).toEqual(
+  it('should hide polymorphic relationships', async () => {
+    expect(await atPath('order.attachments.attachable')).toEqual(
       expect.objectContaining({
         obj: expect.objectContaining({
           fields: expect.arrayContaining([

--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.test.ts
@@ -1,0 +1,963 @@
+import { describe } from 'vitest'
+import { fetchCoreResourcesSuggestions } from './fetchCoreResourcesSuggestions'
+
+describe('fetchCoreResourcesSuggestions', () => {
+  describe('should return the provided "mainResourceIds" list', () => {
+    it('when the path is empty', async () => {
+      expect(await fetchCoreResourcesSuggestions(['order'], ''))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "type": "relationship",
+            "value": "order",
+          },
+        ]
+      `)
+
+      expect(await fetchCoreResourcesSuggestions(['order', 'price'], ''))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "type": "relationship",
+            "value": "order",
+          },
+          {
+            "type": "relationship",
+            "value": "price",
+          },
+        ]
+      `)
+    })
+
+    it('when the first resource in the path is not well-defined', async () => {
+      expect(await fetchCoreResourcesSuggestions(['order'], 'ore'))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "type": "relationship",
+            "value": "order",
+          },
+        ]
+      `)
+
+      expect(await fetchCoreResourcesSuggestions(['order'], 'ore.rew'))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "type": "relationship",
+            "value": "order",
+          },
+        ]
+      `)
+    })
+
+    it('when the first resource in the path is well-defined but a last dot (.) is missing', async () => {
+      expect(await fetchCoreResourcesSuggestions(['order', 'price'], 'order'))
+        .toMatchInlineSnapshot(`
+        [
+          {
+            "type": "relationship",
+            "value": "order",
+          },
+          {
+            "type": "relationship",
+            "value": "price",
+          },
+        ]
+      `)
+    })
+  })
+
+  it('it should return the 2nd level for autocompletion', async () => {
+    expect(
+      await fetchCoreResourcesSuggestions(['order', 'price'], 'order.')
+    ).toMatchInlineSnapshot(orderSuggestionsSnapshot)
+
+    expect(
+      await fetchCoreResourcesSuggestions(
+        ['order', 'price'],
+        'order.something.else'
+      )
+    ).toMatchInlineSnapshot(orderSuggestionsSnapshot)
+  })
+
+  it('it should return the 3rd level for autocompletion', async () => {
+    expect(await fetchCoreResourcesSuggestions(['order'], 'order.line_items.'))
+      .toMatchInlineSnapshot(`
+      [
+        {
+          "type": "field",
+          "value": "order.line_items.sku_code",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.bundle_code",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.quantity",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.currency_code",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.unit_amount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.unit_amount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_unit_amount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.compare_at_amount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.compare_at_amount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_compare_at_amount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.options_amount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.options_amount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_options_amount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.discount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.discount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_discount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.total_amount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.total_amount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_total_amount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.tax_amount_cents",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.tax_amount_float",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.formatted_tax_amount",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.name",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.image_url",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.discount_breakdown",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.tax_rate",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.tax_breakdown",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.item_type",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.frequency",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.coupon_code",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.id",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.circuit_state",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.circuit_failure_count",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.created_at",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.updated_at",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.reference",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.reference_origin",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.metadata",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.order",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.item",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.sku",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.bundle",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.adjustment",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.gift_card",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.shipment",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.payment_method",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.line_item_options",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.return_line_items",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.shipment_line_items",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.stock_reservations",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.stock_line_items",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.stock_transfers",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.events",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.tags",
+        },
+      ]
+    `)
+  })
+
+  it('it should return the 3rd level for autocompletion', async () => {
+    expect(
+      await fetchCoreResourcesSuggestions(['order'], 'order.line_items.events.')
+    ).toMatchInlineSnapshot(`
+      [
+        {
+          "type": "field",
+          "value": "order.line_items.events.name",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.id",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.created_at",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.updated_at",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.reference",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.reference_origin",
+        },
+        {
+          "type": "field",
+          "value": "order.line_items.events.metadata",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.events.webhooks",
+        },
+        {
+          "type": "relationship",
+          "value": "order.line_items.events.last_event_callbacks",
+        },
+      ]
+    `)
+  })
+
+  it('it should stop generating autocompletion when a field is reached', async () => {
+    expect(
+      await fetchCoreResourcesSuggestions(['order'], 'order.number.')
+    ).toMatchInlineSnapshot(orderSuggestionsSnapshot)
+  })
+})
+
+const orderSuggestionsSnapshot = `
+  [
+    {
+      "type": "field",
+      "value": "order.number",
+    },
+    {
+      "type": "field",
+      "value": "order.autorefresh",
+    },
+    {
+      "type": "field",
+      "value": "order.place_async",
+    },
+    {
+      "type": "field",
+      "value": "order.status",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_status",
+    },
+    {
+      "type": "field",
+      "value": "order.fulfillment_status",
+    },
+    {
+      "type": "field",
+      "value": "order.guest",
+    },
+    {
+      "type": "field",
+      "value": "order.editable",
+    },
+    {
+      "type": "field",
+      "value": "order.customer_email",
+    },
+    {
+      "type": "field",
+      "value": "order.customer_password",
+    },
+    {
+      "type": "field",
+      "value": "order.language_code",
+    },
+    {
+      "type": "field",
+      "value": "order.currency_code",
+    },
+    {
+      "type": "field",
+      "value": "order.tax_included",
+    },
+    {
+      "type": "field",
+      "value": "order.tax_rate",
+    },
+    {
+      "type": "field",
+      "value": "order.freight_taxable",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_taxable",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_taxable",
+    },
+    {
+      "type": "field",
+      "value": "order.gift_card_taxable",
+    },
+    {
+      "type": "field",
+      "value": "order.requires_billing_info",
+    },
+    {
+      "type": "field",
+      "value": "order.country_code",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_country_code_lock",
+    },
+    {
+      "type": "field",
+      "value": "order.coupon_code",
+    },
+    {
+      "type": "field",
+      "value": "order.gift_card_code",
+    },
+    {
+      "type": "field",
+      "value": "order.gift_card_or_coupon_code",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_subtotal_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_shipping_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_payment_method_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.discount_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.discount_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_discount_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_adjustment_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.gift_card_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.gift_card_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_gift_card_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.total_tax_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.total_tax_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_total_tax_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_tax_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_tax_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_subtotal_tax_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_tax_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_tax_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_shipping_tax_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_tax_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_tax_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_payment_method_tax_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_tax_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_tax_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_adjustment_tax_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.total_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.total_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_total_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.total_taxable_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.total_taxable_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_total_taxable_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_taxable_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.subtotal_taxable_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_subtotal_taxable_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_taxable_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.shipping_taxable_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_shipping_taxable_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_taxable_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_method_taxable_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_payment_method_taxable_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_taxable_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.adjustment_taxable_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_adjustment_taxable_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.total_amount_with_taxes_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.total_amount_with_taxes_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_total_amount_with_taxes",
+    },
+    {
+      "type": "field",
+      "value": "order.fees_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.fees_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_fees_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.duty_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.duty_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_duty_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.place_total_amount_cents",
+    },
+    {
+      "type": "field",
+      "value": "order.place_total_amount_float",
+    },
+    {
+      "type": "field",
+      "value": "order.formatted_place_total_amount",
+    },
+    {
+      "type": "field",
+      "value": "order.skus_count",
+    },
+    {
+      "type": "field",
+      "value": "order.line_item_options_count",
+    },
+    {
+      "type": "field",
+      "value": "order.shipments_count",
+    },
+    {
+      "type": "field",
+      "value": "order.tax_calculations_count",
+    },
+    {
+      "type": "field",
+      "value": "order.validations_count",
+    },
+    {
+      "type": "field",
+      "value": "order.errors_count",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_source_details",
+    },
+    {
+      "type": "field",
+      "value": "order.token",
+    },
+    {
+      "type": "field",
+      "value": "order.cart_url",
+    },
+    {
+      "type": "field",
+      "value": "order.return_url",
+    },
+    {
+      "type": "field",
+      "value": "order.terms_url",
+    },
+    {
+      "type": "field",
+      "value": "order.privacy_url",
+    },
+    {
+      "type": "field",
+      "value": "order.checkout_url",
+    },
+    {
+      "type": "field",
+      "value": "order.placed_at",
+    },
+    {
+      "type": "field",
+      "value": "order.approved_at",
+    },
+    {
+      "type": "field",
+      "value": "order.cancelled_at",
+    },
+    {
+      "type": "field",
+      "value": "order.payment_updated_at",
+    },
+    {
+      "type": "field",
+      "value": "order.fulfillment_updated_at",
+    },
+    {
+      "type": "field",
+      "value": "order.refreshed_at",
+    },
+    {
+      "type": "field",
+      "value": "order.archived_at",
+    },
+    {
+      "type": "field",
+      "value": "order.subscription_created_at",
+    },
+    {
+      "type": "field",
+      "value": "order.id",
+    },
+    {
+      "type": "field",
+      "value": "order.circuit_state",
+    },
+    {
+      "type": "field",
+      "value": "order.circuit_failure_count",
+    },
+    {
+      "type": "field",
+      "value": "order.created_at",
+    },
+    {
+      "type": "field",
+      "value": "order.updated_at",
+    },
+    {
+      "type": "field",
+      "value": "order.reference",
+    },
+    {
+      "type": "field",
+      "value": "order.reference_origin",
+    },
+    {
+      "type": "field",
+      "value": "order.metadata",
+    },
+    {
+      "type": "relationship",
+      "value": "order.market",
+    },
+    {
+      "type": "relationship",
+      "value": "order.customer",
+    },
+    {
+      "type": "relationship",
+      "value": "order.shipping_address",
+    },
+    {
+      "type": "relationship",
+      "value": "order.billing_address",
+    },
+    {
+      "type": "relationship",
+      "value": "order.available_payment_methods",
+    },
+    {
+      "type": "relationship",
+      "value": "order.available_customer_payment_sources",
+    },
+    {
+      "type": "relationship",
+      "value": "order.available_free_skus",
+    },
+    {
+      "type": "relationship",
+      "value": "order.available_free_bundles",
+    },
+    {
+      "type": "relationship",
+      "value": "order.payment_method",
+    },
+    {
+      "type": "relationship",
+      "value": "order.payment_source",
+    },
+    {
+      "type": "relationship",
+      "value": "order.line_items",
+    },
+    {
+      "type": "relationship",
+      "value": "order.line_item_options",
+    },
+    {
+      "type": "relationship",
+      "value": "order.stock_reservations",
+    },
+    {
+      "type": "relationship",
+      "value": "order.stock_line_items",
+    },
+    {
+      "type": "relationship",
+      "value": "order.stock_transfers",
+    },
+    {
+      "type": "relationship",
+      "value": "order.shipments",
+    },
+    {
+      "type": "relationship",
+      "value": "order.payment_options",
+    },
+    {
+      "type": "relationship",
+      "value": "order.transactions",
+    },
+    {
+      "type": "relationship",
+      "value": "order.authorizations",
+    },
+    {
+      "type": "relationship",
+      "value": "order.captures",
+    },
+    {
+      "type": "relationship",
+      "value": "order.voids",
+    },
+    {
+      "type": "relationship",
+      "value": "order.refunds",
+    },
+    {
+      "type": "relationship",
+      "value": "order.returns",
+    },
+    {
+      "type": "relationship",
+      "value": "order.order_subscription",
+    },
+    {
+      "type": "relationship",
+      "value": "order.order_subscriptions",
+    },
+    {
+      "type": "relationship",
+      "value": "order.order_factories",
+    },
+    {
+      "type": "relationship",
+      "value": "order.order_copies",
+    },
+    {
+      "type": "relationship",
+      "value": "order.recurring_order_copies",
+    },
+    {
+      "type": "relationship",
+      "value": "order.attachments",
+    },
+    {
+      "type": "relationship",
+      "value": "order.links",
+    },
+    {
+      "type": "relationship",
+      "value": "order.resource_errors",
+    },
+    {
+      "type": "relationship",
+      "value": "order.events",
+    },
+    {
+      "type": "relationship",
+      "value": "order.tags",
+    },
+    {
+      "type": "relationship",
+      "value": "order.versions",
+    },
+  ]
+`

--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
@@ -1,0 +1,87 @@
+import { singular } from 'pluralize'
+
+const resources = await fetch(
+  'https://core.commercelayer.io/api/public/resources'
+)
+  .then<{
+    data: Array<{
+      id: string
+      attributes: {
+        fields: Record<string, any>
+        relationships: Record<string, any>
+      }
+    }>
+  }>(async (res) => await res.json())
+  .then<Record<string, { fields: string[]; relationships: string[] }>>(
+    ({ data: resources }) =>
+      resources.reduce((acc, cv) => {
+        return {
+          ...acc,
+          [cv.id]: {
+            fields: Object.keys(cv.attributes.fields)
+              // remove trigger attributes
+              .filter((attr) => !attr.startsWith('_')),
+            relationships: Object.keys(cv.attributes.relationships)
+              // remove trigger attributes
+              .filter((attr) => !attr.startsWith('_'))
+          }
+        }
+      }, {})
+  )
+
+/**
+ *
+ * @returns
+ */
+export async function fetchCoreResourcesSuggestions(
+  mainResourceIds: Array<'order' | 'price'>,
+  path: string
+): Promise<Array<{ value: string; type: 'field' | 'relationship' }>> {
+  path = path.replace(/.$/, '')
+
+  if (!new RegExp(`^(${mainResourceIds.join('|')})(.|$)`).test(path)) {
+    return mainResourceIds.map((res) => ({
+      value: res,
+      type: 'relationship'
+    }))
+  }
+
+  const splittedPath = path.split('.')
+
+  const validPath = splittedPath.reduce<string[]>(
+    (acc, cv, index, list) => {
+      const parent = list[index - 1]
+      if (
+        parent != null &&
+        resources[singular(parent)]?.relationships.includes(cv) === true
+      ) {
+        acc.push(cv)
+      }
+
+      return acc
+    },
+    splittedPath[0] != null ? [splittedPath[0]] : []
+  )
+
+  const lastValidResource = singular(
+    validPath[validPath.length - 1] ?? splittedPath[0] ?? ''
+  )
+
+  const suggestions = (
+    [] as Array<{ value: string; type: 'field' | 'relationship' }>
+  )
+    .concat(
+      resources[lastValidResource]?.fields.map((a) => ({
+        value: `${validPath.join('.')}.${a}`,
+        type: 'field'
+      })) ?? []
+    )
+    .concat(
+      resources[lastValidResource]?.relationships.map((a) => ({
+        value: `${validPath.join('.')}.${a}`,
+        type: 'relationship'
+      })) ?? []
+    )
+
+  return suggestions
+}

--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
@@ -94,7 +94,7 @@ const fetchResources = (() => {
  * @returns
  */
 export async function fetchCoreResourcesSuggestions(
-  mainResourceIds: Array<'order' | 'price'>,
+  mainResourceIds: Array<'order' | 'price' | 'price_list'>,
   path: string
 ): Promise<Array<{ value: string; type: 'field' | 'relationship' }>> {
   if (!new RegExp(`^(${mainResourceIds.join('|')})(.|$)`).test(path)) {

--- a/packages/app-elements/src/ui/forms/CodeEditor/index.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/index.tsx
@@ -1,0 +1,2 @@
+export { CodeEditor } from './CodeEditor'
+export type { CodeEditorProps } from './CodeEditorComponent'

--- a/packages/app-elements/src/ui/forms/CodeEditor/index.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/index.tsx
@@ -1,2 +1,6 @@
 export { CodeEditor } from './CodeEditor'
 export type { CodeEditorProps } from './CodeEditorComponent'
+export {
+  HookedCodeEditor,
+  type HookedCodeEditorProps
+} from './HookedCodeEditor'

--- a/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
@@ -50,11 +50,35 @@ Default.args = {
 export const TypescriptCode: StoryFn<typeof HookedCodeEditor> = (args) => {
   const methods = useForm({
     defaultValues: {
-      'ts-code': `// Simple function
-function greet(name: string): void {
-  alert(\`Hello \${name}!\`)
-}
-`,
+      rules: JSON.stringify(
+        {
+          rules: [
+            {
+              id: 'dkt7685f-7760-452e-b9b4-83434b89e2a4',
+              name: 'Discount products that are not already discounted (by diff price_amount_cents compared_at_amount_cents)',
+              conditions: [
+                {
+                  field:
+                    'order.line_items.diff_cents_compare_at_amount_unit_amount',
+                  matcher: 'eq',
+                  value: 0,
+                  group: 'discountable_items'
+                }
+              ],
+              actions: [
+                {
+                  type: 'percentage',
+                  selector: 'order.line_items.sku',
+                  groups: ['discountable_items'],
+                  value: '10%'
+                }
+              ]
+            }
+          ]
+        },
+        undefined,
+        2
+      ).concat('\n'),
       json: JSON.stringify({ name: 'Marco' }, undefined, 2).concat('\n')
     }
   })
@@ -67,14 +91,16 @@ function greet(name: string): void {
       }}
     >
       <Spacer top='4'>
-        <HookedCodeEditor
-          name='ts-code'
-          label='Typescript'
-          language='typescript'
-        />
+        <HookedCodeEditor name='json' label='JSON' language='json' />
       </Spacer>
       <Spacer top='4'>
-        <HookedCodeEditor name='json' label='JSON' language='json' />
+        <HookedCodeEditor
+          name='rules'
+          label='Rules'
+          language='json'
+          jsonSchema='promotions-rules'
+          height='550px'
+        />
       </Spacer>
       <Spacer top='6'>
         <Button type='submit'>Submit</Button>

--- a/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
@@ -1,0 +1,84 @@
+import { Button } from '#ui/atoms/Button'
+import { Spacer } from '#ui/atoms/Spacer'
+import { HookedCodeEditor } from '#ui/forms/CodeEditor'
+import { HookedForm } from '#ui/forms/Form'
+import { type Meta, type StoryFn } from '@storybook/react'
+import { useForm } from 'react-hook-form'
+
+const setup: Meta<typeof HookedCodeEditor> = {
+  title: 'Forms/react-hook-form/HookedCodeEditor',
+  component: HookedCodeEditor,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      source: {
+        type: 'code'
+      }
+    }
+  }
+}
+export default setup
+
+const Template: StoryFn<typeof HookedCodeEditor> = (args) => {
+  const methods = useForm({
+    defaultValues: {
+      'simple-text': 'This is a simple text!\n'
+    }
+  })
+
+  return (
+    <HookedForm
+      {...methods}
+      onSubmit={(values): void => {
+        alert(JSON.stringify(values))
+      }}
+    >
+      <HookedCodeEditor {...args} />
+      <Spacer top='4'>
+        <Button type='submit'>Submit</Button>
+      </Spacer>
+    </HookedForm>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  label: 'Code',
+  name: 'simple-text'
+}
+
+export const TypescriptCode: StoryFn<typeof HookedCodeEditor> = (args) => {
+  const methods = useForm({
+    defaultValues: {
+      'ts-code': `// Simple function
+function greet(name: string): void {
+  alert(\`Hello \${name}!\`)
+}
+`,
+      json: JSON.stringify({ name: 'Marco' }, undefined, 2).concat('\n')
+    }
+  })
+
+  return (
+    <HookedForm
+      {...methods}
+      onSubmit={(values): void => {
+        alert(JSON.stringify(values))
+      }}
+    >
+      <Spacer top='4'>
+        <HookedCodeEditor
+          name='ts-code'
+          label='Typescript'
+          language='typescript'
+        />
+      </Spacer>
+      <Spacer top='4'>
+        <HookedCodeEditor name='json' label='JSON' language='json' />
+      </Spacer>
+      <Spacer top='6'>
+        <Button type='submit'>Submit</Button>
+      </Spacer>
+    </HookedForm>
+  )
+}

--- a/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
@@ -95,7 +95,7 @@ export const TypescriptCode: StoryFn<typeof HookedCodeEditor> = (args) => {
           name='rules'
           label='Rules'
           language='json'
-          jsonSchema='promotions-rules'
+          jsonSchema='order-rules'
           height='470px'
         />
       </Spacer>

--- a/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/react-hook-form/HookedCodeEditor.stories.tsx
@@ -54,23 +54,20 @@ export const TypescriptCode: StoryFn<typeof HookedCodeEditor> = (args) => {
         {
           rules: [
             {
-              id: 'dkt7685f-7760-452e-b9b4-83434b89e2a4',
-              name: 'Discount products that are not already discounted (by diff price_amount_cents compared_at_amount_cents)',
+              id: 'b569f656-8bc2-4253-a19b-56062e7653ab',
+              name: 'Discount 3% if paid by credit card',
               conditions: [
                 {
-                  field:
-                    'order.line_items.diff_cents_compare_at_amount_unit_amount',
+                  field: 'order.payment_method.payment_source_type',
                   matcher: 'eq',
-                  value: 0,
-                  group: 'discountable_items'
+                  value: 'credit_cards'
                 }
               ],
               actions: [
                 {
                   type: 'percentage',
-                  selector: 'order.line_items.sku',
-                  groups: ['discountable_items'],
-                  value: '10%'
+                  selector: 'order',
+                  value: '3%'
                 }
               ]
             }
@@ -99,7 +96,7 @@ export const TypescriptCode: StoryFn<typeof HookedCodeEditor> = (args) => {
           label='Rules'
           language='json'
           jsonSchema='promotions-rules'
-          height='550px'
+          height='470px'
         />
       </Spacer>
       <Spacer top='6'>

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -113,23 +113,23 @@ PriceListRules.args = {
   ).concat('\n')
 }
 
-export const OrganizationConfig = Template.bind({})
-OrganizationConfig.args = {
-  name: 'organization-config',
-  label: 'Configuration',
-  height: '600px',
-  onChange: (value) => {
-    console.log('organization config • Changed to:', value)
-  },
-  onValidate: (markers) => {
-    console.log('organization config • Markers:', markers)
-  },
-  language: 'json',
-  jsonSchema: 'organization-config',
-  defaultValue: JSON.stringify({ mfe: { default: {} } }, undefined, 2).concat(
-    '\n'
-  )
-}
+// export const OrganizationConfig = Template.bind({})
+// OrganizationConfig.args = {
+//   name: 'organization-config',
+//   label: 'Configuration',
+//   height: '600px',
+//   onChange: (value) => {
+//     console.log('organization config • Changed to:', value)
+//   },
+//   onValidate: (markers) => {
+//     console.log('organization config • Markers:', markers)
+//   },
+//   language: 'json',
+//   jsonSchema: 'organization-config',
+//   defaultValue: JSON.stringify({ mfe: { default: {} } }, undefined, 2).concat(
+//     '\n'
+//   )
+// }
 
 export const WithHint = Template.bind({})
 WithHint.args = {

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -1,0 +1,97 @@
+import { CodeEditor } from '#ui/forms/CodeEditor'
+import { type Meta, type StoryFn } from '@storybook/react'
+
+const setup: Meta<typeof CodeEditor> = {
+  title: 'Forms/ui/CodeEditor',
+  component: CodeEditor,
+  parameters: {
+    layout: 'padded'
+  }
+}
+export default setup
+
+const Template: StoryFn<typeof CodeEditor> = (args) => {
+  return (
+    <>
+      <CodeEditor {...args} />
+    </>
+  )
+}
+
+export const Default = Template.bind({})
+Default.args = {
+  name: 'code-editor',
+  label: 'Code',
+  language: 'typescript',
+  // onChange: (value) => console.log('Changed to:', value),
+  // onValidate: (markers) => console.log('Markers:', markers),
+  defaultValue: `/**
+ * Says hello to whoever dares to enter their name!
+ * @param name The name of the person to greet.
+ */
+function greet(name: string): void {
+  alert(\`Hello \${name}!\`)
+}
+
+greet('Marco')
+`
+}
+
+export const Rules = Template.bind({})
+Rules.args = {
+  name: 'rules',
+  label: 'Rules',
+  height: '520px',
+  // onChange: (value) => console.log('Changed to:', value),
+  // onValidate: (markers) => console.log('Markers:', markers),
+  language: 'json',
+  jsonSchema: 'promotions-rules',
+  defaultValue: JSON.stringify(
+    {
+      rules: [
+        {
+          id: 'dkt7685f-7760-452e-b9b4-83434b89e2a4',
+          name: 'Discount products that are not already discounted (by diff price_amount_cents compared_at_amount_cents)',
+          conditions: [
+            {
+              field:
+                'order.line_items.diff_cents_compare_at_amount_unit_amount',
+              matcher: 'eq',
+              value: 0,
+              group: 'discountable_items'
+            }
+          ],
+          actions: [
+            {
+              type: 'percentage',
+              selector: 'order.line_items.sku',
+              groups: ['discountable_items'],
+              value: '10%'
+            }
+          ]
+        }
+      ]
+    },
+    undefined,
+    2
+  )
+}
+
+export const WithHint = Template.bind({})
+WithHint.args = {
+  name: 'code-editor-hint',
+  label: 'Code',
+  hint: {
+    text: 'Please enter a valid rule'
+  }
+}
+
+export const WithError = Template.bind({})
+WithError.args = {
+  name: 'code-editor-error',
+  label: 'Code',
+  feedback: {
+    variant: 'danger',
+    message: 'Required field'
+  }
+}

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -113,24 +113,6 @@ PriceListRules.args = {
   ).concat('\n')
 }
 
-// export const OrganizationConfig = Template.bind({})
-// OrganizationConfig.args = {
-//   name: 'organization-config',
-//   label: 'Configuration',
-//   height: '600px',
-//   onChange: (value) => {
-//     console.log('organization config • Changed to:', value)
-//   },
-//   onValidate: (markers) => {
-//     console.log('organization config • Markers:', markers)
-//   },
-//   language: 'json',
-//   jsonSchema: 'organization-config',
-//   defaultValue: JSON.stringify({ mfe: { default: {} } }, undefined, 2).concat(
-//     '\n'
-//   )
-// }
-
 export const WithHint = Template.bind({})
 WithHint.args = {
   name: 'code-editor-hint',

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -35,7 +35,7 @@ export const Rules = Template.bind({})
 Rules.args = {
   name: 'rules',
   label: 'Rules',
-  height: '520px',
+  height: '450px',
   onChange: (value) => {
     console.log('rules • Changed to:', value)
   },
@@ -48,23 +48,20 @@ Rules.args = {
     {
       rules: [
         {
-          id: 'dkt7685f-7760-452e-b9b4-83434b89e2a4',
-          name: 'Discount products that are not already discounted (by diff price_amount_cents compared_at_amount_cents)',
+          id: 'b569f656-8bc2-4253-a19b-56062e7653ab',
+          name: 'Discount 3% if paid by credit card',
           conditions: [
             {
-              field:
-                'order.line_items.diff_cents_compare_at_amount_unit_amount',
+              field: 'order.payment_method.payment_source_type',
               matcher: 'eq',
-              value: 0,
-              group: 'discountable_items'
+              value: 'credit_cards'
             }
           ],
           actions: [
             {
               type: 'percentage',
-              selector: 'order.line_items.sku',
-              groups: ['discountable_items'],
-              value: '10%'
+              selector: 'order',
+              value: '3%'
             }
           ]
         }

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -31,19 +31,19 @@ Default.args = {
   defaultValue: 'This is just a \nmulti-line plaintext.\n'
 }
 
-export const Rules = Template.bind({})
-Rules.args = {
-  name: 'rules',
+export const PromotionRules = Template.bind({})
+PromotionRules.args = {
+  name: 'promotions-rules',
   label: 'Rules',
   height: '450px',
   onChange: (value) => {
-    console.log('rules • Changed to:', value)
+    console.log('promotion rules • Changed to:', value)
   },
   onValidate: (markers) => {
-    console.log('rules • Markers:', markers)
+    console.log('promotion rules • Markers:', markers)
   },
   language: 'json',
-  jsonSchema: 'promotions-rules',
+  jsonSchema: 'order-rules',
   defaultValue: JSON.stringify(
     {
       rules: [
@@ -69,6 +69,65 @@ Rules.args = {
     },
     undefined,
     2
+  ).concat('\n')
+}
+
+export const PriceListRules = Template.bind({})
+PriceListRules.args = {
+  name: 'price_lists-rules',
+  label: 'Rules',
+  height: '600px',
+  onChange: (value) => {
+    console.log('price_list rules • Changed to:', value)
+  },
+  onValidate: (markers) => {
+    console.log('price_list rules • Markers:', markers)
+  },
+  language: 'json',
+  jsonSchema: 'price-rules',
+  defaultValue: JSON.stringify(
+    {
+      rules: [
+        {
+          id: 'ce515b39-c820-46ae-b8e2-11a4e919ee22',
+          name: 'Price with amount_cents greather than equal 200',
+          conditions: [
+            {
+              field: 'price.amount_cents',
+              matcher: 'gteq',
+              value: 200
+            }
+          ],
+          actions: [
+            {
+              type: 'percentage',
+              selector: 'price',
+              value: '20%'
+            }
+          ]
+        }
+      ]
+    },
+    undefined,
+    2
+  ).concat('\n')
+}
+
+export const OrganizationConfig = Template.bind({})
+OrganizationConfig.args = {
+  name: 'organization-config',
+  label: 'Configuration',
+  height: '600px',
+  onChange: (value) => {
+    console.log('organization config • Changed to:', value)
+  },
+  onValidate: (markers) => {
+    console.log('organization config • Markers:', markers)
+  },
+  language: 'json',
+  jsonSchema: 'organization-config',
+  defaultValue: JSON.stringify({ mfe: { default: {} } }, undefined, 2).concat(
+    '\n'
   )
 }
 

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -20,21 +20,15 @@ const Template: StoryFn<typeof CodeEditor> = (args) => {
 
 export const Default = Template.bind({})
 Default.args = {
-  name: 'code-editor',
-  label: 'Code',
-  language: 'typescript',
-  // onChange: (value) => console.log('Changed to:', value),
-  // onValidate: (markers) => console.log('Markers:', markers),
-  defaultValue: `/**
- * Says hello to whoever dares to enter their name!
- * @param name The name of the person to greet.
- */
-function greet(name: string): void {
-  alert(\`Hello \${name}!\`)
-}
-
-greet('Marco')
-`
+  name: 'plaintext',
+  label: 'Message',
+  onChange: (value) => {
+    console.log('plaintext • Changed to:', value)
+  },
+  onValidate: (markers) => {
+    console.log('plaintext • Markers:', markers)
+  },
+  defaultValue: 'This is just a \nmulti-line plaintext.\n'
 }
 
 export const Rules = Template.bind({})
@@ -42,8 +36,12 @@ Rules.args = {
   name: 'rules',
   label: 'Rules',
   height: '520px',
-  // onChange: (value) => console.log('Changed to:', value),
-  // onValidate: (markers) => console.log('Markers:', markers),
+  onChange: (value) => {
+    console.log('rules • Changed to:', value)
+  },
+  onValidate: (markers) => {
+    console.log('rules • Markers:', markers)
+  },
   language: 'json',
   jsonSchema: 'promotions-rules',
   defaultValue: JSON.stringify(
@@ -81,6 +79,7 @@ export const WithHint = Template.bind({})
 WithHint.args = {
   name: 'code-editor-hint',
   label: 'Code',
+  language: 'plaintext',
   hint: {
     text: 'Please enter a valid rule'
   }
@@ -90,6 +89,7 @@ export const WithError = Template.bind({})
 WithError.args = {
   name: 'code-editor-error',
   label: 'Code',
+  language: 'plaintext',
   feedback: {
     variant: 'danger',
     message: 'Required field'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@commercelayer/sdk':
         specifier: 6.22.0
         version: 6.22.0
+      '@monaco-editor/react':
+        specifier: 4.6.0
+        version: 4.6.0(monaco-editor@0.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash':
         specifier: ^4.17.10
         version: 4.17.10
@@ -318,10 +321,6 @@ packages:
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
 
-  '@babel/code-frame@7.24.7':
-    resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.25.7':
     resolution: {integrity: sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==}
     engines: {node: '>=6.9.0'}
@@ -495,10 +494,6 @@ packages:
 
   '@babel/helpers@7.25.7':
     resolution: {integrity: sha512-Sv6pASx7Esm38KQpF/U/OXLwPPrdGHNKoeblRxgZRLXnAtnkEe4ptJPDtAZM7fBLadbc1Q07kQpSiGQ0Jg6tRA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/highlight@7.24.7':
-    resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.25.7':
@@ -1430,6 +1425,18 @@ packages:
 
   '@microsoft/tsdoc@0.15.0':
     resolution: {integrity: sha512-HZpPoABogPvjeJOdzCOSJsXeL/SMCBgBZMVC3X3d7YYp2gf31MfxhUoYUNwf1ERPJOnQc0wkFn9trqI6ZEdZuA==}
+
+  '@monaco-editor/loader@1.4.0':
+    resolution: {integrity: sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==}
+    peerDependencies:
+      monaco-editor: '>= 0.21.0 < 1'
+
+  '@monaco-editor/react@4.6.0':
+    resolution: {integrity: sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   '@mswjs/interceptors@0.35.9':
     resolution: {integrity: sha512-SSnyl/4ni/2ViHKkiZb8eajA/eN1DNFaHjhGiLUdZvDz6PKF4COSf/17xqSz64nOo2Ia29SA6B2KNCsyCbVmaQ==}
@@ -4978,6 +4985,9 @@ packages:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
 
+  monaco-editor@0.52.0:
+    resolution: {integrity: sha512-OeWhNpABLCeTqubfqLMXGsqf6OmPU6pHM85kF3dhy6kq5hnhuVS1p3VrEW/XhWHc71P2tHyS5JFySD8mgs1crw==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -6093,6 +6103,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
@@ -6940,11 +6953,6 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  '@babel/code-frame@7.24.7':
-    dependencies:
-      '@babel/highlight': 7.24.7
-      picocolors: 1.1.0
-
   '@babel/code-frame@7.25.7':
     dependencies:
       '@babel/highlight': 7.25.7
@@ -7199,13 +7207,6 @@ snapshots:
     dependencies:
       '@babel/template': 7.25.7
       '@babel/types': 7.25.7
-
-  '@babel/highlight@7.24.7':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.24.7
-      chalk: 2.4.2
-      js-tokens: 4.0.0
-      picocolors: 1.1.0
 
   '@babel/highlight@7.25.7':
     dependencies:
@@ -7894,7 +7895,7 @@ snapshots:
 
   '@babel/template@7.25.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.25.7
       '@babel/parser': 7.25.6
       '@babel/types': 7.25.6
 
@@ -7906,7 +7907,7 @@ snapshots:
 
   '@babel/traverse@7.25.6':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.25.7
       '@babel/generator': 7.25.6
       '@babel/parser': 7.25.6
       '@babel/template': 7.25.0
@@ -8401,6 +8402,18 @@ snapshots:
       resolve: 1.22.8
 
   '@microsoft/tsdoc@0.15.0': {}
+
+  '@monaco-editor/loader@1.4.0(monaco-editor@0.52.0)':
+    dependencies:
+      monaco-editor: 0.52.0
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.6.0(monaco-editor@0.52.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@monaco-editor/loader': 1.4.0(monaco-editor@0.52.0)
+      monaco-editor: 0.52.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@mswjs/interceptors@0.35.9':
     dependencies:
@@ -9096,7 +9109,7 @@ snapshots:
   '@storybook/instrumenter@8.3.5(storybook@8.3.5)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@vitest/utils': 2.0.5
+      '@vitest/utils': 2.1.2
       storybook: 8.3.5
       util: 0.12.5
 
@@ -9191,7 +9204,7 @@ snapshots:
 
   '@testing-library/dom@10.4.0':
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.25.7
       '@babel/runtime': 7.25.6
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
@@ -12777,6 +12790,8 @@ snapshots:
 
   modify-values@1.0.1: {}
 
+  monaco-editor@0.52.0: {}
+
   ms@2.0.0: {}
 
   ms@2.1.2: {}
@@ -13220,7 +13235,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.24.7
+      '@babel/code-frame': 7.25.7
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -14043,6 +14058,8 @@ snapshots:
       minipass: 7.1.2
 
   stackback@0.0.2: {}
+
+  state-local@1.0.7: {}
 
   statuses@2.0.1: {}
 


### PR DESCRIPTION
## What I did

I created the new `CodeEditor` component.

<img width="839" alt="Screenshot 2024-10-11 alle 16 08 44" src="https://github.com/user-attachments/assets/8d980cd5-e7d9-48d1-8e4c-8bc9074c7055">

## How to test

You can test the autocompletion for promotion rules (json-schema) in the link below:

https://deploy-preview-762--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-codeeditor--docs#promotion%20rules

The `field` and `selector` attributes use core resources information.
