### PR TITLE
Improve types for `parseFormValue` method in `useResourceFilters`

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/types.ts
@@ -1,5 +1,7 @@
 import { type InputCurrencyRangeProps } from '#ui/forms/InputCurrencyRange'
 import { type InputResourceGroupProps } from '#ui/forms/InputResourceGroup'
+import { type QueryFilter } from '@commercelayer/sdk'
+import { type ValueOf } from 'type-fest'
 
 export const filterableTimeRangePreset = [
   'today',
@@ -67,7 +69,7 @@ export interface BaseFilterItem {
     /**
      * Custom function to transform the form value to the SDK value
      */
-    parseFormValue?: (value: unknown) => string | number | boolean | undefined
+    parseFormValue?: (value: unknown) => ValueOf<QueryFilter> | undefined
   }
 }
 


### PR DESCRIPTION
## What I did

Since `parseFormValue` should return any valid value consumable by our SDK, I replace the custom returned type with the value returned from sdk QueryFilter type.

```ts
type QueryFilter = Record<string, string | number | boolean | object | Array<string | number>>;

ValueOf<QueryFilter> 
//  ^--- string | number | boolean | object | Array<string | number>
```


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
