### PR TITLE
Remove `isValidGtmId` method from the `GTMProvider`

### DIFF
--- a/packages/app-elements/src/providers/GTMProvider.test.tsx
+++ b/packages/app-elements/src/providers/GTMProvider.test.tsx
@@ -30,17 +30,6 @@ describe('GTMProvider', () => {
     })
   })
 
-  test('Should not initialize GTM if gtmId is invalid', async () => {
-    const { getByText } = render(
-      <GTMProvider gtmId='GT-123456'>
-        <div>App</div>
-      </GTMProvider>
-    )
-
-    expect(getByText('App')).toBeInTheDocument()
-    expect(TagManager.initialize).toHaveBeenCalledTimes(0)
-  })
-
   test('Should render children also when gtmId is not provided', async () => {
     const { getByText } = render(
       <GTMProvider>

--- a/packages/app-elements/src/providers/GTMProvider.tsx
+++ b/packages/app-elements/src/providers/GTMProvider.tsx
@@ -37,7 +37,7 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   gtmId
 }) => {
   useEffect(() => {
-    if (isValidGtmId(gtmId)) {
+    if (gtmId != null && !isEmpty(gtmId)) {
       TagManager.initialize({ gtmId })
     }
   }, [gtmId])
@@ -57,9 +57,4 @@ export const GTMProvider: React.FC<GTMProviderProps> = ({
   }
 
   return <GTMContext.Provider value={{ push }}>{children}</GTMContext.Provider>
-}
-
-function isValidGtmId(gtmId?: string): gtmId is string {
-  const gtmIdRegex = /^GTM-[A-Z0-9]{1,7}$/
-  return gtmIdRegex.test(gtmId ?? '')
 }


### PR DESCRIPTION
## What I did

I remove the check `isValidGtmId` when initializing the GTMProvider since the scenario is already managed by GTM out-of-the-box.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
