### PR TITLE
Infer CodeEditor schema domain from token

### DIFF
--- a/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
+++ b/packages/app-elements/src/ui/forms/CodeEditor/CodeEditorComponent.tsx
@@ -1,3 +1,4 @@
+import { useTokenProvider } from '#providers/TokenProvider'
 import {
   InputWrapper,
   type InputWrapperBaseProps
@@ -74,6 +75,9 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
     const monaco = useMonaco()
     const disposeCompletionItemProvider = useRef<() => void>()
     const [editor, setEditor] = useState<Parameters<OnMount>[0] | null>(null)
+    const {
+      settings: { domain }
+    } = useTokenProvider()
 
     const handleEditorDidMount: OnMount = (editor, monaco) => {
       setEditor(editor)
@@ -119,7 +123,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
             case 'organization-config': {
               schemas.push({
                 schema: await fetch(
-                  'https://provisioning.commercelayer.io/api/public/schemas/organization_config'
+                  `https://provisioning.${domain}/api/public/schemas/organization_config`
                 )
                   .then<JsonValue>(async (res) => await res.json())
                   .then((json) => {
@@ -135,7 +139,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
             case 'order-rules': {
               schemas.push({
                 schema: await fetch(
-                  'https://core.commercelayer.io/api/public/schemas/order_rules'
+                  `https://core.${domain}/api/public/schemas/order_rules`
                 )
                   .then<JsonValue>(async (res) => await res.json())
                   .then((json) => {
@@ -154,7 +158,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
             case 'price-rules': {
               schemas.push({
                 schema: await fetch(
-                  'https://core.commercelayer.io/api/public/schemas/price_rules'
+                  `https://core.${domain}/api/public/schemas/price_rules`
                 )
                   .then<JsonValue>(async (res) => await res.json())
                   .then((json) => {
@@ -184,7 +188,7 @@ export const CodeEditor = forwardRef<HTMLInputElement, CodeEditorProps>(
       return () => {
         disposeCompletionItemProvider.current?.()
       }
-    }, [monaco, editor, jsonSchema])
+    }, [monaco, editor, jsonSchema, domain])
 
     return (
       <InputWrapper


### PR DESCRIPTION
## What I did

Code editor now refers to `domain` found in token provider to download the required schema.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
