### PR TITLE
Set fixed css filename in bundled output

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -71,7 +71,6 @@
     "@types/node": "^20.16.4",
     "@types/pluralize": "^0.0.33",
     "@types/react-gtm-module": "^2.0.4",
-    "@types/testing-library__jest-dom": "^6.0.0",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.20",
     "cross-fetch": "^4.0.0",

--- a/packages/app-elements/tsconfig.json
+++ b/packages/app-elements/tsconfig.json
@@ -50,6 +50,7 @@
     }
   },
   "include": [
+    "vite.config.js",
     "src",
     "mocks",
     ".eslintrc.cjs"

--- a/packages/app-elements/tsconfig.node.json
+++ b/packages/app-elements/tsconfig.node.json
@@ -8,7 +8,7 @@
     "noUncheckedIndexedAccess": true
   },
   "include": [
-    "vite.config.ts",
+    "vite.config.js",
     "package.json"
   ]
 }

--- a/packages/app-elements/vite.config.js
+++ b/packages/app-elements/vite.config.js
@@ -1,3 +1,4 @@
+// @ts-check
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 import dts from 'vite-plugin-dts'
@@ -20,7 +21,8 @@ export default defineConfig({
       name: 'Blocks',
       // the proper extensions will be added
       fileName: 'main',
-      formats: ['es']
+      formats: ['es'],
+      cssFileName: 'style'
     },
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,9 +117,6 @@ importers:
       '@types/react-gtm-module':
         specifier: ^2.0.4
         version: 2.0.4
-      '@types/testing-library__jest-dom':
-        specifier: ^6.0.0
-        version: 6.0.0
       '@vitejs/plugin-react':
         specifier: ^4.3.4
         version: 4.3.4(vite@6.0.1(@types/node@20.17.8)(jiti@1.21.6)(terser@5.36.0)(yaml@2.6.1))
@@ -1982,10 +1979,6 @@ packages:
 
   '@types/statuses@2.0.5':
     resolution: {integrity: sha512-jmIUGWrAiwu3dZpxntxieC+1n/5c3mjrImkmOSQ2NC5uP6cYO4aAZDdSmRcI5C1oiTmqlZGHC+/NmJrKogbP5A==}
-
-  '@types/testing-library__jest-dom@6.0.0':
-    resolution: {integrity: sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==}
-    deprecated: This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -8546,10 +8539,6 @@ snapshots:
   '@types/semver@7.5.8': {}
 
   '@types/statuses@2.0.5': {}
-
-  '@types/testing-library__jest-dom@6.0.0':
-    dependencies:
-      '@testing-library/jest-dom': 6.6.3
 
   '@types/tough-cookie@4.0.5': {}
 


### PR DESCRIPTION
## What I did

- Rename `vite.config.ts` as `vite.config.js` to better handle linting and build process
- Remove unused package  (`@types/testing-library__jest-dom)
- Enforce css file name on vite build config to match previous default name


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
