### PR TITLE
Enforce Tooltip UI with max width

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tooltip.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.tsx
@@ -61,7 +61,7 @@ export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
           // We are using our own styles, by applying tailwind classes
           // https://react-tooltip.com/docs/examples/styling#base-styles
           disableStyleInjection
-          className='rounded bg-black text-white px-4 py-3 text-sm font-semibold w-max'
+          className='rounded bg-black text-white px-4 py-3 text-sm font-semibold w-max max-w-[260px]'
           classNameArrow={cn('w-2 h-2', {
             'rotate-[45deg]': direction.includes('top'),
             'rotate-[225deg]': direction.includes('bottom')


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

According to a related design request I enforce Tooltip UI by setting the wanted max width classname to wrap text in case of long content.