### PR TITLE
Add `diamonds-four` and `trend-up` icons

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -108,6 +108,7 @@ export const iconMapping = {
   ticket: phosphor.Ticket,
   trash: phosphor.Trash,
   treeStructure: phosphor.TreeStructure,
+  trendUp: phosphor.TrendUp,
   truck: phosphor.Truck,
   tShirt: phosphor.TShirt,
   upload: phosphor.Upload,

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -42,6 +42,7 @@ export const iconMapping = {
   copy: phosphor.Copy,
   creditCard: phosphor.CreditCard,
   currencyEur: phosphor.CurrencyEur,
+  diamondsFour: phosphor.DiamondsFour,
   discord: phosphor.DiscordLogo,
   dotsSixVertical: phosphor.DotsSixVertical,
   dotsThree: phosphor.DotsThree,


### PR DESCRIPTION
## What I did

I added the `diamonds-four` and `trend-up` icons.

<img width="146" alt="Screenshot 2025-01-24 alle 11 00 18" src="https://github.com/user-attachments/assets/4c2a6629-1cd6-48ee-abe0-b21b5ba0dcad" />

<img width="113" alt="image" src="https://github.com/user-attachments/assets/45d65627-159d-463f-856b-66e8577de365" />

