### PR TITLE
Add `shouldRender` method in `<TokenProvider>`

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.0",
+    "@commercelayer/organization-config": "^2.0.2",
     "@commercelayer/sdk": "6.25.1",
     "@monaco-editor/react": "4.6.0",
     "@types/lodash": "^4.17.13",

--- a/packages/app-elements/src/providers/TokenProvider/MockTokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/MockTokenProvider.tsx
@@ -40,6 +40,7 @@ export function MockTokenProvider({
     },
     canUser: (action, resource) => true,
     canAccess: () => true,
+    shouldRender: () => true,
     emitInvalidAuth: () => {}
   }
 

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -331,7 +331,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
       })
 
       return appsConfig[appSlug].hide != null
-        ? appsConfig[appSlug].hide
+        ? !appsConfig[appSlug].hide
             // @ts-expect-error TS is not able to infer the type from the union of tuples
             .includes(block)
         : true

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -43,6 +43,9 @@ export interface TokenProviderValue {
     action: TokenProviderRoleActions,
     resource: ListableResourceType
   ) => boolean
+  shouldRender: (
+    block: 'metadata' | 'tags' | 'details' | 'markets' | 'customer_groups'
+  ) => boolean
   canAccess: (appSlug: Exclude<TokenProviderAllowedApp, 'dashboard'>) => boolean
   emitInvalidAuth: (reason: string) => void
 }
@@ -127,6 +130,7 @@ export interface TokenProviderProps {
 export const AuthContext = createContext<TokenProviderValue>({
   canUser: () => false,
   canAccess: () => false,
+  shouldRender: () => false,
   emitInvalidAuth: () => undefined,
   settings: initialTokenProviderState.settings,
   user: null,
@@ -309,12 +313,21 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
     [accessToken]
   )
 
+  const shouldRender = useCallback<TokenProviderValue['shouldRender']>(
+    (block) => {
+      // const appsConfig = getAppsConfig(_state.organization?.config)
+      return false
+    },
+    [_state.organization?.config, appSlug]
+  )
+
   const value: TokenProviderValue = {
     settings: _state.settings,
     user: _state.user,
     organization: _state.organization,
     canUser,
     canAccess,
+    shouldRender,
     emitInvalidAuth
   }
 

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/orders.tsx
@@ -26,7 +26,7 @@ export const orderToProps: ResourceToProps<Order> = ({ resource, user }) => {
       )
 
   return {
-    name: `${resource.market?.name ?? ''} #${resource.number ?? ''}`,
+    name: `${resource.market?.name ?? ''} #${resource.number ?? ''}`.trim(),
     description: (
       <ListItemDescription
         displayStatus={displayStatus}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@commercelayer/js-auth':
         specifier: ^6.7.0
         version: 6.7.0
+      '@commercelayer/organization-config':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@commercelayer/sdk':
         specifier: 6.25.1
         version: 6.25.1
@@ -911,6 +914,10 @@ packages:
   '@commercelayer/js-auth@6.7.0':
     resolution: {integrity: sha512-Eh4v00OVvz0w1iYqz6PTVptNl/ipVs6nBG9NUzYKRSI/8Nnd+qU0MYfiogQYjm4sSoX5+4j0BsJW+9N/6s9Jjw==}
     engines: {node: '>=18.0.0'}
+
+  '@commercelayer/organization-config@2.0.2':
+    resolution: {integrity: sha512-MAVc21ySdfIbredKX1Ut7X//euZ8Wbu+iDoJmnjmQTp+3yJJi2DZwUeJOBbtrEfH1LnDdJUIrUZYB4LappZztw==}
+    engines: {node: '>=18', pnpm: '>=7'}
 
   '@commercelayer/sdk@6.25.1':
     resolution: {integrity: sha512-tIgybw2l5sOCdCsWoGBkHbBbkWcQfiCg7/ZjZ4SPJUMIFHOBMc3q9YvHrLNyMsYxMirB0TvqIAx8reaEmh7MRw==}
@@ -4031,6 +4038,10 @@ packages:
     resolution: {integrity: sha512-LvIm3/KWzS9oRFHugab7d+M/GcBXuXX5xZkzPmN+NxihdQlZUQ4dWuSV1xR/sq6upL1TJEDrfBgRepHFdBtSNQ==}
     engines: {node: '>= 0.4'}
 
+  is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
+
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
     engines: {node: '>=8'}
@@ -4406,6 +4417,10 @@ packages:
   meow@8.1.2:
     resolution: {integrity: sha512-r85E3NdZ+mpYk1C6RjPFEMSE+s1iZMuHtsHAqY0DT3jZczl0diWUZ8g6oU7h0M9cD2EL+PzaYghhCLzR0ZNn5Q==}
     engines: {node: '>=10'}
+
+  merge-anything@5.1.7:
+    resolution: {integrity: sha512-eRtbOb1N5iyH0tkQDAoQ4Ipsp/5qSR79Dzrz8hEPxRX10RWWR/iQXdoKmBSRCThY1Fh5EhISDtpSc93fpxUniQ==}
+    engines: {node: '>=12.13'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -7271,6 +7286,10 @@ snapshots:
       - supports-color
 
   '@commercelayer/js-auth@6.7.0': {}
+
+  '@commercelayer/organization-config@2.0.2':
+    dependencies:
+      merge-anything: 5.1.7
 
   '@commercelayer/sdk@6.25.1': {}
 
@@ -10888,6 +10907,8 @@ snapshots:
       call-bind: 1.0.7
       get-intrinsic: 1.2.4
 
+  is-what@4.1.16: {}
+
   is-wsl@2.2.0:
     dependencies:
       is-docker: 2.2.1
@@ -11475,6 +11496,10 @@ snapshots:
       trim-newlines: 3.0.1
       type-fest: 0.18.1
       yargs-parser: 20.2.9
+
+  merge-anything@5.1.7:
+    dependencies:
+      is-what: 4.1.16
 
   merge-stream@2.0.0: {}
 


### PR DESCRIPTION
## What I did

I've added support for apps organization config exposing `shouldRender` method in TokenProvider context.
I've also added a login in `ResourceListItem` of type `orders` to hide the name of the market if is the only market available in the organization.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
