### PR TITLE
Manage `refunded` return status

### DIFF
--- a/packages/app-elements/src/dictionaries/returns.ts
+++ b/packages/app-elements/src/dictionaries/returns.ts
@@ -56,6 +56,13 @@ export function getReturnDisplayStatus(returnObj: Return): ReturnDisplayStatus {
         color: 'red'
       }
 
+    case 'refunded':
+      return {
+        label: 'Refunded',
+        icon: 'creditCard',
+        color: 'green'
+      }
+
     default:
       return {
         label: `Not handled: (${returnObj.status})`,

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -211,6 +211,15 @@ export const presetResourceListItem = {
     status: 'rejected',
     order
   },
+  returnRefunded: {
+    type: 'returns',
+    id: '',
+    number: '123456',
+    updated_at: '2023-06-10T06:38:44.964Z',
+    created_at: '',
+    status: 'refunded',
+    order
+  },
   customerProspect: {
     type: 'customers',
     id: '',


### PR DESCRIPTION
## What I did

I managed the `refunded` return status.

https://deploy-preview-796--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelistitem--docs#returns


<img width="668" alt="Screenshot 2024-10-11 alle 12 15 04" src="https://github.com/user-attachments/assets/e1e5b383-aa55-441e-af9d-b931bf8eca2a">
