### PR TITLE
Add `requiresBillingInfo` prop to the ResourceAddress component

### DIFF
--- a/packages/app-elements/src/hooks/useOverlay.tsx
+++ b/packages/app-elements/src/hooks/useOverlay.tsx
@@ -65,8 +65,10 @@ export function useOverlay(options?: OverlayOptions): OverlayHook {
     [search, options?.queryParam]
   )
 
+  const Empty = useCallback(() => null, [])
+
   return {
-    Overlay: show ? Overlay : () => null,
+    Overlay: show ? Overlay : Empty,
     close,
     open
   }

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -307,7 +307,7 @@ export {
 export {
   ResourceAddress,
   ResourceAddressFormFields,
-  resourceAddressFormFieldsSchema,
+  getResourceAddressFormFieldsSchema,
   useResourceAddressOverlay,
   type ResourceAddressFormFieldsProps,
   type ResourceAddressProps

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
@@ -36,7 +36,7 @@ const setup = (): RenderResult => {
     <MockTokenProvider kind='integration' appSlug='orders' devMode>
       <CoreSdkProvider>
         <ResourceAddress
-          resource={presetAddresses.withNotes}
+          address={presetAddresses.withNotes}
           showBillingInfo
           editable
         />

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -31,6 +31,11 @@ export interface ResourceAddressProps {
    */
   showBillingInfo?: boolean
   /**
+   * Optional setting to define if given `Address` `billing_info` data is required.
+   * @default false
+   */
+  requiresBillingInfo?: boolean
+  /**
    * Optional setting to define if given `Address` `billing_info` data is visible.
    * @default true
    */
@@ -54,6 +59,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     title,
     editable = false,
     showBillingInfo = false,
+    requiresBillingInfo = false,
     showNotes = true,
     onCreate,
     onUpdate
@@ -87,6 +93,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
       useResourceAddressOverlay({
         address: stateAddress,
         showBillingInfo,
+        requiresBillingInfo,
         showNotes,
         onCreate: handleOnCreate,
         onUpdate: handleOnUpdate

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -7,7 +7,7 @@ import { Text } from '#ui/atoms/Text'
 import { type Address } from '@commercelayer/sdk'
 import { Note, PencilSimple, Phone } from '@phosphor-icons/react'
 import isEmpty from 'lodash/isEmpty'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useResourceAddressOverlay } from './useResourceAddressOverlay'
 
 export interface ResourceAddressProps {
@@ -61,19 +61,33 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     const [address, setAddress] = useState<Address | null | undefined>(resource)
     const { canUser } = useTokenProvider()
 
+    const handleOnUpdate = useCallback<
+      NonNullable<ResourceAddressProps['onUpdate']>
+    >(
+      (address) => {
+        onUpdate?.(address)
+        setAddress(address)
+      },
+      [onUpdate, setAddress]
+    )
+
+    const handleOnCreate = useCallback<
+      NonNullable<ResourceAddressProps['onCreate']>
+    >(
+      (address) => {
+        onCreate?.(address)
+        setAddress(address)
+      },
+      [onUpdate, setAddress]
+    )
+
     const { ResourceAddressOverlay, openAddressOverlay } =
       useResourceAddressOverlay({
         address,
         showBillingInfo,
         showNotes,
-        onCreate: (address) => {
-          onCreate?.(address)
-          setAddress(address)
-        },
-        onUpdate: (address) => {
-          onUpdate?.(address)
-          setAddress(address)
-        }
+        onCreate: handleOnCreate,
+        onUpdate: handleOnUpdate
       })
 
     useEffect(() => {

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -14,7 +14,7 @@ export interface ResourceAddressProps {
   /**
    * Resource of type `Address`
    */
-  resource?: Address | null | undefined
+  address?: Address | null
   /**
    * Optional address title (if added it will be shown in bold on top of address infos)
    */
@@ -50,7 +50,7 @@ export interface ResourceAddressProps {
  */
 export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
   ({
-    resource,
+    address,
     title,
     editable = false,
     showBillingInfo = false,
@@ -58,7 +58,9 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     onCreate,
     onUpdate
   }) => {
-    const [address, setAddress] = useState<Address | null | undefined>(resource)
+    const [stateAddress, setStateAddress] = useState<
+      Address | null | undefined
+    >(address)
     const { canUser } = useTokenProvider()
 
     const handleOnUpdate = useCallback<
@@ -66,9 +68,9 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     >(
       (address) => {
         onUpdate?.(address)
-        setAddress(address)
+        setStateAddress(address)
       },
-      [onUpdate, setAddress]
+      [onUpdate, setStateAddress]
     )
 
     const handleOnCreate = useCallback<
@@ -76,14 +78,14 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
     >(
       (address) => {
         onCreate?.(address)
-        setAddress(address)
+        setStateAddress(address)
       },
-      [onUpdate, setAddress]
+      [onUpdate, setStateAddress]
     )
 
     const { ResourceAddressOverlay, openAddressOverlay } =
       useResourceAddressOverlay({
-        address,
+        address: stateAddress,
         showBillingInfo,
         showNotes,
         onCreate: handleOnCreate,
@@ -91,8 +93,8 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
       })
 
     useEffect(() => {
-      setAddress(resource)
-    }, [resource?.id])
+      setStateAddress(address)
+    }, [address?.id])
 
     return (
       <>
@@ -105,7 +107,7 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
                 </Text>
               </Spacer>
             )}
-            {address != null ? (
+            {stateAddress != null ? (
               <>
                 <Text
                   tag='div'
@@ -113,54 +115,54 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
                   weight={title == null ? 'bold' : undefined}
                   variant={title != null ? 'info' : undefined}
                 >
-                  {address.full_name}
+                  {stateAddress.full_name}
                 </Text>
                 <Text
                   tag='div'
                   variant='info'
                   data-testid='ResourceAddress-address'
                 >
-                  {address.line_1} {address.line_2}
+                  {stateAddress.line_1} {stateAddress.line_2}
                   <br />
-                  {address.city} {address.state_code} {address.zip_code} (
-                  {address.country_code})
+                  {stateAddress.city} {stateAddress.state_code}{' '}
+                  {stateAddress.zip_code} ({stateAddress.country_code})
                 </Text>
 
-                {address.billing_info != null && showBillingInfo ? (
+                {stateAddress.billing_info != null && showBillingInfo ? (
                   <Text
                     tag='div'
                     variant='info'
                     data-testid='ResourceAddress-billingInfo'
                   >
-                    {address.billing_info}
+                    {stateAddress.billing_info}
                   </Text>
                 ) : null}
 
-                {!isEmpty(address.phone) ||
-                (showNotes && !isEmpty(address.notes)) ? (
+                {!isEmpty(stateAddress.phone) ||
+                (showNotes && !isEmpty(stateAddress.notes)) ? (
                   <>
                     <Spacer top='4' bottom='4'>
                       <Hr variant='dashed' />
                     </Spacer>
                     <div className='grid gap-1'>
-                      {!isEmpty(address.phone) && (
+                      {!isEmpty(stateAddress.phone) && (
                         <div className='flex gap-2 '>
                           {/* mt-[2px] to keep icon aligned with text  */}
                           <Text tag='div' variant='info' className='mt-[2px]'>
                             <Phone weight='bold' />
                           </Text>
                           <Text tag='div' size='small' variant='info'>
-                            {address.phone}
+                            {stateAddress.phone}
                           </Text>
                         </div>
                       )}
-                      {showNotes && !isEmpty(address.notes) && (
+                      {showNotes && !isEmpty(stateAddress.notes) && (
                         <div className='flex gap-2'>
                           <Text tag='div' variant='info' className='mt-[2px]'>
                             <Note weight='bold' />
                           </Text>
                           <Text tag='div' size='small' variant='info'>
-                            {address.notes}
+                            {stateAddress.notes}
                           </Text>
                         </div>
                       )}

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
@@ -10,26 +10,32 @@ import { useForm } from 'react-hook-form'
 import { type ResourceAddressProps } from './ResourceAddress'
 import {
   ResourceAddressFormFields,
-  resourceAddressFormFieldsSchema,
+  getResourceAddressFormFieldsSchema,
   type ResourceAddressFormFieldsProps
 } from './ResourceAddressFormFields'
 
 interface ResourceAddressFormProps
   extends Omit<ResourceAddressFormFieldsProps, 'name'>,
-    Pick<ResourceAddressProps, 'address' | 'onCreate' | 'onUpdate'> {}
+    Pick<
+      ResourceAddressProps,
+      'address' | 'onCreate' | 'onUpdate' | 'requiresBillingInfo'
+    > {}
 
 export const ResourceAddressForm =
   withSkeletonTemplate<ResourceAddressFormProps>(
     ({
       address,
       showBillingInfo = false,
+      requiresBillingInfo = false,
       showNotes = true,
       onUpdate,
       onCreate
     }) => {
       const methods = useForm({
         defaultValues: address ?? undefined,
-        resolver: zodResolver(resourceAddressFormFieldsSchema)
+        resolver: zodResolver(
+          getResourceAddressFormFieldsSchema({ requiresBillingInfo })
+        )
       })
 
       const [apiError, setApiError] = useState<any>()

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressForm.tsx
@@ -4,10 +4,10 @@ import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { HookedForm } from '#ui/forms/Form/HookedForm'
 import { HookedValidationApiError } from '#ui/forms/ReactHookForm/HookedValidationApiError'
-import { type Address } from '@commercelayer/sdk'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
+import { type ResourceAddressProps } from './ResourceAddress'
 import {
   ResourceAddressFormFields,
   resourceAddressFormFieldsSchema,
@@ -15,11 +15,8 @@ import {
 } from './ResourceAddressFormFields'
 
 interface ResourceAddressFormProps
-  extends Omit<ResourceAddressFormFieldsProps, 'name'> {
-  address?: Address | null | undefined
-  onChange: (updatedAddress: Address) => void
-  onCreate: (createdAddress: Address) => void
-}
+  extends Omit<ResourceAddressFormFieldsProps, 'name'>,
+    Pick<ResourceAddressProps, 'address' | 'onCreate' | 'onUpdate'> {}
 
 export const ResourceAddressForm =
   withSkeletonTemplate<ResourceAddressFormProps>(
@@ -27,7 +24,7 @@ export const ResourceAddressForm =
       address,
       showBillingInfo = false,
       showNotes = true,
-      onChange,
+      onUpdate,
       onCreate
     }) => {
       const methods = useForm({
@@ -47,7 +44,7 @@ export const ResourceAddressForm =
               await sdkClient.addresses
                 .update({ ...formValues, id: address.id })
                 .then((address) => {
-                  onChange(address)
+                  onUpdate?.(address)
                 })
                 .catch((error) => {
                   setApiError(error)
@@ -56,7 +53,7 @@ export const ResourceAddressForm =
               await sdkClient.addresses
                 .create({ ...formValues })
                 .then((address) => {
-                  onCreate(address)
+                  onCreate?.(address)
                 })
                 .catch((error) => {
                   setApiError(error)

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -8,6 +8,7 @@ import { HookedInputTextArea } from '#ui/forms/InputTextArea'
 import React, { useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { z } from 'zod'
+import { type ResourceAddressProps } from './ResourceAddress'
 
 const zodRequiredField = z
   .string({
@@ -18,49 +19,55 @@ const zodRequiredField = z
     message: 'Required field'
   })
 
-export const resourceAddressFormFieldsSchema = z
-  .object({
-    business: z.boolean().nullish().default(false),
-    first_name: z.string().nullish(),
-    last_name: z.string().nullish(),
-    company: z.string().nullish(),
-    line_1: zodRequiredField,
-    line_2: z.string().nullish(),
-    city: zodRequiredField,
-    zip_code: z.string().nullish(),
-    state_code: zodRequiredField,
-    country_code: zodRequiredField,
-    phone: zodRequiredField,
-    billing_info: z.string().nullish(),
-    notes: z.string().nullish()
-  })
-  .superRefine((data, ctx) => {
-    if (data.business === true) {
-      if (data.company == null || data.company.length === 0) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['company'],
-          message: 'Required field'
-        })
-      }
-    } else {
-      if (data.first_name == null || data.first_name.length === 0) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['first_name'],
-          message: 'Required field'
-        })
-      }
+export const getResourceAddressFormFieldsSchema = ({
+  requiresBillingInfo = false
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+}: Pick<ResourceAddressProps, 'requiresBillingInfo'> = {}) =>
+  z
+    .object({
+      business: z.boolean().nullish().default(false),
+      first_name: z.string().nullish(),
+      last_name: z.string().nullish(),
+      company: z.string().nullish(),
+      line_1: zodRequiredField,
+      line_2: z.string().nullish(),
+      city: zodRequiredField,
+      zip_code: z.string().nullish(),
+      state_code: zodRequiredField,
+      country_code: zodRequiredField,
+      phone: zodRequiredField,
+      billing_info: requiresBillingInfo
+        ? zodRequiredField
+        : z.string().nullish(),
+      notes: z.string().nullish()
+    })
+    .superRefine((data, ctx) => {
+      if (data.business === true) {
+        if (data.company == null || data.company.length === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['company'],
+            message: 'Required field'
+          })
+        }
+      } else {
+        if (data.first_name == null || data.first_name.length === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['first_name'],
+            message: 'Required field'
+          })
+        }
 
-      if (data.last_name == null || data.last_name.length === 0) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['last_name'],
-          message: 'Required field'
-        })
+        if (data.last_name == null || data.last_name.length === 0) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['last_name'],
+            message: 'Required field'
+          })
+        }
       }
-    }
-  })
+    })
 
 export interface ResourceAddressFormFieldsProps {
   /**
@@ -223,7 +230,9 @@ const SelectCountry: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
 const SelectStates: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
   const [states, setStates] = useState<InputSelectValue[] | undefined>()
   const { watch, setValue } =
-    useFormContext<z.infer<typeof resourceAddressFormFieldsSchema>>()
+    useFormContext<
+      z.infer<ReturnType<typeof getResourceAddressFormFieldsSchema>>
+    >()
   const [forceTextInput, setForceTextInput] = useState(false)
 
   const countryCode = watch('country_code')

--- a/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/index.tsx
@@ -1,7 +1,7 @@
 export { ResourceAddress, type ResourceAddressProps } from './ResourceAddress'
 export {
   ResourceAddressFormFields,
-  resourceAddressFormFieldsSchema,
+  getResourceAddressFormFieldsSchema,
   type ResourceAddressFormFieldsProps
 } from './ResourceAddressFormFields'
 export { useResourceAddressOverlay } from './useResourceAddressOverlay'

--- a/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
@@ -12,6 +12,7 @@ export const useResourceAddressOverlay = ({
   title,
   address,
   showBillingInfo,
+  requiresBillingInfo,
   showNotes,
   onUpdate,
   onCreate
@@ -43,6 +44,7 @@ export const useResourceAddressOverlay = ({
             <ResourceAddressForm
               address={address}
               showBillingInfo={showBillingInfo}
+              requiresBillingInfo={requiresBillingInfo}
               showNotes={showNotes}
               onUpdate={(updatedAddress: Address) => {
                 onUpdate?.(updatedAddress)

--- a/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
@@ -61,7 +61,15 @@ export const useResourceAddressOverlay = ({
         </Overlay>
       )
     )
-  }, [Overlay, close, canUser, address, showBillingInfo, showNotes, onUpdate])
-
+  }, [
+    Overlay,
+    close,
+    canUser,
+    address,
+    showBillingInfo,
+    showNotes,
+    onUpdate,
+    onCreate
+  ])
   return { ResourceAddressOverlay, openAddressOverlay }
 }

--- a/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/useResourceAddressOverlay.tsx
@@ -3,7 +3,10 @@ import { useTokenProvider } from '#providers/TokenProvider'
 import { PageLayout } from '#ui/composite/PageLayout'
 import { type Address } from '@commercelayer/sdk'
 import { useCallback } from 'react'
+import { type ResourceAddressProps } from './ResourceAddress'
 import { ResourceAddressForm } from './ResourceAddressForm'
+
+type Props = Omit<ResourceAddressProps, 'editable'>
 
 export const useResourceAddressOverlay = ({
   title,
@@ -12,15 +15,8 @@ export const useResourceAddressOverlay = ({
   showNotes,
   onUpdate,
   onCreate
-}: {
-  title?: string
-  address?: Address | null | undefined
-  showBillingInfo?: boolean
-  showNotes?: boolean
-  onUpdate?: (updatedAddress: Address) => void
-  onCreate?: (createdAddress: Address) => void
   // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-}) => {
+}: Props) => {
   const { canUser } = useTokenProvider()
   const { Overlay, open, close } = useOverlay()
 
@@ -48,7 +44,7 @@ export const useResourceAddressOverlay = ({
               address={address}
               showBillingInfo={showBillingInfo}
               showNotes={showNotes}
-              onChange={(updatedAddress: Address) => {
+              onUpdate={(updatedAddress: Address) => {
                 onUpdate?.(updatedAddress)
                 close()
               }}

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -52,27 +52,27 @@ const Template: StoryFn<Props> = ({ preset, ...args }) => {
 export const Default = Template.bind({})
 Default.args = {
   isLoading: false,
-  resource: presetAddresses.withName
+  address: presetAddresses.withName
 }
 
 export const WithoutTitle = Template.bind({})
 WithoutTitle.args = {
   isLoading: false,
-  resource: presetAddresses.withName
+  address: presetAddresses.withName
 }
 
 export const WithTitle = Template.bind({})
 WithTitle.args = {
   isLoading: false,
   title: 'Shipping address',
-  resource: presetAddresses.withName
+  address: presetAddresses.withName
 }
 
 export const Editable = Template.bind({})
 Editable.args = {
   isLoading: false,
   editable: true,
-  resource: presetAddresses.withNotes
+  address: presetAddresses.withNotes
 }
 
 export const NoAddress: StoryFn = () => {
@@ -88,7 +88,7 @@ export const NoAddress: StoryFn = () => {
       <ResourceAddress
         title='Shipping address'
         editable
-        resource={null}
+        address={null}
         onCreate={(address) => {
           console.log('new shipping address', address)
         }}
@@ -101,12 +101,12 @@ export const StackedAddresses: StoryFn = () => {
   return (
     <Stack>
       <ResourceAddress
-        resource={presetAddresses.withCompany}
+        address={presetAddresses.withCompany}
         title='Billing address'
         editable
       />
       <ResourceAddress
-        resource={presetAddresses.withNotes}
+        address={presetAddresses.withNotes}
         title='Shipping address'
         editable
       />
@@ -118,10 +118,10 @@ export const ListedAddresses: StoryFn = () => {
   return (
     <>
       <ListItem>
-        <ResourceAddress resource={presetAddresses.withCompany} editable />
+        <ResourceAddress address={presetAddresses.withCompany} editable />
       </ListItem>
       <ListItem>
-        <ResourceAddress resource={presetAddresses.withName} editable />
+        <ResourceAddress address={presetAddresses.withName} editable />
       </ListItem>
     </>
   )
@@ -131,7 +131,7 @@ export const ApiError: StoryFn = () => {
   return (
     <Stack>
       <ResourceAddress
-        resource={presetAddresses.withErrors}
+        address={presetAddresses.withErrors}
         title='Billing address'
         editable
       />

--- a/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceAddress.stories.tsx
@@ -15,7 +15,7 @@ import {
 import { presetAddresses } from '#ui/resources/ResourceAddress/ResourceAddress.mocks'
 import {
   ResourceAddressFormFields,
-  resourceAddressFormFieldsSchema
+  getResourceAddressFormFieldsSchema
 } from '#ui/resources/ResourceAddress/ResourceAddressFormFields'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { type Meta, type StoryFn } from '@storybook/react'
@@ -81,6 +81,8 @@ export const NoAddress: StoryFn = () => {
       <ResourceAddress
         title='Billing address'
         editable
+        showBillingInfo
+        requiresBillingInfo
         onCreate={(address) => {
           console.log('new billing address', address)
         }}
@@ -186,7 +188,7 @@ export const ReuseTheAddressForm: StoryFn = () => {
           .min(1, {
             message: 'Required field'
           }),
-        address: resourceAddressFormFieldsSchema
+        address: getResourceAddressFormFieldsSchema()
       })
     )
   })
@@ -234,7 +236,7 @@ export const ShowNameOrCompany: StoryFn = () => {
           .min(1, {
             message: 'Required field'
           }),
-        address: resourceAddressFormFieldsSchema
+        address: getResourceAddressFormFieldsSchema()
       })
     )
   })


### PR DESCRIPTION
## What I did

This PR adds/edits a few things to the `ResourceAddress` component:

- I added a new prop called `requiresBillingInfo`. When `true`, it forces `billing_info` as a required field.
- I removed unnecessary re-renders.
- **Breaking Change** - I renamed the prop `resource` to `address`.

