### PR TITLE
Dropdown when empty is no more visible

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.test.tsx
@@ -61,6 +61,9 @@ describe('PageHeadingToolbar', () => {
 
     expect(queryAllByTestId('toolbar-button').length).toEqual(2)
     expect(queryAllByTestId('toolbar-dropdown-button').length).toEqual(1)
+    expect(queryByTestId('toolbar-dropdown-button')).not.toHaveClass(
+      'md:hidden'
+    )
     const dropDownButton = queryByTestId('toolbar-dropdown-button')
     if (dropDownButton != null) {
       act(() => {
@@ -72,5 +75,26 @@ describe('PageHeadingToolbar', () => {
         expect(getByText('Delete')).toBeInTheDocument()
       })
     }
+  })
+
+  it('Should not display the dropdown button when empty', async () => {
+    const { queryAllByTestId, queryByTestId } = render(
+      <PageHeadingToolbar
+        buttons={[
+          {
+            label: 'Primary',
+            size: 'small',
+            onClick: () => {
+              console.log('Primary')
+            }
+          }
+        ]}
+        dropdownItems={[[]]}
+      />
+    )
+
+    expect(queryAllByTestId('toolbar-button').length).toEqual(1)
+    expect(queryAllByTestId('toolbar-dropdown-button').length).toEqual(1)
+    expect(queryByTestId('toolbar-dropdown-button')).toHaveClass('md:hidden')
   })
 })

--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.tsx
@@ -50,7 +50,7 @@ export const PageHeadingToolbar = withSkeletonTemplate<PageHeadingToolbarProps>(
         icon: 'dotsThree',
         size: 'small',
         variant: 'secondary',
-        className: dropdownItems.length > 0 ? '' : 'flex md:hidden',
+        className: dropdownItems.flat().length > 0 ? '' : 'flex md:hidden',
         dropdownItems: combinedDropdownItems
       })
     }


### PR DESCRIPTION
## What I did

I fixed the dropdown visibility when empty.

## How to test

![Dropdown when empty](https://github.com/user-attachments/assets/3fc3e4c2-08b1-4d49-88fc-2fd9343c8562)

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
