### PR TITLE
Enforce empty check of `ResourceDetails` components

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
@@ -6,6 +6,7 @@ import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
 import { ListDetailsItem } from '#ui/composite/ListDetailsItem'
 import { type Resource } from '@commercelayer/sdk'
+import isEmpty from 'lodash/isEmpty'
 
 export interface ResourceDetailsProps {
   resource: Resource
@@ -24,16 +25,17 @@ export const ResourceDetails = withSkeletonTemplate<ResourceDetailsProps>(
           <ListDetailsItem label='ID' gutter='none'>
             <CopyToClipboard value={resource?.id} />
           </ListDetailsItem>
-          {resource?.reference != null && (
+          {resource?.reference != null && !isEmpty(resource?.reference) && (
             <ListDetailsItem label='Reference' gutter='none'>
               <CopyToClipboard value={resource?.reference} />
             </ListDetailsItem>
           )}
-          {resource?.reference_origin != null && (
-            <ListDetailsItem label='Reference origin' gutter='none'>
-              <CopyToClipboard value={resource?.reference_origin} />
-            </ListDetailsItem>
-          )}
+          {resource?.reference_origin != null &&
+            !isEmpty(resource?.reference_origin) && (
+              <ListDetailsItem label='Reference origin' gutter='none'>
+                <CopyToClipboard value={resource?.reference_origin} />
+              </ListDetailsItem>
+            )}
           <ListDetailsItem label='Updated' gutter='none'>
             <Text weight='semibold'>
               {formatDate({


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced empty check of `reference` related fields in `ResourceDetails` components

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
