### PR TITLE
Add an 'input' variant to the Button component

### DIFF
--- a/packages/app-elements/src/styles/vendor.css
+++ b/packages/app-elements/src/styles/vendor.css
@@ -15,7 +15,9 @@ body {
 
 input,
 textarea,
-div[role="textbox"] {
+div[role="textbox"],
+.form-input,
+.form-textarea {
   border: none !important;
   box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
   -webkit-box-shadow: inset 0 0 0 1px var(--tw-shadow-color) !important;
@@ -25,8 +27,12 @@ div[role="textbox"] {
 input:focus-visible,
 textarea:focus-visible,
 div[role="textbox"]:focus,
+.form-input:focus,
+.form-textarea:focus,
 .group:focus-within input,
-.group:focus-within div[role="textbox"] {
+.group:focus-within div[role="textbox"],
+.group:focus-within .form-input,
+.group:focus-within .form-textarea {
   ring: none;
   outline: none !important;
   box-shadow: inset 0 0 0 2px theme(colors.primary.DEFAULT) !important;

--- a/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
+++ b/packages/app-elements/src/ui/internals/InteractiveElement.className.ts
@@ -10,6 +10,7 @@ type Variant =
   | 'link'
   | 'circle'
   | 'relationship'
+  | 'input'
 type Size = 'mini' | 'small' | 'regular' | 'large'
 
 export interface InteractiveElementProps {
@@ -121,7 +122,9 @@ function getVariantCss(
       'font-semibold bg-white text-black hover:opacity-80 hover:bg-gray-50 rounded-full',
     danger: 'font-bold bg-white border border-red text-red hover:bg-red/10',
     link: 'text-primary hover:text-primary-light border-primary-light cursor-pointer',
-    relationship: 'font-bold text-primary border border-gray-300 border-dashed'
+    relationship: 'font-bold text-primary border border-gray-300 border-dashed',
+    input:
+      'form-input block w-full !px-4 !py-2.5 font-medium rounded outline-0 !text-left text-gray-500'
   } satisfies Record<NonNullable<InteractiveElementProps['variant']>, string>
 
   return mapping[variant]

--- a/packages/docs/src/stories/atoms/Button.stories.tsx
+++ b/packages/docs/src/stories/atoms/Button.stories.tsx
@@ -1,6 +1,7 @@
 import { A } from '#ui/atoms/A'
 import { Button } from '#ui/atoms/Button'
 import { Icon } from '#ui/atoms/Icon'
+import { Input as InputElement } from '#ui/forms/Input'
 import { type Meta, type StoryFn } from '@storybook/react'
 
 const setup: Meta<typeof Button> = {
@@ -88,3 +89,17 @@ Circle.args = {
   variant: 'circle',
   children: <Icon name='dotsThree' size={24} />
 }
+
+/** A `<Button>` with `variant="input"` can be used to simulate an input/select that opens an overlay with a more complex design.  */
+export const Input: StoryFn = (_args) => (
+  <div>
+    A button:
+    <Button type='button' variant='input'>
+      Search products...
+    </Button>
+    <br />
+    <br />
+    An input:
+    <InputElement placeholder='Search products...' />
+  </div>
+)


### PR DESCRIPTION
## What I did

I added an `input` variant to the `<Button>` component.

<img width="679" alt="Screenshot 2025-01-24 alle 10 37 28" src="https://github.com/user-attachments/assets/15297675-5d23-4e21-bba5-6bc29f19979d" />

https://deploy-preview-872--commercelayer-app-elements.netlify.app/?path=/docs/atoms-button--docs#input
