### PR TITLE
Adjust type for `emptyState` prop in `useResourceList` to accept any ReactNode

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceList/useResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceList/useResourceList.tsx
@@ -66,9 +66,9 @@ export type ResourceListProps<TResource extends ListableResourceType> = Pick<
    * An element to be rendered when the list is empty.
    * When not provided, a default message will be shown.
    * When a string is provided, it will be rendered as inline text below title and actionButton.
-   * When a JSX element is provided, it will be rendered as a custom element and no title or actionButton will be shown.
+   * When other ReactNode is provided, it will be rendered as a custom element and no title or actionButton will be shown.
    */
-  emptyState?: JSX.Element
+  emptyState?: ReactNode
   /**
    * Title.
    */


### PR DESCRIPTION
## What I did

I've update the type definition for useResourceList since `emptyState` prop could be any ReactNode (including null or string)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
