### PR TITLE
Add `info` prop in `DropdownItem`

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -6,6 +6,7 @@ import { useMemo, type FC } from 'react'
 
 export type DropdownItemProps = React.HTMLAttributes<HTMLElement> & {
   label: string
+  info?: string
   icon?: IconProps['name'] | 'keep-space'
 } & (
     | {
@@ -27,7 +28,17 @@ export type DropdownItemProps = React.HTMLAttributes<HTMLElement> & {
  * When no `href` or `onClick` is provided, the component still renders as `button` tag to prevent the dropdown to be closed when clicked.
  */
 export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
-  ({ label, icon, isLoading, delayMs, href, className, onClick, ...rest }) => {
+  ({
+    label,
+    info,
+    icon,
+    isLoading,
+    delayMs,
+    href,
+    className,
+    onClick,
+    ...rest
+  }) => {
     const JsxTag = useMemo(
       () =>
         enforceAllowedTags({
@@ -50,10 +61,14 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
         }}
         href={href}
         className={cn(
-          'w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none',
+          'w-full bg-black !text-white py-2 pl-4 text-sm font-semibold flex items-center focus:!outline-none',
+          {
+            'pr-8': info == null,
+            'min-w-[250px] pr-6': info != null
+          },
           className,
           {
-            'hover:bg-violet cursor-pointer focus:bg-violet':
+            'hover:bg-violet cursor-pointer focus:bg-violet group':
               onClick != null || href != null,
             'cursor-default': onClick == null && href == null,
             'opacity-50 pointer-events-none': isDisabled
@@ -77,6 +92,11 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
         >
           {label}
         </span>
+        {info != null && (
+          <span className='ml-auto pl-1 text-xs text-gray-500 font-semibold group-hover:text-white'>
+            {info}
+          </span>
+        )}
       </JsxTag>
     )
   }

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownMenu.tsx
@@ -54,10 +54,13 @@ export const DropdownMenu: FC<DropdownMenuProps> = ({
       )}
       <div
         {...rest}
-        className={cn('bg-black text-white rounded overflow-hidden py-2', {
-          'min-w-[150px] md:max-w-[250px]': menuWidth == null, // default width
-          'w-[280px]': menuWidth === 'wide'
-        })}
+        className={cn(
+          'bg-black text-white rounded overflow-x-hidden overflow-y-auto max-h-[450px] py-2',
+          {
+            'min-w-[150px] md:max-w-[250px]': menuWidth == null, // default width
+            'w-[280px]': menuWidth === 'wide'
+          }
+        )}
       >
         {menuHeader != null && (
           <>

--- a/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Dropdown > Should be rendering bottom-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-x-hidden overflow-y-auto max-h-[450px] py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -80,7 +80,7 @@ exports[`Dropdown > Should be rendering top-left 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; left: -6px;"
         />
         <div
-          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-x-hidden overflow-y-auto max-h-[450px] py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -125,7 +125,7 @@ exports[`Dropdown > Should be rendering top-right 1`] = `
           style="border-left-width: 6px; border-right-width: 6px; border-top-width: 5px; border-bottom-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-x-hidden overflow-y-auto max-h-[450px] py-2 min-w-[150px] md:max-w-[250px]"
         >
           <div />
         </div>
@@ -170,11 +170,11 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           style="border-left-width: 6px; border-right-width: 6px; border-bottom-width: 5px; border-top-color: transparent; right: -6px;"
         />
         <div
-          class="bg-black text-white rounded overflow-hidden py-2 min-w-[150px] md:max-w-[250px]"
+          class="bg-black text-white rounded overflow-x-hidden overflow-y-auto max-h-[450px] py-2 min-w-[150px] md:max-w-[250px]"
         >
           <button
             aria-label="Payments"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
+            class="w-full bg-black !text-white py-2 pl-4 text-sm font-semibold flex items-center focus:!outline-none pr-8 hover:bg-violet cursor-pointer focus:bg-violet group"
           >
             <div
               class="mr-2"
@@ -200,7 +200,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </button>
           <button
             aria-label="Items"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
+            class="w-full bg-black !text-white py-2 pl-4 text-sm font-semibold flex items-center focus:!outline-none pr-8 hover:bg-violet cursor-pointer focus:bg-violet group"
           >
             <div
               class="mr-2"
@@ -225,7 +225,7 @@ exports[`Dropdown > Should be rendering with default bottom-right position 1`] =
           </div>
           <button
             aria-label="Delete"
-            class="w-full bg-black !text-white py-2 pl-4 pr-8 text-sm font-semibold flex items-center focus:!outline-none hover:bg-violet cursor-pointer focus:bg-violet"
+            class="w-full bg-black !text-white py-2 pl-4 text-sm font-semibold flex items-center focus:!outline-none pr-8 hover:bg-violet cursor-pointer focus:bg-violet group"
           >
             <div
               class="mr-2"

--- a/packages/docs/src/stories/composite/Dropdown.stories.tsx
+++ b/packages/docs/src/stories/composite/Dropdown.stories.tsx
@@ -54,6 +54,87 @@ Default.args = {
 }
 
 /**
+ * Each dropdown item can have an `info` prop that will be rendered as a secondary text on the right side of the item.
+ * When the `info` prop is set, the item will have a fixed minimum width to accommodate the text.
+ **/
+export const WithInfo = Template.bind({})
+WithInfo.args = {
+  dropdownItems: (
+    <>
+      <DropdownItem
+        onClick={() => {}}
+        label='Europe'
+        info='€45.230'
+        icon='check'
+      />
+      <DropdownItem
+        onClick={() => {}}
+        label='USA'
+        info='$15.445'
+        icon='keep-space'
+      />
+      <DropdownItem
+        onClick={() => {}}
+        label='Canada'
+        info='$3.890'
+        icon='keep-space'
+      />
+      <DropdownItem
+        onClick={() => {}}
+        label='Japan'
+        info='¥780'
+        icon='keep-space'
+      />
+      <DropdownDivider />
+      <DropdownItem
+        onClick={() => {}}
+        label='Italy'
+        info='€0'
+        icon='keep-space'
+      />
+      <DropdownItem
+        onClick={() => {}}
+        label='France'
+        info='€0'
+        icon='keep-space'
+      />
+      <DropdownItem
+        onClick={() => {}}
+        label='United States of America'
+        info='$1,000'
+        icon='keep-space'
+      />
+    </>
+  )
+}
+
+/**
+ * Dropdown menu has a fixed maximum height. When content exceeds this height, it will be scrollable.
+ **/
+export const WithScrollbar = Template.bind({})
+WithScrollbar.args = {
+  dropdownLabel: 'Long menu list',
+  dropdownItems: (
+    <>
+      {Array.from({ length: 30 }, (_, i) => (
+        <DropdownItem key={i} label={`Item ${i + 1}`} />
+      ))}
+    </>
+  )
+}
+WithScrollbar.decorators = [
+  (Story) => (
+    <div
+      style={{
+        paddingBottom: '320px'
+      }}
+    >
+      <Story />
+    </div>
+  )
+]
+
+/**
  * It is possible to pass a custom `<button>` element as the dropdown label.
  * In this case the Dropdown component will use the provided button instead of creating a new one.
  **/


### PR DESCRIPTION
## What I did

I have added a new prop `info` to `DropdownItem` to show a right content as grey text.

[preview 1](https://deploy-preview-823--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#with%20info) 
<img width="354" alt="image" src="https://github.com/user-attachments/assets/09d085e7-768c-4faf-94af-cce442bbb6a8">

I've also set the max height to dropdown menu to show a scrollbar when there are too many items
[preview 2](https://deploy-preview-823--commercelayer-app-elements.netlify.app/?path=/docs/composite-dropdown--docs#with%20scrollbar)

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
