### PR TITLE
Relax shipping rates schema

### DIFF
--- a/packages/app-elements/src/helpers/tracking.ts
+++ b/packages/app-elements/src/helpers/tracking.ts
@@ -149,13 +149,13 @@ const rateSchema = z.object({
   /** currency for the rate */
   currency: z.string(),
   /** delivery days for this service */
-  delivery_days: z.number(),
+  delivery_days: z.number().optional(),
   /** date for delivery */
-  delivery_date: z.string(),
+  delivery_date: z.string().optional(),
   /** *This field is deprecated and should be ignored. @deprecated */
-  est_delivery_days: z.number(),
+  est_delivery_days: z.number().optional(),
   /** formatted date for delivery */
-  formatted_delivery_date: z.string(),
+  formatted_delivery_date: z.string().optional(),
   /** the actual formatted rate quote for this service */
   formatted_rate: z.string()
 })

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -293,7 +293,7 @@ const Tracking = withSkeletonTemplate<{
           </Text>
         </FlexRow>
       )}
-      {showEstimatedDelivery && rate != null && (
+      {showEstimatedDelivery && rate?.formatted_delivery_date != null && (
         <FlexRow className='mt-4'>
           <Text variant='info'>Estimated delivery</Text>
           <Text weight='semibold'>{rate.formatted_delivery_date}</Text>


### PR DESCRIPTION
Closes commercelayer/issues-app#300

## What I did

I have relaxed the `rateSchema` and set `delivery_date`, `est_delivery_days` and `formatted_delivery_date` optional since they won't be always available from easy post

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
