### PR TITLE
Restore original behavior of title size in resource list

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceList/useResourceList.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceList/useResourceList.tsx
@@ -228,7 +228,7 @@ export function useResourceList<TResource extends ListableResourceType>({
       ItemTemplate,
       emptyState: emptyStateProp,
       title,
-      titleSize,
+      titleSize: titleSizeProp,
       variant,
       actionButton,
       ...rest
@@ -240,6 +240,10 @@ export function useResourceList<TResource extends ListableResourceType>({
               title,
               recordCount
             })
+      // lists by default have a small title, but table and boxed have a normal title size unless specified
+      const titleSize =
+        titleSizeProp ??
+        (variant === 'table' || variant === 'boxed' ? 'normal' : 'small')
       const sectionBorder =
         variant === 'boxed' || variant === 'table' ? 'none' : undefined
       const tableHeadings = 'headings' in rest ? rest.headings : undefined


### PR DESCRIPTION
## What I did

I've fixed a regression with the default title size in `useResourceList` hook (former `useResourceList`).

Lists of resources by default have a small title, but table and boxed variants have a normal title size unless manually specified.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
