### PR TITLE
Make `ResourceDetails` editable

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
@@ -23,7 +23,9 @@ export const ResourceDetails = withSkeletonTemplate<ResourceDetailsProps>(
     const { user, canUser } = useTokenProvider()
     const { Overlay: EditDetailsOverlay, show } = useEditDetailsOverlay()
 
-    const reference = `${resource?.reference ?? ''}${resource?.reference != null && resource?.reference_origin != null ? ' · ' : ''}${resource?.reference_origin ?? ''}`
+    const reference = [resource?.reference, resource?.reference_origin]
+      .filter(Boolean)
+      .join(' · ')
 
     return (
       <>

--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
@@ -1,41 +1,50 @@
 import { formatDate } from '#helpers/date'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { CopyToClipboard } from '#ui/atoms/CopyToClipboard'
+import { Icon } from '#ui/atoms/Icon'
 import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
 import { ListDetailsItem } from '#ui/composite/ListDetailsItem'
-import { type Resource } from '@commercelayer/sdk'
-import isEmpty from 'lodash/isEmpty'
+import { FlexRow } from '#ui/internals/FlexRow'
+import { type ListableResourceType, type Resource } from '@commercelayer/sdk'
+import { useEditDetailsOverlay } from './useEditDetailsOverlay'
 
 export interface ResourceDetailsProps {
   resource: Resource
+  onUpdated: (updatedResource: Resource) => void
 }
 
 /**
  * This component provides a listed visualization of details attributes of a given resource.
  */
 export const ResourceDetails = withSkeletonTemplate<ResourceDetailsProps>(
-  ({ resource }) => {
-    const { user } = useTokenProvider()
+  ({ resource, onUpdated }) => {
+    const { user, canUser } = useTokenProvider()
+    const { Overlay: EditDetailsOverlay, show } = useEditDetailsOverlay()
+
+    const reference = `${resource?.reference ?? ''}${resource?.reference != null && resource?.reference_origin != null ? ' · ' : ''}${resource?.reference_origin ?? ''}`
 
     return (
-      <div>
+      <>
         <Section title='Details'>
           <ListDetailsItem label='ID' gutter='none'>
             <CopyToClipboard value={resource?.id} />
           </ListDetailsItem>
-          {resource?.reference != null && !isEmpty(resource?.reference) && (
-            <ListDetailsItem label='Reference' gutter='none'>
-              <CopyToClipboard value={resource?.reference} />
-            </ListDetailsItem>
-          )}
-          {resource?.reference_origin != null &&
-            !isEmpty(resource?.reference_origin) && (
-              <ListDetailsItem label='Reference origin' gutter='none'>
-                <CopyToClipboard value={resource?.reference_origin} />
-              </ListDetailsItem>
-            )}
+          <ListDetailsItem label='Reference' gutter='none'>
+            <FlexRow alignItems='center'>
+              <Text weight='semibold'>{reference}</Text>
+              {canUser('update', resource.type as ListableResourceType) && (
+                <button
+                  onClick={() => {
+                    show()
+                  }}
+                >
+                  <Icon name='pencilSimple' size={16} />
+                </button>
+              )}
+            </FlexRow>
+          </ListDetailsItem>
           <ListDetailsItem label='Updated' gutter='none'>
             <Text weight='semibold'>
               {formatDate({
@@ -57,7 +66,8 @@ export const ResourceDetails = withSkeletonTemplate<ResourceDetailsProps>(
             </Text>
           </ListDetailsItem>
         </Section>
-      </div>
+        <EditDetailsOverlay resource={resource} onUpdated={onUpdated} />
+      </>
     )
   }
 )

--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetails.tsx
@@ -12,7 +12,7 @@ import { useEditDetailsOverlay } from './useEditDetailsOverlay'
 
 export interface ResourceDetailsProps {
   resource: Resource
-  onUpdated: (updatedResource: Resource) => void
+  onUpdated: () => Promise<void>
 }
 
 /**

--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
@@ -1,0 +1,73 @@
+import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import { HookedForm } from '#ui/forms/Form'
+import { HookedInput } from '#ui/forms/Input'
+import { HookedValidationApiError } from '#ui/forms/ReactHookForm'
+import { useForm } from 'react-hook-form'
+
+import { useCoreSdkProvider } from '#providers/CoreSdkProvider'
+import { Button } from '#ui/atoms/Button'
+import { Spacer } from '#ui/atoms/Spacer'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { z } from 'zod'
+import { type ResourceDetailsProps } from './ResourceDetails'
+
+const metadataForm = z.object({
+  reference: z.string().nullable(),
+  reference_origin: z.string().nullable()
+})
+
+export const ResourceDetailsForm = withSkeletonTemplate<{
+  resource: ResourceDetailsProps['resource']
+  onUpdated: ResourceDetailsProps['onUpdated']
+}>(({ resource, onUpdated }) => {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [apiError, setApiError] = useState<any>(undefined)
+  const { sdkClient } = useCoreSdkProvider()
+
+  const methods = useForm({
+    defaultValues: {
+      reference: resource.reference,
+      reference_origin: resource.reference_origin
+    },
+    resolver: zodResolver(metadataForm)
+  })
+
+  return (
+    <HookedForm
+      {...methods}
+      onSubmit={(formValues) => {
+        setIsSubmitting(true)
+        void sdkClient[resource.type]
+          .update({
+            id: resource.id,
+            reference: formValues.reference,
+            reference_origin: formValues.reference_origin
+          })
+          .then((updatedResource) => {
+            setIsSubmitting(false)
+            onUpdated(updatedResource)
+          })
+          .catch((error) => {
+            setApiError(error)
+            setIsSubmitting(false)
+          })
+      }}
+    >
+      <Spacer bottom='12'>
+        <Spacer bottom='8'>
+          <HookedInput name='reference' label='Reference' />
+        </Spacer>
+        <Spacer bottom='8'>
+          <HookedInput name='reference_origin' label='Reference origin' />
+        </Spacer>
+      </Spacer>
+      <Button type='submit' disabled={isSubmitting} className='w-full'>
+        Update
+      </Button>
+      <Spacer top='2'>
+        <HookedValidationApiError apiError={apiError} />
+      </Spacer>
+    </HookedForm>
+  )
+})

--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
@@ -44,9 +44,9 @@ export const ResourceDetailsForm = withSkeletonTemplate<{
             reference: formValues.reference,
             reference_origin: formValues.reference_origin
           })
-          .then((updatedResource) => {
+          .then(() => {
             setIsSubmitting(false)
-            onUpdated(updatedResource)
+            void onUpdated()
           })
           .catch((error) => {
             setApiError(error)

--- a/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/ResourceDetailsForm.tsx
@@ -21,7 +21,6 @@ export const ResourceDetailsForm = withSkeletonTemplate<{
   resource: ResourceDetailsProps['resource']
   onUpdated: ResourceDetailsProps['onUpdated']
 }>(({ resource, onUpdated }) => {
-  const [isSubmitting, setIsSubmitting] = useState(false)
   const [apiError, setApiError] = useState<any>(undefined)
   const { sdkClient } = useCoreSdkProvider()
 
@@ -37,7 +36,6 @@ export const ResourceDetailsForm = withSkeletonTemplate<{
     <HookedForm
       {...methods}
       onSubmit={(formValues) => {
-        setIsSubmitting(true)
         void sdkClient[resource.type]
           .update({
             id: resource.id,
@@ -45,12 +43,10 @@ export const ResourceDetailsForm = withSkeletonTemplate<{
             reference_origin: formValues.reference_origin
           })
           .then(() => {
-            setIsSubmitting(false)
             void onUpdated()
           })
           .catch((error) => {
             setApiError(error)
-            setIsSubmitting(false)
           })
       }}
     >
@@ -62,7 +58,11 @@ export const ResourceDetailsForm = withSkeletonTemplate<{
           <HookedInput name='reference_origin' label='Reference origin' />
         </Spacer>
       </Spacer>
-      <Button type='submit' disabled={isSubmitting} className='w-full'>
+      <Button
+        type='submit'
+        disabled={methods.formState.isSubmitting}
+        className='w-full'
+      >
         Update
       </Button>
       <Spacer top='2'>

--- a/packages/app-elements/src/ui/resources/ResourceDetails/useEditDetailsOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/useEditDetailsOverlay.tsx
@@ -1,0 +1,57 @@
+import { useOverlay } from '#hooks/useOverlay'
+import { PageLayout } from '#ui/composite/PageLayout'
+import { type FC, useCallback } from 'react'
+import { type ResourceDetailsProps } from './ResourceDetails'
+import { ResourceDetailsForm } from './ResourceDetailsForm'
+
+export interface EditDetailsOverlayProps {
+  /**
+   * Optional title shown as first line in edit overlay heading
+   */
+  title?: string
+  resource: ResourceDetailsProps['resource']
+  onUpdated: ResourceDetailsProps['onUpdated']
+}
+
+interface DetailsOverlayHook {
+  show: () => void
+  Overlay: FC<EditDetailsOverlayProps>
+}
+
+export function useEditDetailsOverlay(): DetailsOverlayHook {
+  const { Overlay: OverlayElement, open, close } = useOverlay()
+
+  const OverlayComponent = useCallback<FC<EditDetailsOverlayProps>>(
+    ({ title = 'Back', resource, onUpdated }) => {
+      return (
+        <OverlayElement backgroundColor='light'>
+          <PageLayout
+            title='Edit details'
+            minHeight={false}
+            navigationButton={{
+              label: title,
+              icon: 'arrowLeft',
+              onClick: () => {
+                close()
+              }
+            }}
+          >
+            <ResourceDetailsForm
+              resource={resource}
+              onUpdated={(updatedResource) => {
+                onUpdated(updatedResource)
+                close()
+              }}
+            />
+          </PageLayout>
+        </OverlayElement>
+      )
+    },
+    [OverlayElement]
+  )
+
+  return {
+    show: open,
+    Overlay: OverlayComponent
+  }
+}

--- a/packages/app-elements/src/ui/resources/ResourceDetails/useEditDetailsOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceDetails/useEditDetailsOverlay.tsx
@@ -38,9 +38,10 @@ export function useEditDetailsOverlay(): DetailsOverlayHook {
           >
             <ResourceDetailsForm
               resource={resource}
-              onUpdated={(updatedResource) => {
-                onUpdated(updatedResource)
-                close()
+              onUpdated={async () => {
+                await onUpdated().then(() => {
+                  close()
+                })
               }}
             />
           </PageLayout>

--- a/packages/docs/src/stories/resources/ResourceDetails.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceDetails.stories.tsx
@@ -46,7 +46,12 @@ export const ResourceDetailsDefault: StoryFn = () => {
   return (
     <TokenProvider kind='integration' appSlug='customers' devMode>
       <CoreSdkProvider>
-        <ResourceDetails resource={customer} />
+        <ResourceDetails
+          resource={customer}
+          onUpdated={async () => {
+            console.log('updated')
+          }}
+        />
       </CoreSdkProvider>
     </TokenProvider>
   )


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added `onUpdated` prop to `ResourceDetails` component to be able to manage any kind of callback in consumer apps that should happen once the internal patch of the resource managed by the component is completed.

<img width="669" alt="Screenshot 2024-10-11 alle 12 08 57" src="https://github.com/user-attachments/assets/8792301b-bdf6-4383-9a75-1b8681f68514">

An example usage should be this one:
```
<ResourceDetails
                resource={resourceData}
                onUpdated={async () => {
                  void mutateResource()
                }}
/>
```

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
