### PR TITLE
Cleanup props of `ResourceMetadata` component

### DIFF
--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -2,7 +2,7 @@ import { useOverlay } from '#hooks/useOverlay'
 import { PageLayout } from '#ui/composite/PageLayout'
 import { type ResourceMetadataProps } from '#ui/resources/ResourceMetadata'
 import { ResourceMetadataForm } from '#ui/resources/ResourceMetadata/ResourceMetadataForm'
-import React, { useCallback } from 'react'
+import { type FC, useCallback } from 'react'
 
 export interface EditMetadataOverlayProps {
   /**
@@ -15,13 +15,13 @@ export interface EditMetadataOverlayProps {
 
 interface MetadataOverlayHook {
   show: () => void
-  Overlay: React.FC<EditMetadataOverlayProps>
+  Overlay: FC<EditMetadataOverlayProps>
 }
 
 export function useEditMetadataOverlay(): MetadataOverlayHook {
   const { Overlay: OverlayElement, open, close } = useOverlay()
 
-  const OverlayComponent = useCallback<React.FC<EditMetadataOverlayProps>>(
+  const OverlayComponent = useCallback<FC<EditMetadataOverlayProps>>(
     ({ title = 'Back', resourceId, resourceType }) => {
       return (
         <OverlayElement backgroundColor='light'>

--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -10,7 +10,6 @@ export interface EditMetadataOverlayProps {
   title?: string
   resourceId: ResourceMetadataProps['resourceId']
   resourceType: ResourceMetadataProps['resourceType']
-  mode?: ResourceMetadataProps['mode']
 }
 
 interface MetadataOverlayHook {
@@ -23,12 +22,7 @@ export function useEditMetadataOverlay(): MetadataOverlayHook {
 
   return {
     show: open,
-    Overlay: ({
-      title = 'Back',
-      resourceId,
-      resourceType,
-      mode = 'advanced'
-    }) => {
+    Overlay: ({ title = 'Back', resourceId, resourceType }) => {
       return (
         <OverlayElement backgroundColor='light'>
           <PageLayout
@@ -45,7 +39,6 @@ export function useEditMetadataOverlay(): MetadataOverlayHook {
             <ResourceMetadataForm
               resourceId={resourceId}
               resourceType={resourceType}
-              mode={mode}
               onSubmitted={() => {
                 close()
               }}

--- a/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditMetadataOverlay.tsx
@@ -2,6 +2,7 @@ import { useOverlay } from '#hooks/useOverlay'
 import { PageLayout } from '#ui/composite/PageLayout'
 import { type ResourceMetadataProps } from '#ui/resources/ResourceMetadata'
 import { ResourceMetadataForm } from '#ui/resources/ResourceMetadata/ResourceMetadataForm'
+import React, { useCallback } from 'react'
 
 export interface EditMetadataOverlayProps {
   /**
@@ -20,9 +21,8 @@ interface MetadataOverlayHook {
 export function useEditMetadataOverlay(): MetadataOverlayHook {
   const { Overlay: OverlayElement, open, close } = useOverlay()
 
-  return {
-    show: open,
-    Overlay: ({ title = 'Back', resourceId, resourceType }) => {
+  const OverlayComponent = useCallback<React.FC<EditMetadataOverlayProps>>(
+    ({ title = 'Back', resourceId, resourceType }) => {
       return (
         <OverlayElement backgroundColor='light'>
           <PageLayout
@@ -46,6 +46,12 @@ export function useEditMetadataOverlay(): MetadataOverlayHook {
           </PageLayout>
         </OverlayElement>
       )
-    }
+    },
+    [OverlayElement]
+  )
+
+  return {
+    show: open,
+    Overlay: OverlayComponent
   }
 }

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -10,28 +10,15 @@ import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
-import { ListItem } from '#ui/composite/ListItem'
-import { humanizeString } from '#utils/text'
+import { ListDetailsItem } from '#ui/composite/ListDetailsItem'
 import { type ListableResourceType } from '@commercelayer/sdk'
 
 interface MetadataOverlay
-  extends Omit<
-    EditMetadataOverlayProps,
-    'resourceId' | 'resourceType' | 'mode'
-  > {}
-
-export type ResourceMetadataMode = 'simple' | 'advanced'
+  extends Omit<EditMetadataOverlayProps, 'resourceId' | 'resourceType'> {}
 
 export interface ResourceMetadataProps {
   resourceType: ListableResourceType
   resourceId: string
-  /**
-   * Metadata management mode:
-   * - If set to `simple` the edit page will permit to edit just the values of the existing items.
-   * - If set to `advanced` the edit page will permit to fully create, edit and remove the items.
-   * @default advanced
-   */
-  mode?: ResourceMetadataMode
   /**
    * Edit overlay configuration
    */
@@ -50,7 +37,7 @@ export const isUpdatableType = (value: any): value is UpdatableType => {
  * More in detail the `metadata` attribute is a JSON object, customizable for several purposes, and this component will allow to show and manage its keys with a simple (string kind) values.
  */
 export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
-  ({ resourceType, resourceId, mode = 'advanced', overlay }) => {
+  ({ resourceType, resourceId, overlay }) => {
     const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
 
     const { canUser } = useTokenProvider()
@@ -78,7 +65,6 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
         <Section
           title='Metadata'
           actionButton={
-            mode === 'advanced' &&
             canUser('update', resourceType) && (
               <Button
                 variant='secondary'
@@ -101,23 +87,19 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
                 if (!isUpdatableType(metadataValue)) return null
 
                 return (
-                  <ListItem
-                    padding='y'
+                  <ListDetailsItem
                     key={idx}
+                    gutter='none'
+                    label={metadataKey}
                     data-testid={`ResourceMetadata-item-${metadataKey}`}
                   >
-                    <Text variant='info'>
-                      {mode === 'advanced'
-                        ? metadataKey
-                        : humanizeString(metadataKey)}
-                    </Text>
                     <Text
                       weight='semibold'
                       data-testid={`ResourceMetadata-value-${metadataKey}`}
                     >
                       {metadataValue.toString()}
                     </Text>
-                  </ListItem>
+                  </ListDetailsItem>
                 )
               }
             )
@@ -127,14 +109,11 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
             </Spacer>
           )}
         </Section>
-        {mode === 'advanced' && canUser('update', resourceType) && (
-          <EditMetadataOverlay
-            title={overlay?.title}
-            resourceId={resourceId}
-            resourceType={resourceType}
-            mode={mode}
-          />
-        )}
+        <EditMetadataOverlay
+          title={overlay?.title}
+          resourceId={resourceId}
+          resourceType={resourceType}
+        />
       </div>
     )
   }

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadataForm.tsx
@@ -10,9 +10,7 @@ import { Button } from '#ui/atoms/Button'
 import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { Spacer } from '#ui/atoms/Spacer'
-import { Text } from '#ui/atoms/Text'
 import { ListItem } from '#ui/composite/ListItem'
-import { humanizeString } from '#utils/text'
 import { type Metadata } from '@commercelayer/sdk'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { Fragment, useMemo, useState } from 'react'
@@ -48,26 +46,18 @@ const metadataForm = z
 export const ResourceMetadataForm = withSkeletonTemplate<{
   resourceId: ResourceMetadataProps['resourceId']
   resourceType: ResourceMetadataProps['resourceType']
-  mode: ResourceMetadataProps['mode']
   onSubmitted: () => void
-}>(({ resourceId, resourceType, mode, onSubmitted }) => {
+}>(({ resourceId, resourceType, onSubmitted }) => {
   const {
     data: resourceData,
     isLoading,
     mutate: mutateResource
-  } = useCoreApi(
-    resourceType,
-    'retrieve',
-    [
-      resourceId,
-      {
-        fields: ['metadata']
-      }
-    ],
+  } = useCoreApi(resourceType, 'retrieve', [
+    resourceId,
     {
-      revalidateOnFocus: false
+      fields: ['metadata']
     }
-  )
+  ])
 
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [apiError, setApiError] = useState<any>(undefined)
@@ -82,7 +72,7 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
         })
       )
 
-      if (mode === 'advanced' && result.length === 0) {
+      if (result.length === 0) {
         result.push({
           key: '',
           value: ''
@@ -92,7 +82,7 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
       return result
     }
     return []
-  }, [resourceData?.metadata, mode])
+  }, [resourceData?.metadata])
 
   const methods = useForm({
     defaultValues: { metadata: keyedMetadata },
@@ -190,46 +180,38 @@ export const ResourceMetadataForm = withSkeletonTemplate<{
             return (
               <ListItem key={`metadata.${idx}`} alignItems='center' padding='y'>
                 <div className='flex items-center justify-between gap-4'>
-                  {mode === 'simple' ? (
-                    <Text variant='info'>{humanizeString(metadata.key)}</Text>
-                  ) : (
-                    <HookedInput name={`metadata.${idx}.key`} />
-                  )}
+                  <HookedInput name={`metadata.${idx}.key`} />
                   <div className='md:w-3/5'>
                     {editInputComponent(originalMetadata, idx)}
                   </div>
                 </div>
-                {mode === 'advanced' && (
-                  <button
-                    aria-label='Remove'
-                    type='button'
-                    className='rounded'
-                    onClick={() => {
-                      watchedMetadata.splice(idx, 1)
-                      methods.setValue('metadata', watchedMetadata)
-                    }}
-                  >
-                    <Icon name='minus' size={24} />
-                  </button>
-                )}
+                <button
+                  aria-label='Remove'
+                  type='button'
+                  className='rounded'
+                  onClick={() => {
+                    watchedMetadata.splice(idx, 1)
+                    methods.setValue('metadata', watchedMetadata)
+                  }}
+                >
+                  <Icon name='minus' size={24} />
+                </button>
               </ListItem>
             )
           })}
-          {mode === 'advanced' && (
-            <Spacer top='4'>
-              <Button
-                variant='secondary'
-                type='button'
-                onClick={() => {
-                  addNewRow()
-                }}
-                size='small'
-                alignItems='center'
-              >
-                <Icon name='plus' /> Add another
-              </Button>
-            </Spacer>
-          )}
+          <Spacer top='4'>
+            <Button
+              variant='secondary'
+              type='button'
+              onClick={() => {
+                addNewRow()
+              }}
+              size='small'
+              alignItems='center'
+            >
+              <Icon name='plus' /> Add another
+            </Button>
+          </Spacer>
         </Section>
       </Spacer>
       <Button type='submit' disabled={isSubmitting} className='w-full'>

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/index.tsx
@@ -1,5 +1,4 @@
 export {
   ResourceMetadata,
-  type ResourceMetadataMode,
   type ResourceMetadataProps
 } from './ResourceMetadata'

--- a/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceMetadata.stories.tsx
@@ -34,19 +34,6 @@ Default.args = {
 }
 
 /**
- * When mode attribute is set to `simple` you'll be able just to edit the metadata values.
- */
-export const Simple = Template.bind({})
-Simple.args = {
-  resourceType: 'customers',
-  resourceId: 'NMWYhbGorj',
-  mode: 'simple',
-  overlay: {
-    title: 'hello@commercelayer.io'
-  }
-}
-
-/**
  * When `metadata` are not defined the component doesn't render at all.
  */
 export const WithoutMetadata = Template.bind({})


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- Removed unused `mode` prop in `ResourceMetadata` component and nested components
- Finally fixed `ResourceMetadata` edit overlay by adopting the `useCallback` hook to load it
- Refined the `ResourceMetadata` values list by adopting `ListDetailsItem` component instead of `ListItem`

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
