### PR TITLE
Preserve `useResourceFilters` form state when opening date range overlay

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
@@ -21,9 +21,7 @@ interface FieldTimeRangeProps {
 
 export function FieldTimeRange({ item }: FieldTimeRangeProps): JSX.Element {
   const { user } = useTokenProvider()
-  const { Overlay, close, open } = useOverlay({
-    queryParam: `timeRangePickerView`
-  })
+  const { Overlay, close, open } = useOverlay()
 
   const { watch, setValue, trigger } = useFormContext<TimeRangeFormValues>()
   const timePreset = watch('timePreset')


### PR DESCRIPTION
## What I did

In `useResourceFilters` hook, when a custom date range overlay is open the url query string changes and a custom parameter is added.
This is causing the remounting of the entire form component that is built to react to changes in query string.

In this PR I have removed the `queryParam` option to prevent unwanted re-mounting of the filters form component, when the custom date range overlay is open


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
