### PR TITLE
Fix long text visualization in `ResourceMetadata` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -10,7 +10,6 @@ import { Section } from '#ui/atoms/Section'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
-import { ListDetailsItem } from '#ui/composite/ListDetailsItem'
 import { type ListableResourceType } from '@commercelayer/sdk'
 
 interface MetadataOverlay
@@ -87,19 +86,19 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
                 if (!isUpdatableType(metadataValue)) return null
 
                 return (
-                  <ListDetailsItem
+                  <div
                     key={idx}
-                    gutter='none'
-                    label={metadataKey}
+                    className='grid grid-cols-2 p-4 border-b border-gray-100'
                     data-testid={`ResourceMetadata-item-${metadataKey}`}
                   >
+                    <Text variant='info'>{metadataKey}</Text>
                     <Text
                       weight='semibold'
                       data-testid={`ResourceMetadata-value-${metadataKey}`}
                     >
                       {metadataValue.toString()}
                     </Text>
-                  </ListDetailsItem>
+                  </div>
                 )
               }
             )

--- a/packages/docs/src/mocks/data/customers.js
+++ b/packages/docs/src/mocks/data/customers.js
@@ -11,6 +11,7 @@ export default [
     age: 35,
     height: 1.8,
     is_vip: true,
+    microstore_i18n_en_reference_name: "Men's T-Shirt with black logo",
     other: { pet: 'cat' }
   }),
   ...mockCustomer('ASEYfdNrwa', {


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/274

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed long text visualization in `ResourceMetadata` component by replacing `flex` with `grid` layout for showing columns.

### Actual behavior

<img width="424" alt="Screenshot 2025-01-03 alle 12 37 14" src="https://github.com/user-attachments/assets/f77fdeaa-f050-48cc-b244-dae93d4db8e8" />

### Expected behavior

<img width="424" alt="Screenshot 2025-01-03 alle 12 37 56" src="https://github.com/user-attachments/assets/215ac60c-f3f4-4eab-b10b-4f4430c2a0b9" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
