### PR TITLE
Handle `formatDateRange` with timezone

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -597,6 +597,36 @@ describe('formatDateRange should return the proper date format', () => {
       })
     ).toEqual('Dec 01, 2023 - Jan 31, 2025')
   })
+
+  test('with timezone Italy', () => {
+    expect(
+      formatDateRange({
+        rangeFrom: '2024-12-09T22:00:00.000Z',
+        rangeTo: '2024-12-10T21:59:59.999Z',
+        timezone: 'Europe/Rome'
+      })
+    ).toEqual('10-10 Dec')
+  })
+
+  test('with timezone Italy', () => {
+    expect(
+      formatDateRange({
+        rangeFrom: '2024-12-10T00:00:00.000Z',
+        rangeTo: '2024-12-10T23:59:59.999Z',
+        timezone: 'Europe/Rome'
+      })
+    ).toEqual('10-11 Dec')
+  })
+
+  test('with timezone Dublin', () => {
+    expect(
+      formatDateRange({
+        rangeFrom: '2024-12-10T00:00:00.000Z',
+        rangeTo: '2024-12-10T23:59:59.999Z',
+        timezone: 'Europe/Dublin'
+      })
+    ).toEqual('10-10 Dec')
+  })
 })
 
 describe('makeDateYearsRange', () => {

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -1,5 +1,7 @@
 import { fromZonedTime } from 'date-fns-tz/fromZonedTime'
+import { getTimezoneOffset } from 'date-fns-tz/getTimezoneOffset'
 import { toZonedTime } from 'date-fns-tz/toZonedTime'
+import { addMilliseconds } from 'date-fns/addMilliseconds'
 import { endOfDay } from 'date-fns/endOfDay'
 import { format } from 'date-fns/format'
 import { formatDistance } from 'date-fns/formatDistance'
@@ -311,8 +313,15 @@ export function formatDateRange({
   /** Set a specific timezone, when not passed default value is 'UTC' */
   timezone?: string
 }): string {
-  const zonedFrom = toZonedTime(new Date(rangeFrom), timezone)
-  const zonedTo = toZonedTime(new Date(rangeTo), timezone)
+  const offsetMilliseconds = getTimezoneOffset(timezone)
+  const zonedFrom = toZonedTime(
+    addMilliseconds(rangeFrom, offsetMilliseconds),
+    timezone
+  )
+  const zonedTo = toZonedTime(
+    addMilliseconds(rangeTo, offsetMilliseconds),
+    timezone
+  )
 
   if (isSameYear(zonedFrom, zonedTo) && isSameMonth(zonedFrom, zonedTo)) {
     const dayOfMonthFrom = format(zonedFrom, 'd')


### PR DESCRIPTION
Closes commercelayer/issues-app#271

## What I did

This pull request includes changes to the `formatDateRange` function and its associated tests to handle different timezones correctly. The most important changes involve updating the `formatDateRange` function to adjust for timezone offsets and adding new test cases to ensure the function works as expected with various timezones.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
