### PR TITLE
Set responsive paddings on `PageHeading`

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.test.tsx
@@ -69,7 +69,7 @@ describe('PageHeading gap', () => {
       id: 'heading',
       title: 'My Page Heading'
     })
-    expect(element).toHaveClass('pt-10 pb-14')
+    expect(element).toHaveClass('pt-5 md:pt-10 pb-6 md:pb-14')
   })
 
   test('Should have gap only on top', () => {
@@ -78,8 +78,8 @@ describe('PageHeading gap', () => {
       title: 'My Page Heading',
       gap: 'only-top'
     })
-    expect(element).toHaveClass('pt-10')
-    expect(element).not.toHaveClass('pb-14')
+    expect(element).toHaveClass('pt-5 md:pt-10')
+    expect(element).not.toHaveClass('pb-6 md:pb-14')
   })
 
   test('Should have no vertical gap', () => {

--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
@@ -67,9 +67,9 @@ const PageHeading = withSkeletonTemplate<PageHeadingProps>(
         className={cn([
           'w-full',
           {
-            'pt-10 pb-14': gap === 'both',
-            'pt-10': gap === 'only-top',
-            'pb-14': gap === 'only-bottom'
+            'pt-5 md:pt-10 pb-6 md:pb-14': gap === 'both',
+            'pt-5 md:pt-10': gap === 'only-top',
+            'pb-6 md:pb-14': gap === 'only-bottom'
           }
         ])}
         {...rest}

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`PageLayout > Should be rendered 1`] = `
     class="mb-14"
   >
     <div
-      class="w-full pt-10 pb-14"
+      class="w-full pt-5 md:pt-10 pb-6 md:pb-14"
     >
       <h1
         class="font-semibold text-2xl md:text-title leading-title break-words"

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`PageSkeleton > Should be rendered 1`] = `
             class="select-none pointer-events-none inline"
           >
             <div
-              class="w-full pt-10"
+              class="w-full pt-5 md:pt-10"
             >
               <div
                 class="mb-4 flex items-center justify-between"


### PR DESCRIPTION
## What I did

Vertical padding in PageHeading for mobile viewport is too high.
We decided to make it smaller

**Was:**
(too much space between topbar and <- back button)
<img width="362" alt="image" src="https://github.com/user-attachments/assets/a5a18818-33c6-4dc9-a373-aa4f2dd9093b">


----

**Now:**
<img width="361" alt="image" src="https://github.com/user-attachments/assets/18a3c5fa-4bc5-41c5-ac92-1e7719a1913c">


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
