### PR TITLE
Avoid empty  `payment_response` visualization

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -29,7 +29,7 @@
   "scripts": {
     "build": "tsc && vite build && pnpm build:css-vendor && pnpm build:tailwind-cfg",
     "build:tailwind-cfg": "cp ./tailwind.config.cjs ./dist/tailwind.config.js",
-    "build:css-vendor": "pnpm dlx tailwindcss -i ./src/styles/vendor.css -o ./dist/vendor.css --minify",
+    "build:css-vendor": "pnpm exec tailwindcss -i ./src/styles/vendor.css -o ./dist/vendor.css --minify",
     "lint": "eslint src --ext .ts,.tsx",
     "lint:fix": "eslint src --ext .ts,.tsx --fix",
     "test": "vitest run",

--- a/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
+++ b/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
@@ -8,6 +8,7 @@ import {
   type PaymentMethod
 } from '@commercelayer/sdk'
 import cn from 'classnames'
+import isEmpty from 'lodash/isEmpty'
 import { useState, type FC } from 'react'
 import type { SetNonNullable, SetRequired } from 'type-fest'
 import { z } from 'zod'
@@ -63,7 +64,8 @@ export const ResourcePaymentMethod: FC<ResourcePaymentMethodProps> = ({
 
   const paymentResponse =
     resource.payment_source != null &&
-    'payment_response' in resource.payment_source
+    'payment_response' in resource.payment_source &&
+    !isEmpty(resource.payment_source.payment_response)
       ? resource.payment_source.payment_response
       : null
 


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/277

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added empty check on `payment_response` in `ResourcePaymentMethod` component to avoid the show of empty Payment response detail.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
