### PR TITLE
Add variant `table` in `ResourceList`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Table/Table.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Table.tsx
@@ -1,18 +1,13 @@
 import cn from 'classnames'
 import React from 'react'
 
-export type TableProps = {
+export interface TableProps {
   thead?: React.ReactNode
   className?: string
   variant?: 'boxed'
-} & (
-  | {
-      tbody?: React.ReactNode
-    }
-  | {
-      children: React.ReactNode
-    }
-)
+  tbody?: React.ReactNode
+  tfoot?: React.ReactNode
+}
 
 /**
  * `<Table>` component is used to organize and display data efficiently.
@@ -32,7 +27,8 @@ export const Table: React.FC<TableProps> = ({
   thead,
   className,
   variant,
-  ...rest
+  tbody,
+  tfoot
 }) => {
   return (
     <table
@@ -46,11 +42,8 @@ export const Table: React.FC<TableProps> = ({
       ])}
     >
       {thead != null && <thead>{thead}</thead>}
-      {'tbody' in rest && rest.tbody != null ? (
-        <tbody>{rest.tbody}</tbody>
-      ) : 'children' in rest ? (
-        <>{rest.children}</>
-      ) : null}
+      {tbody != null && <tbody>{tbody}</tbody>}
+      {tfoot != null && <tfoot>{tfoot}</tfoot>}
     </table>
   )
 }

--- a/packages/app-elements/src/ui/atoms/Table/Table.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Table.tsx
@@ -1,12 +1,18 @@
 import cn from 'classnames'
 import React from 'react'
 
-export interface TableProps {
+export type TableProps = {
   thead?: React.ReactNode
-  tbody?: React.ReactNode
   className?: string
   variant?: 'boxed'
-}
+} & (
+  | {
+      tbody?: React.ReactNode
+    }
+  | {
+      children: React.ReactNode
+    }
+)
 
 /**
  * `<Table>` component is used to organize and display data efficiently.
@@ -24,9 +30,9 @@ export interface TableProps {
  */
 export const Table: React.FC<TableProps> = ({
   thead,
-  tbody,
   className,
-  variant
+  variant,
+  ...rest
 }) => {
   return (
     <table
@@ -40,7 +46,11 @@ export const Table: React.FC<TableProps> = ({
       ])}
     >
       {thead != null && <thead>{thead}</thead>}
-      {tbody != null && <tbody>{tbody}</tbody>}
+      {'tbody' in rest && rest.tbody != null ? (
+        <tbody>{rest.tbody}</tbody>
+      ) : 'children' in rest ? (
+        <>{rest.children}</>
+      ) : null}
     </table>
   )
 }

--- a/packages/app-elements/src/ui/atoms/Table/Td.tsx
+++ b/packages/app-elements/src/ui/atoms/Table/Td.tsx
@@ -1,7 +1,13 @@
 import { isJsonPrimitive } from '#utils/text'
 import cn from 'classnames'
+import {
+  SkeletonTemplate,
+  type SkeletonTemplateProps
+} from '../SkeletonTemplate'
 
-export interface TdProps extends React.TdHTMLAttributes<HTMLElement> {
+export interface TdProps
+  extends React.TdHTMLAttributes<HTMLElement>,
+    SkeletonTemplateProps {
   children?: React.ReactNode
   textEllipsis?: number
 }
@@ -10,6 +16,8 @@ export const Td: React.FC<TdProps> = ({
   children,
   className,
   textEllipsis,
+  isLoading,
+  delayMs,
   ...rest
 }) => {
   return (
@@ -17,23 +25,25 @@ export const Td: React.FC<TdProps> = ({
       className={cn('p-4 text-sm border-b border-gray-100 bg-white', className)}
       {...rest}
     >
-      {textEllipsis !== undefined ? (
-        <div
-          title={
-            isJsonPrimitive(children) &&
-            children !== null &&
-            children.toString().length > textEllipsis
-              ? children.toString()
-              : undefined
-          }
-          className='overflow-hidden text-ellipsis whitespace-nowrap'
-          style={{ maxWidth: `${textEllipsis}ch` }}
-        >
-          {children}
-        </div>
-      ) : (
-        children
-      )}
+      <SkeletonTemplate isLoading={isLoading} delayMs={delayMs}>
+        {textEllipsis !== undefined ? (
+          <div
+            title={
+              isJsonPrimitive(children) &&
+              children !== null &&
+              children.toString().length > textEllipsis
+                ? children.toString()
+                : undefined
+            }
+            className='overflow-hidden text-ellipsis whitespace-nowrap'
+            style={{ maxWidth: `${textEllipsis}ch` }}
+          >
+            {children}
+          </div>
+        ) : (
+          children
+        )}
+      </SkeletonTemplate>
     </td>
   )
 }

--- a/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx
@@ -90,6 +90,9 @@ export type ResourceListProps<TResource extends ListableResourceType> = Pick<
   }
   /**
    * An element to be rendered when the list is empty.
+   * When not provided, a default message will be shown.
+   * When a string is provided, it will be rendered as inline text below title and actionButton.
+   * When a JSX element is provided, it will be rendered as a custom element and no title or actionButton will be shown.
    */
   emptyState?: JSX.Element
   /**
@@ -98,6 +101,10 @@ export type ResourceListProps<TResource extends ListableResourceType> = Pick<
   title?:
     | ((recordCount: number | undefined) => React.ReactNode)
     | React.ReactNode
+  /**
+   * Force the size of the title, when not defined, title size will be `small` by default or `normal` when variant is `table` or `boxed`.
+   */
+  titleSize?: SectionProps['titleSize']
 } & (
     | {
         /** Boxed variant wraps the list in a Card */
@@ -138,6 +145,7 @@ export function ResourceList<TResource extends ListableResourceType>({
   type,
   query,
   title,
+  titleSize,
   variant,
   actionButton,
   metricsQuery,
@@ -224,7 +232,10 @@ export function ResourceList<TResource extends ListableResourceType>({
             variant === 'boxed' || variant === 'table' ? 'none' : undefined
           }
           actionButton={actionButton}
-          titleSize={variant === 'table' ? 'normal' : 'small'}
+          titleSize={
+            titleSize ??
+            (variant === 'boxed' || variant === 'table' ? 'normal' : 'small')
+          }
           data-testid='resource-list'
         >
           <SkeletonTemplate
@@ -266,13 +277,15 @@ export function ResourceList<TResource extends ListableResourceType>({
   }
 
   if (isEmptyList) {
-    return variant === 'table' ? (
+    return variant != null || typeof emptyStateProp === 'string' ? (
+      // inline empty state
       <Section>
         <div className='border-t' />
         <Spacer top='4'>{emptyState}</Spacer>
       </Section>
     ) : (
-      <>{emptyState}</>
+      // custom JSX element (no title or actionButton)
+      emptyState
     )
   }
 

--- a/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
@@ -74,10 +74,7 @@ interface UseResourceFiltersHook {
    * Filtered ResourceList component based on current active filters
    */
   FilteredList: <TResource extends ListableResourceType>(
-    props: Pick<
-      ResourceListProps<TResource>,
-      'type' | 'emptyState' | 'actionButton'
-    > &
+    props: Omit<ResourceListProps<TResource>, 'query' | 'metricsQuery'> &
       ResourceListItemTemplate<TResource> & {
         query?: Omit<
           NonNullable<ResourceListProps<TResource>['query']>,
@@ -149,7 +146,10 @@ export function useResourceFilters({
       }
       return (
         <ResourceList
-          {...listProps}
+          {
+            // could not discriminate on `variant`
+            ...(listProps as ResourceListProps<any>)
+          }
           title={
             hideTitle === true
               ? undefined

--- a/packages/docs/src/mocks/data/orders.js
+++ b/packages/docs/src/mocks/data/orders.js
@@ -3652,11 +3652,23 @@ const orderList = http.get(
   'https://mock.localhost/api/orders',
   async ({ request }) => {
     const url = new URL(request.url)
+    const marketIdFilter = url.searchParams.get('filter[q][market_id_eq]')
     const currentPage = parseInt(url.searchParams.get('page[number]') ?? '1')
     const itemPerPage = parseInt(url.searchParams.get('page[size]') ?? '5')
     const pageCount = itemPerPage <= 5 ? 1 : 3
 
     await delay(2000)
+
+    if (marketIdFilter === 'not-existing-id') {
+      return HttpResponse.json({
+        data: [],
+        meta: {
+          record_count: 0,
+          page_count: 1
+        },
+        included: []
+      })
+    }
 
     return HttpResponse.json({
       data: Array(itemPerPage)

--- a/packages/docs/src/stories/resources/ResourceList.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceList.stories.tsx
@@ -1,8 +1,10 @@
 import { CoreSdkProvider } from '#providers/CoreSdkProvider'
 import { MockTokenProvider as TokenProvider } from '#providers/TokenProvider/MockTokenProvider'
 import { Button } from '#ui/atoms/Button'
+import { Icon } from '#ui/atoms/Icon'
 import { SkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
+import { Td, Tr } from '#ui/atoms/Table'
 import { Text } from '#ui/atoms/Text'
 import { InputCheckboxGroup } from '#ui/forms/InputCheckboxGroup'
 import { ResourceList } from '#ui/resources/ResourceList'
@@ -66,6 +68,81 @@ export const WithNoTitle: StoryFn<typeof ResourceList> = () => {
               <SkeletonTemplate isLoading={isLoading}>
                 <ResourceListItem resource={resource} />
               </SkeletonTemplate>
+            )
+          }}
+        />
+      </CoreSdkProvider>
+    </TokenProvider>
+  )
+}
+
+export const AsTableVariant: StoryFn<typeof ResourceList> = () => {
+  return (
+    <TokenProvider kind='integration' appSlug='orders' devMode>
+      <CoreSdkProvider>
+        <ResourceList
+          title='Orders'
+          type='orders'
+          variant='table'
+          headings={[
+            { label: 'NUMBER' },
+            { label: 'MARKET' },
+            { label: 'TOTAL', align: 'right' }
+          ]}
+          actionButton={
+            <Button variant='secondary' size='mini' alignItems='center'>
+              <Icon name='plus' /> Order
+            </Button>
+          }
+          ItemTemplate={({ resource = mockedOrder, isLoading }) => {
+            return (
+              <Tr>
+                <Td isLoading={isLoading}>#{resource.number}</Td>
+                <Td isLoading={isLoading}>{resource.market?.name}</Td>
+                <Td isLoading={isLoading} align='right'>
+                  {resource.formatted_total_amount}
+                </Td>
+              </Tr>
+            )
+          }}
+        />
+      </CoreSdkProvider>
+    </TokenProvider>
+  )
+}
+
+export const AsTableWithEmptyList: StoryFn<typeof ResourceList> = () => {
+  return (
+    <TokenProvider kind='integration' appSlug='orders' devMode>
+      <CoreSdkProvider>
+        <ResourceList
+          title='Orders'
+          type='orders'
+          variant='table'
+          headings={[
+            { label: 'NUMBER' },
+            { label: 'MARKET' },
+            { label: 'TOTAL', align: 'right' }
+          ]}
+          query={{
+            filters: {
+              market_id_eq: 'not-existing-id'
+            }
+          }}
+          actionButton={
+            <Button variant='secondary' size='mini' alignItems='center'>
+              <Icon name='plus' /> Order
+            </Button>
+          }
+          ItemTemplate={({ resource = mockedOrder, isLoading }) => {
+            return (
+              <Tr>
+                <Td isLoading={isLoading}>#{resource.number}</Td>
+                <Td isLoading={isLoading}>{resource.market?.name}</Td>
+                <Td isLoading={isLoading} align='right'>
+                  {resource.formatted_total_amount}
+                </Td>
+              </Tr>
             )
           }}
         />


### PR DESCRIPTION
## What I did

[Preview](https://deploy-preview-777--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelist--docs#as%20table%20variant) 

I have added a new `ResourceList` variant to render the fetched content as a table.
When setting `variant='table'` a new `headings` prop is required to define the table heading columns.


Example
```tsx
<ResourceList
  title='Orders'
  type='orders'
  variant='table'
  headings={[
    { label: 'NUMBER' },
    { label: 'MARKET' },
    { label: 'TOTAL', align: 'right' }
  ]}
  actionButton={
    <Button variant='secondary' size='mini' alignItems='center'>
      <Icon name='plus' /> Order
    </Button>
  }
  ItemTemplate={({ resource = mockedOrder, isLoading }) => {
    return (
      <Tr>
        <Td isLoading={isLoading}>#{resource.number}</Td>
        <Td isLoading={isLoading}>{resource.market?.name}</Td>
        <Td isLoading={isLoading} align='right'>
          {resource.formatted_total_amount}
        </Td>
      </Tr>
    )
  }}
/>
```


## AI generates summary
 
This pull request introduces several enhancements and new features to the `Table` and `ResourceList` components, including the addition of a `tfoot` prop to the `Table` component and a new `table` variant for the `ResourceList` component. The changes also integrate a `SkeletonTemplate` for loading states and improve the handling of empty states and API errors.

### Enhancements to Table Component:
* Added `tfoot` prop to `TableProps` and updated the component to render it if provided. (`packages/app-elements/src/ui/atoms/Table/Table.tsx`) [[1]](diffhunk://#diff-39acf5d6a1c7bc81e996846326608d637dde33412344d036ca5feb54469c5328L6-R9) [[2]](diffhunk://#diff-39acf5d6a1c7bc81e996846326608d637dde33412344d036ca5feb54469c5328L27-R31) [[3]](diffhunk://#diff-39acf5d6a1c7bc81e996846326608d637dde33412344d036ca5feb54469c5328R46)

### Enhancements to Td Component:
* Integrated `SkeletonTemplate` into `Td` component to handle loading states. (`packages/app-elements/src/ui/atoms/Table/Td.tsx`) [[1]](diffhunk://#diff-7969935f1db7ada728f60daf03f3f3c2213f1055cbba2804c5d5d26db3f3ca2eR3-R10) [[2]](diffhunk://#diff-7969935f1db7ada728f60daf03f3f3c2213f1055cbba2804c5d5d26db3f3ca2eR19-R28) [[3]](diffhunk://#diff-7969935f1db7ada728f60daf03f3f3c2213f1055cbba2804c5d5d26db3f3ca2eR46)

### Enhancements to ResourceList Component:
* Added a new `table` variant to `ResourceList` with customizable table headings and improved empty state handling. (`packages/app-elements/src/ui/resources/ResourceList/ResourceList.tsx`) [[1]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9R1-R15) [[2]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L18-R32) [[3]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9R52-R55) [[4]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L76-R111) [[5]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L119-R144) [[6]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L178-R212) [[7]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L211-R312) [[8]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9L249-R345) [[9]](diffhunk://#diff-ffa3730e7382fcca97d65861b0a00dfec1c0c1de56103ecc2b3c04a6a06c32f9R376-R433)

### Improvements to Mock Data and Stories:
* Updated mock data to handle specific filters and added stories to demonstrate the new `table` variant of `ResourceList`. (`packages/docs/src/mocks/data/orders.js`, `packages/docs/src/stories/resources/ResourceList.stories.tsx`) [[1]](diffhunk://#diff-d2bd04a4e808b6876117f7dcebf58b8f126cad3637e55c9415f6fbc526630480R3655-R3672) [[2]](diffhunk://#diff-be757cb3fd3dab0373c581c44cbc398ed607aa534b698df463082d8360e8fbfdR4-R7) [[3]](diffhunk://#diff-be757cb3fd3dab0373c581c44cbc398ed607aa534b698df463082d8360e8fbfdR79-R153)

### Enhancements to useResourceFilters Hook:
* Modified `useResourceFilters` to support the new `table` variant of `ResourceList`. (`packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx`) [[1]](diffhunk://#diff-741416cf64e3ea218cbcc48c0a07350795cf9997941a9bda144b1e235ff47378L77-R77) [[2]](diffhunk://#diff-741416cf64e3ea218cbcc48c0a07350795cf9997941a9bda144b1e235ff47378L152-R152)