### PR TITLE
Toolbar when navigationButton is not defined displays beside the title

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.test.tsx
@@ -25,12 +25,12 @@ describe('PageHeading', () => {
   })
 
   test('Should also render optional description', () => {
-    const { element } = setup({
+    const { getByText } = setup({
       id: 'heading',
       title: 'My Page Heading',
       description: 'Lorem ipsum...'
     })
-    expect(element.querySelector('div')?.innerHTML).toBe('Lorem ipsum...')
+    expect(getByText('Lorem ipsum...')).toBeVisible()
   })
 
   test('Should also render optional badge', () => {

--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
@@ -74,20 +74,18 @@ const PageHeading = withSkeletonTemplate<PageHeadingProps>(
         ])}
         {...rest}
       >
-        {(navigationButton != null || toolbar != null) && (
+        {navigationButton != null && (
           <div className={cn('mb-4 flex items-center justify-between')}>
-            {navigationButton != null ? (
-              <button
-                type='button'
-                className='flex items-center gap-1'
-                onClick={() => {
-                  navigationButton.onClick()
-                }}
-              >
-                <Icon name={navigationButton.icon ?? 'arrowLeft'} size={24} />{' '}
-                <Text weight='semibold'>{navigationButton.label}</Text>
-              </button>
-            ) : null}
+            <button
+              type='button'
+              className='flex items-center gap-1'
+              onClick={() => {
+                navigationButton.onClick()
+              }}
+            >
+              <Icon name={navigationButton.icon ?? 'arrowLeft'} size={24} />{' '}
+              <Text weight='semibold'>{navigationButton.label}</Text>
+            </button>
             {toolbar != null ? <PageHeadingToolbar {...toolbar} /> : null}
           </div>
         )}
@@ -98,9 +96,14 @@ const PageHeading = withSkeletonTemplate<PageHeadingProps>(
             </Badge>
           </div>
         )}
-        <h1 className='font-semibold text-2xl md:text-title leading-title break-words'>
-          {title}
-        </h1>
+        <div className='flex items-center justify-between'>
+          <h1 className='font-semibold text-2xl md:text-title leading-title break-words'>
+            {title}
+          </h1>
+          {navigationButton == null && toolbar != null ? (
+            <PageHeadingToolbar {...toolbar} />
+          ) : null}
+        </div>
         {description !== null && (
           <div className='text-gray-500 leading-6 mt-2'>{description}</div>
         )}

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
@@ -11,11 +11,15 @@ exports[`PageLayout > Should be rendered 1`] = `
     <div
       class="w-full pt-10 pb-14"
     >
-      <h1
-        class="font-semibold text-2xl md:text-title leading-title break-words"
+      <div
+        class="flex items-center justify-between"
       >
-        Page title
-      </h1>
+        <h1
+          class="font-semibold text-2xl md:text-title leading-title break-words"
+        >
+          Page title
+        </h1>
+      </div>
       <div
         class="text-gray-500 leading-6 mt-2"
       />

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
@@ -51,15 +51,19 @@ exports[`PageSkeleton > Should be rendered 1`] = `
                   </span>
                 </button>
               </div>
-              <h1
-                class="font-semibold text-2xl md:text-title leading-title break-words"
+              <div
+                class="flex items-center justify-between"
               >
-                <span
-                  class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                <h1
+                  class="font-semibold text-2xl md:text-title leading-title break-words"
                 >
-                  Loading
-                </span>
-              </h1>
+                  <span
+                    class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"
+                  >
+                    Loading
+                  </span>
+                </h1>
+              </div>
               <div
                 class="text-gray-500 leading-6 mt-2"
               />

--- a/packages/docs/src/stories/atoms/PageHeading.stories.tsx
+++ b/packages/docs/src/stories/atoms/PageHeading.stories.tsx
@@ -31,6 +31,15 @@ Default.args = {
   description: 'Lorem ipsum dolor sit'
 }
 
+export const WithBadge = Template.bind({})
+WithBadge.args = {
+  title: 'Resources',
+  badge: {
+    label: 'TEST DATA'
+  },
+  description: 'Lorem ipsum dolor sit'
+}
+
 export const WithNavGoBack = Template.bind({})
 WithNavGoBack.args = {
   title: 'Order details',
@@ -56,8 +65,8 @@ WithNavClose.args = {
   }
 }
 
-export const WithBadge = Template.bind({})
-WithBadge.args = {
+export const WithNavAndBadge = Template.bind({})
+WithNavAndBadge.args = {
   title: 'SKUs',
   badge: {
     label: 'TEST DATA'

--- a/packages/docs/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/docs/src/stories/composite/PageLayout.stories.tsx
@@ -83,6 +83,12 @@ WithToolbar.args = {
   }
 }
 
+export const WithoutNavigationButton = Template.bind({})
+WithoutNavigationButton.args = {
+  ...WithToolbar.args,
+  navigationButton: undefined
+}
+
 export const MobileWidthWithLongTitle = Template.bind({})
 MobileWidthWithLongTitle.args = {
   title: 'welcome@commercelayer.io',


### PR DESCRIPTION
Closes commercelayer/issues-app#254

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

The toolbar when navigationButton is not defined displays beside the title.

<img width="703" alt="Screenshot 2024-11-08 alle 17 36 41" src="https://github.com/user-attachments/assets/d21aa551-9a9f-40b6-b501-b23f9859a301">

<img width="737" alt="Screenshot 2024-11-08 alle 17 36 24" src="https://github.com/user-attachments/assets/ef655882-7762-4de2-82c3-fe2394072d0a">

## How to test

https://deploy-preview-834--commercelayer-app-elements.netlify.app/?path=/docs/atoms-pageheading--docs

https://deploy-preview-834--commercelayer-app-elements.netlify.app/?path=/docs/composite-pagelayout--docs#without%20navigation%20button
