### PR TITLE
Correct broken query in `MarketWithCurrencySelector`

### DIFF
--- a/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
+++ b/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
@@ -151,13 +151,13 @@ export const HookedMarketWithCurrencySelector: FC<
                   .list({
                     pageSize: 25,
                     filters: {
-                      name_cont: hint,
-                      fields: {
-                        markets: ['name', 'price_list'],
-                        price_lists: ['currency_code']
-                      },
-                      include: ['price_list']
-                    }
+                      name_cont: hint
+                    },
+                    fields: {
+                      markets: ['name', 'price_list'],
+                      price_lists: ['currency_code']
+                    },
+                    include: ['price_list']
                   })
                   .then((res) => {
                     return res.map((market) => ({


### PR DESCRIPTION
## What I did

Market search in `<MarketWithCurrencySelector>` was failing due to a broken filter object composition.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
