### PR TITLE
Enhance `formatDate` time formatting

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -67,6 +67,16 @@ describe('formatDate', () => {
     ).toBe('Today')
   })
 
+  test('Should return "00:32" as time', () => {
+    expect(
+      formatDate({
+        isoDate: '2023-12-25T00:32:00.000Z',
+        format: 'fullWithSeconds',
+        showCurrentYear: true
+      })
+    ).toContain('00:32')
+  })
+
   test('Should return a date with time', () => {
     // AM
     expect(

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -145,7 +145,7 @@ function getPresetFormatTemplate(
           ? 'LLL dd'
           : 'LLL dd, yyyy'
     case 'time':
-      return 'kk:mm'
+      return 'HH:mm'
     case 'timeWithSeconds':
       return `${getPresetFormatTemplate(zonedDate, timezone, 'time', showCurrentYear)}:ss`
     case 'full':


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/246

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Replaced time format of `formatDate` helper to show 0-23 hours instead of 1-24 according to `date-fns` documentation:
https://date-fns.org/v4.1.0/docs/format

## Actual behavior
<img width="600" alt="Screenshot 2024-10-15 alle 10 44 03" src="https://github.com/user-attachments/assets/9c38c6bd-4974-4872-bb15-a5cb2df3c020">

<img width="600" alt="Screenshot 2024-10-15 alle 10 42 52" src="https://github.com/user-attachments/assets/dc773f47-8bcb-4df0-827b-c3680817833d">

## Wanted behavior
<img width="600" alt="Screenshot 2024-10-15 alle 10 43 40" src="https://github.com/user-attachments/assets/bf59f270-7f38-49cb-828d-45c69d0aadba">

<img width="600" alt="Screenshot 2024-10-15 alle 10 41 33" src="https://github.com/user-attachments/assets/8fc27e2e-be1a-4eb1-81a4-1aea5100e186">

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
