### PR TITLE
Remove `domain` prop in TokenProvider

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -37,6 +37,7 @@
     "ts:check": "tsc --noEmit"
   },
   "dependencies": {
+    "@commercelayer/js-auth": "^6.6.2",
     "@commercelayer/sdk": "6.22.0",
     "@monaco-editor/react": "4.6.0",
     "@types/lodash": "^4.17.10",

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.test.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.test.tsx
@@ -5,9 +5,9 @@ import { TokenProvider, type TokenProviderProps } from './TokenProvider'
 // slug is `giuseppe`
 // kind is `integration`
 const accessToken =
-  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJrUk1lakZXalpSIiwic2x1ZyI6ImdpdXNlcHBlIiwiZW50ZXJwcmlzZSI6ZmFsc2V9LCJhcHBsaWNhdGlvbiI6eyJpZCI6IkFwUGtaaWxWQk0iLCJraW5kIjoiaW50ZWdyYXRpb24iLCJwdWJsaWMiOmZhbHNlfSwidGVzdCI6dHJ1ZSwiZXhwIjoxNjc1Njg0Mzk5LCJyYW5kIjowLjg1ODA5MzgzOTA3OTQ1OTZ9.fake-signature-test'
+  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJrUk1lakZXalpSIiwic2x1ZyI6ImdpdXNlcHBlIiwiZW50ZXJwcmlzZSI6ZmFsc2V9LCJhcHBsaWNhdGlvbiI6eyJpZCI6IkFwUGtaaWxWQk0iLCJraW5kIjoiaW50ZWdyYXRpb24iLCJwdWJsaWMiOmZhbHNlfSwidGVzdCI6dHJ1ZSwiZXhwIjoxNjc1Njg0Mzk5LCJyYW5kIjowLjg1ODA5MzgzOTA3OTQ1OTYsImlzcyI6Imh0dHBzOi8vYXV0aC5jb21tZXJjZWxheWVyLmlvIn0.fake-signature-test'
 const accessTokenLive =
-  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJrUk1lakZXalpSIiwic2x1ZyI6ImdpdXNlcHBlIiwiZW50ZXJwcmlzZSI6ZmFsc2V9LCJhcHBsaWNhdGlvbiI6eyJpZCI6IkFwUGtaaWxWQk0iLCJraW5kIjoiaW50ZWdyYXRpb24iLCJwdWJsaWMiOmZhbHNlfSwidGVzdCI6dHJ1ZSwiZXhwIjoxNjc1Njg0Mzk5LCJyYW5kIjowLjg1ODA5MzgzOTA3OTQ1OTZ9.fake-signature-live'
+  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJrUk1lakZXalpSIiwic2x1ZyI6ImdpdXNlcHBlIiwiZW50ZXJwcmlzZSI6ZmFsc2V9LCJhcHBsaWNhdGlvbiI6eyJpZCI6IkFwUGtaaWxWQk0iLCJraW5kIjoiaW50ZWdyYXRpb24iLCJwdWJsaWMiOmZhbHNlfSwidGVzdCI6ZmFsc2UsImV4cCI6MTY3NTY4NDM5OSwicmFuZCI6MC44NTgwOTM4MzkwNzk0NTk2LCJpc3MiOiJodHRwczovL2F1dGguY29tbWVyY2VsYXllci5pbyJ9.fake-signature-live'
 const validDateNow = new Date('2023-02-06T10:00:00.000Z')
 const expiredDateNow = new Date('2023-02-10T10:00:00.000Z')
 
@@ -93,7 +93,7 @@ describe('TokenProvider', () => {
     expect(getByText('can access orders: yes')).toBeVisible()
     expect(getByText('can access exports: no')).toBeVisible()
 
-    expect(onInvalidAuth).toBeCalledTimes(0)
+    expect(onInvalidAuth).toHaveBeenCalledTimes(0)
   })
 
   test('Should return live mode if token comes from live environment', async () => {

--- a/packages/app-elements/src/providers/TokenProvider/getOrganization.ts
+++ b/packages/app-elements/src/providers/TokenProvider/getOrganization.ts
@@ -1,23 +1,18 @@
+import { getCoreApiBaseEndpoint } from '@commercelayer/js-auth'
 import { type Organization } from '@commercelayer/sdk'
 import fetch from 'cross-fetch'
 
 export async function getOrganization({
-  accessToken,
-  organizationSlug,
-  domain
+  accessToken
 }: {
   accessToken: string
-  organizationSlug: string
-  domain: string
 }): Promise<Organization | null> {
   try {
-    const response = await fetch(
-      `https://${organizationSlug}.${domain}/api/organization`,
-      {
-        method: 'GET',
-        headers: { authorization: `Bearer ${accessToken}` }
-      }
-    )
+    const apiBaseEndpoint = getCoreApiBaseEndpoint(accessToken)
+    const response = await fetch(`${apiBaseEndpoint}/api/organization`, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${accessToken}` }
+    })
     const organization = await response.json()
     return organization?.data?.attributes ?? null
   } catch {

--- a/packages/app-elements/src/providers/TokenProvider/url.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/url.test.ts
@@ -1,45 +1,15 @@
-import { isProductionHostname } from './url'
+import { extractDomainFromApiBaseEndpoint } from './url'
 
-describe('isProductionHostname', () => {
-  const { location } = window
-  beforeAll(function clearLocation() {
-    delete (window as any).location
-    ;(window as any).location = {
-      ...location,
-      hostname: ''
-    }
-  })
-  afterAll(function resetLocation() {
-    window.location = location
-  })
+describe('extractDomainFromApiBaseEndpoint', () => {
+  test('should return the domain from the apiBaseEndpoint', () => {
+    expect(
+      extractDomainFromApiBaseEndpoint('https://demo-store.commercelayer.io')
+    ).toBe('commercelayer.io')
 
-  test('should return true for production hostnames', () => {
-    ;[
-      'org.commercelayer.app',
-      'org-123.commercelayer.app',
-      '123-456.commercelayer.app',
-      'dashboard.commercelayer.io',
-      '_org.commercelayer.app',
-      'org_.commercelayer.app',
-      'org-_.commercelayer.app',
-      'org_-.commercelayer.app',
-      '123.commercelayer.app',
-      'org123.commercelayer.app'
-    ].forEach((hostname) => {
-      window.location.hostname = hostname
-      expect(isProductionHostname()).toBe(true)
-    })
-  })
-
-  test('should return false for non-production hostnames', () => {
-    ;[
-      'demo-store.stg.commercelayer.app',
-      'demo-store.stg.commercelayer.app.test',
-      'org.dashboard.commercelayer.io',
-      'dashboard.commercelayer.io.test'
-    ].forEach((hostname) => {
-      window.location.hostname = hostname
-      expect(isProductionHostname()).toBe(false)
-    })
+    expect(
+      extractDomainFromApiBaseEndpoint(
+        'https://demo-store.foo.commercelayer.io'
+      )
+    ).toBe('foo.commercelayer.io')
   })
 })

--- a/packages/app-elements/src/providers/TokenProvider/url.ts
+++ b/packages/app-elements/src/providers/TokenProvider/url.ts
@@ -19,12 +19,11 @@ export function makeDashboardUrl({
   return `https://dashboard.${domain}/${mode}/${orgSlug}`
 }
 
-export function isProductionHostname(): boolean {
-  if (typeof window !== 'undefined') {
-    return /^[\w-]+\.commercelayer\.app$|^dashboard\.commercelayer\.io$/.test(
-      window.location.hostname
-    )
+export function extractDomainFromApiBaseEndpoint(
+  apiBaseEndpoint?: string | null
+): string {
+  if (apiBaseEndpoint == null) {
+    return 'commercelayer.io'
   }
-
-  return false
+  return apiBaseEndpoint.replace('https://', '').split('.').slice(1).join('.')
 }

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
@@ -1,7 +1,7 @@
 import { isTokenExpired, isValidTokenForCurrentApp } from './validateToken'
 
 const token =
-  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJkWGttWkZNcUdSIiwic2x1ZyI6ImdpdXNlcHBlLWltcG9ydHMiLCJlbnRlcnByaXNlIjpmYWxzZX0sImFwcGxpY2F0aW9uIjp7ImlkIjoiYU1hS21pYW5CTiIsImtpbmQiOiJpbnRlZ3JhdGlvbiIsInB1YmxpYyI6ZmFsc2V9LCJ0ZXN0Ijp0cnVlLCJleHAiOjE2NjE4NjA4NzksInJhbmQiOjAuNDIzNzM0OTczNTE3NzY0OH0.1dJs_MjNl8rEa8KOSFNea921LS-PpVOaM65kNqL-yFYy4NJdpZ_HHTNAWCCX2LXV2RQ5cg241CvxPJz3IhFw2g'
+  'eyJhbGciOiJIUzUxMiJ9.eyJvcmdhbml6YXRpb24iOnsiaWQiOiJkWGttWkZNcUdSIiwic2x1ZyI6ImdpdXNlcHBlLWltcG9ydHMiLCJlbnRlcnByaXNlIjpmYWxzZX0sImFwcGxpY2F0aW9uIjp7ImlkIjoiYU1hS21pYW5CTiIsImtpbmQiOiJpbnRlZ3JhdGlvbiIsInB1YmxpYyI6ZmFsc2V9LCJ0ZXN0Ijp0cnVlLCJleHAiOjE2NjE4NjA4NzksInJhbmQiOjAuNDIzNzM0OTczNTE3NzY0OCwiaXNzIjoiaHR0cHM6Ly9hdXRoLmNvbW1lcmNlbGF5ZXIuaW8ifQ.yw9TjnpUDUyqeyJ0xv7AS-Suq0TIh7GIAtLyEDvG0yy8t94XM4HojZ6sTU7o963qGOj9Ni7z4wUT4RihWWRpCw'
 
 describe('isTokenExpired', () => {
   test('should check expired token', () => {
@@ -31,7 +31,6 @@ describe('isValidTokenForCurrentApp', () => {
     const tokenInfo = await isValidTokenForCurrentApp({
       accessToken: token,
       kind: 'integration',
-      domain: 'commercelayer.io',
       isProduction: false,
       currentMode: 'test'
     })

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.ts
@@ -3,6 +3,7 @@ import {
   type TokenProviderAllowedApp,
   type TokenProviderTokenApplicationKind
 } from '#providers/TokenProvider'
+import { getCoreApiBaseEndpoint } from '@commercelayer/js-auth'
 import { type ListableResourceType } from '@commercelayer/sdk'
 import fetch from 'cross-fetch'
 import isEmpty from 'lodash/isEmpty'
@@ -49,14 +50,12 @@ interface InvalidToken {
 export async function isValidTokenForCurrentApp({
   accessToken,
   kind,
-  domain,
   isProduction,
   currentMode,
   organizationSlug
 }: {
   accessToken: string
   kind: TokenProviderTokenApplicationKind
-  domain: string
   isProduction: boolean
   currentMode: Mode
   /**
@@ -83,9 +82,9 @@ export async function isValidTokenForCurrentApp({
   try {
     const tokenInfo = await fetchTokenInfo({
       accessToken,
-      orgSlug: jwtInfo.orgSlug,
-      domain
+      orgSlug: jwtInfo.orgSlug
     })
+
     const isValidOnCore = Boolean(tokenInfo?.token)
     const isValidKind = jwtInfo.appKind === kind
     const isValidOrganizationSlug = isEmpty(organizationSlug)
@@ -152,16 +151,15 @@ export async function isValidTokenForCurrentApp({
 
 async function fetchTokenInfo({
   accessToken,
-  orgSlug,
-  domain
+  orgSlug
 }: {
   accessToken: string
   orgSlug: string
-  domain: string
 }): Promise<TokenProviderTokenInfo | null> {
   try {
+    const coreApiBaseEndpoint = getCoreApiBaseEndpoint(accessToken)
     const tokenInfoResponse = await fetch(
-      `https://${orgSlug}.${domain}/oauth/tokeninfo`,
+      `${coreApiBaseEndpoint}/oauth/tokeninfo`,
       {
         method: 'GET',
         headers: { authorization: `Bearer ${accessToken}` }

--- a/packages/app-elements/src/providers/createApp.tsx
+++ b/packages/app-elements/src/providers/createApp.tsx
@@ -20,11 +20,6 @@ declare global {
   interface Window extends ClApp {
     clAppConfig: {
       /**
-       * Specific domain to use for Commerce Layer API requests.
-       * It must be set as `commercelayer.io`.
-       */
-      domain: string
-      /**
        * Enable Google Tag Manager for the provided GTM ID.
        */
       gtmId?: string
@@ -35,7 +30,7 @@ declare global {
 export interface ClAppProps
   extends Pick<
     TokenProviderProps,
-    'organizationSlug' | 'domain' | 'onAppClose' | 'isInDashboard' | 'extras'
+    'organizationSlug' | 'onAppClose' | 'isInDashboard' | 'extras'
   > {
   /**
    * Base path for internal routing.
@@ -67,7 +62,6 @@ export function createApp(
       root.render(
         children({
           ...props,
-          domain: props?.domain ?? window.clAppConfig?.domain,
           organizationSlug: parseOrganizationSlug(props?.organizationSlug),
           routerBase: parseRouterBase(props?.routerBase)
         })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   packages/app-elements:
     dependencies:
+      '@commercelayer/js-auth':
+        specifier: ^6.6.2
+        version: 6.6.2
       '@commercelayer/sdk':
         specifier: 6.22.0
         version: 6.22.0
@@ -1092,6 +1095,10 @@ packages:
     peerDependencies:
       eslint: '>=8.0'
       typescript: '>=5.0'
+
+  '@commercelayer/js-auth@6.6.2':
+    resolution: {integrity: sha512-mFfAnoPBHyaH6KrRI7jr3XYxVX0BlnN6pDUUj5HQx3h2iOBzmG8R2B9MQnW/inFTmF0qL4KZx8FZ2hFcb5gZ3w==}
+    engines: {node: '>=18.0.0'}
 
   '@commercelayer/sdk@6.22.0':
     resolution: {integrity: sha512-iaNFlW5QXE/+/4fsAwhGZ1j3H3PVcablNuRnOCXyMZ2keybJsQ/VEfJDeUnpD3FLEjDyUa4Z+HJzlgb+373puw==}
@@ -3780,6 +3787,7 @@ packages:
   follow-redirects@1.15.8:
     resolution: {integrity: sha512-xgrmBhBToVKay1q2Tao5LI26B83UhrB/vM1avwVSDzt8rx3rO6AizBAaF46EgksTVr+rFTQaqZZ9MVBfUe4nig==}
     engines: {node: '>=4.0'}
+    deprecated: Browser detection issues fixed in v1.15.9
     peerDependencies:
       debug: '*'
     peerDependenciesMeta:
@@ -7990,6 +7998,8 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  '@commercelayer/js-auth@6.6.2': {}
 
   '@commercelayer/sdk@6.22.0': {}
 


### PR DESCRIPTION
 Closes commercelayer/issues-app#182

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

TokenProvider does not accept anymore `domain` prop.
Base API endpoint will be derived now from `iss` property present in access token.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
