### PR TITLE
Add `ResourcePaymentMethod` component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -333,6 +333,11 @@ export {
   type ResourceOrderTimelineProps
 } from '#ui/resources/ResourceOrderTimeline'
 export {
+  ResourcePaymentMethod,
+  getPaymentMethodLogoSrc,
+  type ResourcePaymentMethodProps
+} from '#ui/resources/ResourcePaymentMethod'
+export {
   ResourceShipmentParcels,
   type ResourceShipmentParcelsProps
 } from '#ui/resources/ResourceShipmentParcels'

--- a/packages/app-elements/src/ui/resources/ResourcePaymentMethod.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ResourcePaymentMethod.mocks.tsx
@@ -1,0 +1,490 @@
+import { type CustomerPaymentSource, type Order } from '@commercelayer/sdk'
+
+export const orderWithoutPaymentSourceResponse = {
+  id: 'ABCXFJAKO',
+  type: 'orders',
+  created_at: '',
+  updated_at: '',
+  status: 'approved',
+  payment_status: 'paid',
+  fulfillment_status: 'fulfilled',
+  payment_method: {
+    id: 'xxxxx',
+    type: 'payment_methods',
+    name: 'Adyen Payment',
+    payment_source_type: 'adyen_payments',
+    currency_code: 'EUR',
+    price_amount_cents: 0,
+    price_amount_float: 0,
+    formatted_price_amount: '€0,00',
+    created_at: '',
+    updated_at: ''
+  },
+  payment_source: {
+    id: 'abc123',
+    type: 'adyen_payments',
+    public_key: null,
+    payment_methods: {},
+    mismatched_amounts: false,
+    created_at: '',
+    updated_at: ''
+  }
+} satisfies Order
+
+export const orderWithPaymentSourceResponse = {
+  id: 'ABCXFJAKO',
+  type: 'orders',
+  created_at: '',
+  updated_at: '',
+  status: 'approved',
+  payment_status: 'paid',
+  fulfillment_status: 'fulfilled',
+  payment_method: {
+    id: 'xxxxx',
+    type: 'payment_methods',
+    name: 'Adyen Payment',
+    payment_source_type: 'adyen_payments',
+    currency_code: 'EUR',
+    price_amount_cents: 0,
+    price_amount_float: 0,
+    formatted_price_amount: '€0,00',
+    created_at: '',
+    updated_at: ''
+  },
+  payment_source: {
+    id: 'abc123',
+    type: 'adyen_payments',
+    public_key: null,
+    payment_methods: {
+      paymentMethods: [
+        {
+          name: 'Credit Card',
+          type: 'scheme',
+          brands: [
+            'visa',
+            'mc',
+            'amex',
+            'cup',
+            'diners',
+            'discover',
+            'jcb',
+            'maestro'
+          ],
+          details: [
+            {
+              key: 'encryptedCardNumber',
+              type: 'cardToken'
+            },
+            {
+              key: 'encryptedSecurityCode',
+              type: 'cardToken'
+            },
+            {
+              key: 'encryptedExpiryMonth',
+              type: 'cardToken'
+            },
+            {
+              key: 'encryptedExpiryYear',
+              type: 'cardToken'
+            },
+            {
+              key: 'holderName',
+              type: 'text',
+              optional: true
+            }
+          ]
+        },
+        {
+          name: 'PayPal',
+          type: 'paypal',
+          configuration: {
+            intent: 'authorize',
+            merchantId: 'xxxxxxxx'
+          }
+        }
+      ]
+    },
+    payment_response: {
+      amount: {
+        value: 400,
+        currency: 'EUR'
+      },
+      resultCode: 'Authorised',
+      fraudResult: {
+        results: [
+          {
+            FraudCheckResult: {
+              name: 'Pre-Auth-Risk-Total',
+              checkId: -1,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'AVSAuthResultCheck',
+              checkId: 20,
+              accountScore: 25
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'CVCAuthResultCheck',
+              checkId: 25,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'LiabilityShiftCheck',
+              checkId: 29,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PaymentDetailRefCheck',
+              checkId: 1,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperIpRefCheck',
+              checkId: 6,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'IssuerRefCheck',
+              checkId: 13,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PmOwnerRefCheck',
+              checkId: 27,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PaymentDetailNonFraudRefCheck',
+              checkId: 41,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperReferenceCheck',
+              checkId: 56,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'EmailDomainRefCheck',
+              checkId: 65,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PaymentDetailCarteBancaireRefCheck',
+              checkId: 75,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PhoneNumberRefCheck',
+              checkId: 66,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperEmailRefCheck',
+              checkId: 26,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperAddressRefCheck',
+              checkId: 40,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'CardChunkUsage',
+              checkId: 2,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'PaymentDetailUsage',
+              checkId: 3,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'HolderNameUsage',
+              checkId: 4,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperIpUsage',
+              checkId: 7,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperEmailUsage',
+              checkId: 8,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperDetailsUsage',
+              checkId: 37,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctCountryUsageByShopper',
+              checkId: 46,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'BlockedCardsUsageByShopper',
+              checkId: 47,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ChargebackCountByShopper',
+              checkId: 48,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctShopperIpUsageByShopper',
+              checkId: 49,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctShopperEmailUsageByShopper',
+              checkId: 50,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctShopperReferenceUsageByShopper',
+              checkId: 51,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctPaymentDetailUsageByShopper',
+              checkId: 52,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctSharedShopperIpUsageByShopper',
+              checkId: 53,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'DistinctSharedPaymentDetailUsageByShopper',
+              checkId: 54,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperAuthorisedFrequency',
+              checkId: 55,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'TransactionAmountVelocity',
+              checkId: 64,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperConsecutiveRefusalsCheck',
+              checkId: 70,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'LoyalShopperTrustCheck',
+              checkId: 71,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'IPCountryReferral',
+              checkId: 5,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperIpIssuingCountry',
+              checkId: 9,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'HolderNameContainsNumber',
+              checkId: 10,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'HolderNameIsOneWord',
+              checkId: 11,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'IssuingCountryReferral',
+              checkId: 15,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'BillingAddressDeliveryAddress',
+              checkId: 57,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'TransactionAmountCheck',
+              checkId: 63,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'EmailNameCheck',
+              checkId: 74,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'EmailSyntaxCheck',
+              checkId: 77,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'ShopperBehaviorCheck',
+              checkId: 78,
+              accountScore: 0
+            }
+          },
+          {
+            FraudCheckResult: {
+              name: 'CustomFieldCheck',
+              checkId: 82,
+              accountScore: 0
+            }
+          }
+        ],
+        accountScore: 25
+      },
+      pspReference: 'AKF9S9291SAA',
+      additionalData: {
+        cardSummary: '4242',
+        paymentMethod: 'amex',
+        cardHolderName: 'Ringo Starr',
+        fraudResultType: 'GREEN',
+        fraudManualReview: 'false',
+        paymentMethodVariant: 'amex'
+      },
+      merchantReference: '123456789'
+    },
+    mismatched_amounts: false,
+    payment_instrument: {
+      issuer_type: 'credit card',
+      card_type: 'amex',
+      card_last_digits: '4242',
+      card_holder_name: 'Ringo Starr'
+    },
+    created_at: '',
+    updated_at: ''
+  }
+} satisfies Order
+
+export const customerPaymentSource = {
+  id: 'gvXpwsjjdv',
+  type: 'customer_payment_sources',
+  name: 'braintree_payment #8404',
+  created_at: '',
+  updated_at: '',
+  payment_source: {
+    id: 'ZdZqLswKYb',
+    type: 'braintree_payments',
+    client_token: '',
+    payment_method_nonce: '',
+    payment_id: null,
+    local: null,
+    options: {
+      id: '',
+      card: {
+        brand: 'visa',
+        last4: '0004',
+        exp_year: '2030',
+        exp_month: '10'
+      },
+      payment_method_token: 'abc123'
+    },
+    payment_instrument: {
+      issuer: 'unknown',
+      issuer_type: 'braintree',
+      card_type: 'visa',
+      card_last_digits: '0004',
+      card_expiry_month: '10',
+      card_expiry_year: '2030'
+    },
+    created_at: '',
+    updated_at: ''
+  }
+} satisfies CustomerPaymentSource

--- a/packages/app-elements/src/ui/resources/ResourcePaymentMethod.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourcePaymentMethod.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from '@testing-library/react'
+import { ResourcePaymentMethod } from './ResourcePaymentMethod'
+import {
+  orderWithoutPaymentSourceResponse,
+  orderWithPaymentSourceResponse
+} from './ResourcePaymentMethod.mocks'
+
+describe('ResourcePaymentMethod', () => {
+  it('should render the component', () => {
+    const { getByText } = render(
+      <ResourcePaymentMethod resource={orderWithoutPaymentSourceResponse} />
+    )
+    expect(getByText('Adyen Payment')).toBeVisible()
+  })
+
+  it('should show the expandable show more button', async () => {
+    const { getByText, queryByText } = render(
+      <ResourcePaymentMethod resource={orderWithPaymentSourceResponse} />
+    )
+    expect(getByText('Adyen Payment')).toBeVisible()
+    expect(getByText('Amex credit card')).toBeVisible()
+    expect(getByText('··4242')).toBeVisible()
+
+    // expandable content is enabled
+    expect(getByText('Show more')).toBeVisible()
+
+    // show payment response block
+    fireEvent.click(getByText('Show more'))
+    expect(getByText('Show less')).toBeVisible()
+    expect(getByText('resultCode:')).toBeVisible()
+    expect(getByText('fraudResult:')).toBeVisible()
+
+    // hide payment response block
+    fireEvent.click(getByText('Show less'))
+    expect(queryByText('Show more')).toBeVisible()
+    expect(queryByText('Show less')).not.toBeInTheDocument()
+    expect(queryByText('resultCode:')).not.toBeInTheDocument()
+    expect(queryByText('fraudResult:')).not.toBeInTheDocument()
+  })
+})

--- a/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
+++ b/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
@@ -1,0 +1,225 @@
+import { Button } from '#ui/atoms/Button'
+import { Spacer } from '#ui/atoms/Spacer'
+import { Text } from '#ui/atoms/Text'
+import {
+  type CustomerPaymentSource,
+  type Order,
+  type PaymentMethod
+} from '@commercelayer/sdk'
+import { useState, type FC } from 'react'
+import type { SetNonNullable, SetRequired } from 'type-fest'
+import { z } from 'zod'
+
+export interface ResourcePaymentMethodProps {
+  /**
+   * Any resource that has `payment_source` or `payment_method` properties is actually eligible.
+   * But we are only interested in `Order` and `CustomerPaymentSource` resources.
+   */
+  resource:
+    | SetRequired<
+        SetNonNullable<Partial<Order>, 'payment_method'>,
+        'payment_method'
+      >
+    | SetRequired<
+        SetNonNullable<CustomerPaymentSource, 'payment_source'>,
+        'payment_source'
+      >
+}
+
+/**
+ * Show info about the payment method from the given Order or CustomerPaymentSource.
+ */
+export const ResourcePaymentMethod: FC<ResourcePaymentMethodProps> = ({
+  resource
+}) => {
+  const [showMore, setShowMore] = useState(false)
+  const paymentInstrument = paymentInstrumentType.safeParse(
+    resource.payment_source?.payment_instrument
+  )
+
+  const paymentMethodName =
+    'payment_method' in resource
+      ? resource.payment_method?.name
+      : resource.type === 'customer_payment_sources'
+        ? getPaymentMethodNameFromCustomerPaymentSource(resource)
+        : undefined
+
+  const avatarSrc = getPaymentMethodLogoSrc(
+    resource.payment_method?.payment_source_type ??
+      resource.payment_source?.type
+  )
+
+  const paymentResponse =
+    resource.payment_source != null &&
+    'payment_response' in resource.payment_source
+      ? resource.payment_source.payment_response
+      : null
+
+  if (paymentMethodName == null) {
+    return null
+  }
+
+  return (
+    <div className='bg-gray-50 px-4 rounded'>
+      <div className='flex gap-4 py-4'>
+        <img src={avatarSrc} alt={paymentMethodName} className='h-8' />
+        <div className='flex gap-4 items-center justify-between w-full'>
+          {paymentInstrument.success ? (
+            <div>
+              <Text weight='semibold'>{paymentMethodName}</Text>
+              <Text>{' · '}</Text>
+              <Text weight='medium' variant='info'>
+                {paymentInstrument.data.card_type != null ? (
+                  <span>
+                    {paymentInstrument.data.card_type}{' '}
+                    {paymentInstrument.data.issuer_type}
+                    {paymentInstrument.data.card_last_digits != null && (
+                      <Spacer left='2' style={{ display: 'inline-block' }}>
+                        ··{paymentInstrument.data.card_last_digits}
+                      </Spacer>
+                    )}
+                  </span>
+                ) : (
+                  paymentInstrument.data.issuer_type
+                )}
+              </Text>
+            </div>
+          ) : (
+            <Text tag='div' weight='semibold'>
+              {paymentMethodName}
+            </Text>
+          )}
+          {paymentResponse != null && (
+            <Button
+              onClick={() => {
+                setShowMore(!showMore)
+              }}
+              variant='link'
+              size='mini'
+              className='text-sm font-bold'
+            >
+              {showMore ? 'Show less' : 'Show more'}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {showMore && paymentResponse != null ? (
+        <div className='flex gap-4 pt-4 pb-2 overflow-hidden border-t border-dashed border-gray-200'>
+          <img
+            src={avatarSrc}
+            alt={paymentMethodName}
+            className='h-8 opacity-0' // keep image hidden to set same left spacing of the first block
+          />
+          <div className='font-mono text-sm overflow-auto max-h-48'>
+            {Object.entries(paymentResponse).map(([key, value]) => (
+              <div key={key}>
+                <span className='font-semibold'>{key}: </span>
+                <span className='font-medium break-words overflow-hidden'>
+                  {typeof value === 'string' || typeof value === 'number'
+                    ? value
+                    : typeof value === 'boolean'
+                      ? `${value}`
+                      : JSON.stringify(value).replaceAll(',', ', ')}
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+const paymentInstrumentType = z.object({
+  issuer_type: z.string(),
+  card_type: z
+    .string()
+    .optional()
+    .transform((brand) => {
+      if (brand == null) {
+        return brand
+      }
+
+      return brand
+        .toLowerCase()
+        .split(' ')
+        .map((word) => {
+          const firstLetter = word.charAt(0).toUpperCase()
+          const rest = word.slice(1).toLowerCase()
+
+          return firstLetter + rest
+        })
+        .join(' ')
+    }),
+  card_last_digits: z.string().optional(),
+  card_expiry_month: z.string().optional(),
+  card_expiry_year: z.string().optional()
+})
+
+/**
+ * Retrieve the logo URL based on the payment source type.
+ */
+export function getPaymentMethodLogoSrc(
+  type?: PaymentMethod['payment_source_type']
+): string {
+  const assetsUrl =
+    'https://data.commercelayer.app/assets/images/icons/credit-cards/color'
+
+  const logos: Record<PaymentMethod['payment_source_type'], string> = {
+    adyen_payments: `${assetsUrl}/adyen.svg`,
+    axerve_payments: `${assetsUrl}/axerve.svg`,
+    braintree_payments: `${assetsUrl}/braintree.svg`,
+    checkout_com_payments: `${assetsUrl}/checkout_com.svg`,
+    credit_cards: `${assetsUrl}/credit-card.svg`,
+    external_payments: `${assetsUrl}/external.svg`,
+    klarna_payments: `${assetsUrl}/klarna.svg`,
+    paypal_payments: `${assetsUrl}/paypal.svg`,
+    satispay_payments: `${assetsUrl}/satispay.svg`,
+    stripe_payments: `${assetsUrl}/stripe.svg`,
+    wire_transfers: `${assetsUrl}/manual.svg`
+  }
+
+  const defaultLogo = `${assetsUrl}/credit-card.svg`
+  if (type == null) {
+    return defaultLogo
+  }
+  return logos[type] ?? defaultLogo
+}
+
+/**
+ * Extracts the payment method name from a customer payment source.
+ * It first tries to get it from the first payment method found in `payment_source.payment_methods` (if available).
+ * Otherwise it tries to get it from a custom mapping of user-friendly names from the `payment_source.type`.
+ */
+function getPaymentMethodNameFromCustomerPaymentSource(
+  customerPaymentSource: CustomerPaymentSource
+): string | undefined {
+  const paymentSourceTypeNiceName = {
+    adyen_payments: 'Adyen',
+    axerve_payments: 'Axerve',
+    braintree_payments: 'Braintree',
+    checkout_com_payments: 'Checkout.com',
+    klarna_payments: 'Klarna',
+    paypal_payments: 'Paypal',
+    satispay_payments: 'Satispay',
+    stripe_payments: 'Stripe'
+  }
+
+  const paymentSource = customerPaymentSource.payment_source
+  const paymentMethod =
+    paymentSource != null &&
+    'payment_methods' in paymentSource &&
+    Array.isArray(paymentSource.payment_methods) &&
+    paymentSource.payment_methods[0] != null
+      ? (paymentSource.payment_methods[0] as PaymentMethod)
+      : undefined
+
+  const paymentMethodName =
+    paymentMethod?.name ??
+    paymentSourceTypeNiceName[
+      paymentSource?.type as keyof typeof paymentSourceTypeNiceName
+    ]
+
+  return paymentMethodName
+}

--- a/packages/docs/src/stories/resources/ResourcePaymentMethod.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourcePaymentMethod.stories.tsx
@@ -1,0 +1,38 @@
+import { ResourcePaymentMethod } from '#ui/resources/ResourcePaymentMethod'
+import {
+  customerPaymentSource,
+  orderWithPaymentSourceResponse,
+  orderWithoutPaymentSourceResponse
+} from '#ui/resources/ResourcePaymentMethod.mocks'
+import { type Meta, type StoryFn } from '@storybook/react'
+
+const setup: Meta<typeof ResourcePaymentMethod> = {
+  title: 'Resources/ResourcePaymentMethod',
+  component: ResourcePaymentMethod
+}
+export default setup
+
+const Template: StoryFn<typeof ResourcePaymentMethod> = (args) => (
+  <ResourcePaymentMethod {...args} />
+)
+
+export const Default = Template.bind({})
+Default.args = {
+  resource: orderWithoutPaymentSourceResponse
+}
+
+/**
+ * If the order includes the `payment_source` the component will show more details (expandable) on the transaction.
+ */
+export const WithOrder = Template.bind({})
+WithOrder.args = {
+  resource: orderWithPaymentSourceResponse
+}
+
+/**
+ * When working in a customer context, we can pass the `customer_payment_source` to render the block related to the saved payment source.
+ */
+export const WithCustomerPaymentSource = Template.bind({})
+WithCustomerPaymentSource.args = {
+  resource: customerPaymentSource
+}

--- a/packages/docs/src/stories/resources/ResourcePaymentMethod.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourcePaymentMethod.stories.tsx
@@ -8,7 +8,17 @@ import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof ResourcePaymentMethod> = {
   title: 'Resources/ResourcePaymentMethod',
-  component: ResourcePaymentMethod
+  component: ResourcePaymentMethod,
+  parameters: {
+    layout: 'fullscreen'
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '1rem 2rem' }}>
+        <Story />
+      </div>
+    )
+  ]
 }
 export default setup
 


### PR DESCRIPTION
Closes commercelayer/issues-app#154

## What I did

I've added a new component `ResourcePaymentMethod` that accept an order or a customer payment source and render the payment method with the relative icon.
If the payment source contains the `payment_response` object, the component will show a "show more" button to view more info

https://deploy-preview-809--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcepaymentmethod--docs

<img width="675" alt="image" src="https://github.com/user-attachments/assets/f6a75a7d-4426-4ec1-b39b-7af657368157">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
