### PR TITLE
Add `organization-config` schema to the CodeEditor component

### DIFF
--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -35,7 +35,7 @@ export interface CodeEditorProps
    * JSON Schema to be used when writing JSON
    * @default none
    */
-  jsonSchema?: 'none' | 'order-rules' | 'price-rules'
+  jsonSchema?: 'none' | 'order-rules' | 'price-rules' | 'organization-config'
   /**
    * Trigger on every update.
    * @param markers List of markers (errors). `null` when there're no errors.
@@ -113,6 +113,22 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
 
           switch (jsonSchema) {
             case 'none': {
+              break
+            }
+
+            case 'organization-config': {
+              schemas.push({
+                schema: await fetch(
+                  'https://provisioning.commercelayer.io/api/public/schemas/organization_config'
+                )
+                  .then<JsonValue>(async (res) => await res.json())
+                  .then((json) => {
+                    return clearExamples(json)
+                  }),
+                uri: `file:///json-schema--${jsonSchema}.json`,
+                fileMatch: [uri]
+              })
+
               break
             }
 

--- a/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/CodeEditor.stories.tsx
@@ -113,6 +113,24 @@ PriceListRules.args = {
   ).concat('\n')
 }
 
+export const OrganizationConfig = Template.bind({})
+OrganizationConfig.args = {
+  name: 'organization-config',
+  label: 'Configuration',
+  height: '600px',
+  onChange: (value) => {
+    console.log('organization config • Changed to:', value)
+  },
+  onValidate: (markers) => {
+    console.log('organization config • Markers:', markers)
+  },
+  language: 'json',
+  jsonSchema: 'organization-config',
+  defaultValue: JSON.stringify({ mfe: { default: {} } }, undefined, 2).concat(
+    '\n'
+  )
+}
+
 export const WithHint = Template.bind({})
 WithHint.args = {
   name: 'code-editor-hint',


### PR DESCRIPTION
## What I did

I added an `organization-config` value to the `jsonSchema` property for the `CodeEditor` component.

This setting will help you in writing a proper valid JSON for the `organization.config` attribute.

## How to test

https://github.com/user-attachments/assets/8d2962a5-156b-401c-80ce-a1e99f942762

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
