### PR TITLE
Enhance `ResourceAddress` visualization

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.mocks.ts
@@ -42,7 +42,7 @@ export const presetAddresses = {
   withNotes: {
     type: 'addresses',
     id: 'ccZYuDJVXW',
-    company: '',
+    company: 'Rebellion',
     first_name: 'Luke',
     last_name: 'Skywalker',
     full_name: 'Luke Skywalker',

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.test.tsx
@@ -57,11 +57,16 @@ describe('ResourceAddress', () => {
     expect(queryByTestId('ResourceAddress-noAddress')).not.toBeInTheDocument()
   })
 
-  test('Should render fullName', async () => {
+  test('Should render firstLastName', async () => {
     const { getByTestId } = setup()
-    expect(getByTestId('ResourceAddress-fullName')).toContainHTML(
+    expect(getByTestId('ResourceAddress-firstLastName')).toContainHTML(
       'Luke Skywalker'
     )
+  })
+
+  test('Should render company', async () => {
+    const { getByTestId } = setup()
+    expect(getByTestId('ResourceAddress-company')).toContainHTML('Rebellion')
   })
 
   test('Should render address', async () => {

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddress.tsx
@@ -117,14 +117,27 @@ export const ResourceAddress = withSkeletonTemplate<ResourceAddressProps>(
             )}
             {stateAddress != null ? (
               <>
-                <Text
-                  tag='div'
-                  data-testid='ResourceAddress-fullName'
-                  weight={title == null ? 'bold' : undefined}
-                  variant={title != null ? 'info' : undefined}
-                >
-                  {stateAddress.full_name}
-                </Text>
+                {stateAddress.first_name != null &&
+                  stateAddress.last_name != null && (
+                    <Text
+                      tag='div'
+                      data-testid='ResourceAddress-firstLastName'
+                      weight={title == null ? 'bold' : undefined}
+                      variant={title != null ? 'info' : undefined}
+                    >
+                      {stateAddress.first_name} {stateAddress.last_name}
+                    </Text>
+                  )}
+                {stateAddress.company != null && (
+                  <Text
+                    tag='div'
+                    data-testid='ResourceAddress-company'
+                    weight={title == null ? 'bold' : undefined}
+                    variant={title != null ? 'info' : undefined}
+                  >
+                    {stateAddress.company}
+                  </Text>
+                )}
                 <Text
                   tag='div'
                   variant='info'


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/302

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enhanced `ResourceAddress` visualization to show both `first_name` + `last_name` and/or `company` attributes same as they are shown in the edit/create form since the two groups could be filled together and this particular case is not reflected in the `full_name` attribute of the address.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
