### PR TITLE
Add storage methods in `TokenProvider`

### DIFF
--- a/.github/workflows/pkg-pr-new.yaml
+++ b/.github/workflows/pkg-pr-new.yaml
@@ -1,0 +1,44 @@
+name: pkg-pr-new
+
+on:
+  push:
+    branches:
+      - "**"
+      - "!main"
+      - "!release"
+    tags-ignore:
+      - "v*"
+  pull_request:
+    types: [ready_for_review]
+    branches-ignore:
+      - release
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: pnpm 🧰
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.x
+
+      - name: Node 🧰
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+
+      - name: Install 📦
+        run: pnpm install --frozen-lockfile
+
+      - name: Build elements 🛠
+        run: pnpm build:elements
+
+      - name: Publish 🚀 pkg.pr.new
+        run: |
+          npx pkg-pr-new publish './packages/app-elements' --no-template

--- a/packages/app-elements/src/providers/createApp.tsx
+++ b/packages/app-elements/src/providers/createApp.tsx
@@ -28,19 +28,12 @@ declare global {
 }
 
 export interface ClAppProps
-  extends Pick<
-    TokenProviderProps,
-    'organizationSlug' | 'onAppClose' | 'isInDashboard' | 'extras'
-  > {
+  extends Partial<Omit<TokenProviderProps, 'appSlug' | 'children'>> {
   /**
    * Base path for internal routing.
    * Example: `my-app` if you want to serve the app at `https://my-domain.com/my-app/`.
    */
   routerBase?: string
-  /**
-   * Callback to be called when the user is not authenticated or the token is invalid/expired.
-   */
-  onInvalidAuth?: () => void
 }
 
 /**


### PR DESCRIPTION
## What I did

This pull request introduces several changes to enhance the flexibility and functionality of the `TokenProvider` component. The most important changes include adding support for custom storage methods in the `TokenProvider`, and modifying the `ClAppProps` interface to accept almost all `TokenProvider` props.

### Enhancements to `TokenProvider`:

* Added an optional `storage` property to the `TokenProviderProps` interface, allowing custom methods for persisting and retrieving access tokens and extra data.
* Updated the `TokenProvider` component to use the custom storage methods if provided, or fallback to the internal methods otherwise. [[1]](diffhunk://#diff-b99b20a022b0c3e3a296d0c1ec8def0c985ae59aaf5626796c61a0824fb216f3R146) [[2]](diffhunk://#diff-b99b20a022b0c3e3a296d0c1ec8def0c985ae59aaf5626796c61a0824fb216f3L142-R172) [[3]](diffhunk://#diff-b99b20a022b0c3e3a296d0c1ec8def0c985ae59aaf5626796c61a0824fb216f3L231-R268)

### Modifications to `ClAppProps` interface:

* Changed `ClAppProps` to extend a partial version of `TokenProviderProps`, excluding `appSlug` and `children`, for better type safety and flexibility.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
