### PR TITLE
Clean up unwanted css class in InputWrapper

### DIFF
--- a/packages/app-elements/src/ui/internals/InputWrapper.tsx
+++ b/packages/app-elements/src/ui/internals/InputWrapper.tsx
@@ -75,7 +75,7 @@ export const InputWrapper = withSkeletonTemplate<InputWrapperProps>(
               </Label>
             ))}
           <div
-            className={cn('justify-self-end', {
+            className={cn({
               'w-full flex justify-end text-right': inline
             })}
           >

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`ResourceLineItems > should disable the remove action when \`onSwap\` is
                   class=""
                 >
                   <div
-                    class="justify-self-end"
+                    class=""
                   >
                     <div
                       class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
@@ -533,7 +533,7 @@ exports[`ResourceLineItems > should render the InputSpinner and the trash icon w
                   class=""
                 >
                   <div
-                    class="justify-self-end"
+                    class=""
                   >
                     <div
                       class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
@@ -1207,7 +1207,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                   class=""
                 >
                   <div
-                    class="justify-self-end"
+                    class=""
                   >
                     <div
                       class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"
@@ -1464,7 +1464,7 @@ exports[`ResourceLineItems > should render the swap action when \`onSwap\` is de
                   class=""
                 >
                   <div
-                    class="justify-self-end"
+                    class=""
                   >
                     <div
                       class="flex items-center justify-between rounded w-[122px] p-0.5 py-1 bg-white shadow-[0_0_0_1px_#e6e7e7_inset] focus-within:shadow-[0_0_0_2px_#101111_inset]"


### PR DESCRIPTION
## What I did

I've removed an not required css classname to mitigate a regression with latest (130.0.6723.59 - at the time of writing) chromium engine
https://issues.chromium.org/issues/374034249


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
