### PR TITLE
Fix `ResourceTags` edit ability check

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -71,7 +71,7 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
       <Section
         title='Tags'
         actionButton={
-          canUser('update', 'tags') && (
+          canUser('update', resourceType) && (
             <Button
               variant='secondary'
               size='mini'


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed `ResourceTags` edit ability check