### PR TITLE
Avoid wrong timezone conversions in `formatDateRange` helper

### DIFF
--- a/packages/app-elements/src/helpers/date.test.ts
+++ b/packages/app-elements/src/helpers/date.test.ts
@@ -638,17 +638,28 @@ describe('formatDateRange should return the proper date format', () => {
     ).toEqual('Dec 01, 2023 - Jan 31, 2025')
   })
 
-  test('with timezone Italy', () => {
+  test('with timezone Italy in winter', () => {
     expect(
       formatDateRange({
-        rangeFrom: '2024-12-09T22:00:00.000Z',
-        rangeTo: '2024-12-10T21:59:59.999Z',
-        timezone: 'Europe/Rome'
+        rangeFrom: '2024-02-04T23:00:00.000Z',
+        rangeTo: '2024-02-05T22:59:59.000Z',
+        timezone: 'Europe/Rome',
+        zonedAlready: true
       })
-    ).toEqual('10-10 Dec')
+    ).toEqual('5-5 Feb')
   })
 
-  test('with timezone Italy', () => {
+  test('with timezone Italy in summer', () => {
+    expect(
+      formatDateRange({
+        rangeFrom: '2024-05-04T22:00:00.000Z',
+        rangeTo: '2024-05-05T21:59:59.000Z',
+        timezone: 'Europe/Rome'
+      })
+    ).toEqual('5-5 May')
+  })
+
+  test('with timezone Italy in winter (more than 1 day)', () => {
     expect(
       formatDateRange({
         rangeFrom: '2024-12-10T00:00:00.000Z',

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -1,8 +1,7 @@
 import { type I18NLocale } from '#providers/I18NProvider'
+import { formatInTimeZone } from 'date-fns-tz/formatInTimeZone'
 import { fromZonedTime } from 'date-fns-tz/fromZonedTime'
-import { getTimezoneOffset } from 'date-fns-tz/getTimezoneOffset'
 import { toZonedTime } from 'date-fns-tz/toZonedTime'
-import { addMilliseconds } from 'date-fns/addMilliseconds'
 import { endOfDay } from 'date-fns/endOfDay'
 import { format } from 'date-fns/format'
 import { formatDistance } from 'date-fns/formatDistance'
@@ -332,34 +331,30 @@ export function formatDateRange({
   timezone = 'UTC',
   locale = 'en-US'
 }: {
-  /** JavaScript ISO date string. Example '2022-10-06T11:59:30.371Z' */
-  rangeFrom: DateISOString
-  /** JavaScript ISO date string. Example '2022-11-06T11:59:30.371Z' */
-  rangeTo: DateISOString
+  /** JavaScript Date or ISO string. Example '2022-10-06T11:59:30.371Z' */
+  rangeFrom: DateISOString | Date
+  /** JavaScript Date or ISO string. Example '2022-11-06T11:59:30.371Z' */
+  rangeTo: DateISOString | Date
   /** Set a specific timezone, when not passed default value is 'UTC' */
   timezone?: string
   /** Locale to use for formatting the date. */
   locale?: I18NLocale
+  zonedAlready?: boolean
 }): string {
-  const offsetMilliseconds = getTimezoneOffset(timezone)
-  const zonedFrom = toZonedTime(
-    addMilliseconds(rangeFrom, offsetMilliseconds),
-    timezone
-  )
-  const zonedTo = toZonedTime(
-    addMilliseconds(rangeTo, offsetMilliseconds),
-    timezone
-  )
+  rangeFrom = new Date(rangeFrom).toISOString()
+  rangeTo = new Date(rangeTo).toISOString()
 
-  if (isSameYear(zonedFrom, zonedTo) && isSameMonth(zonedFrom, zonedTo)) {
-    const dayOfMonthFrom = format(zonedFrom, 'd', {
+  if (isSameYear(rangeFrom, rangeTo) && isSameMonth(rangeFrom, rangeTo)) {
+    const dayOfMonthFrom = formatInTimeZone(rangeFrom, timezone, 'd', {
       locale: getLocaleOption(locale)
     })
-    const dayOfMonthTo = format(zonedTo, 'd', {
+    const dayOfMonthTo = formatInTimeZone(rangeTo, timezone, 'd', {
       locale: getLocaleOption(locale)
     })
-    const month = format(zonedFrom, 'LLL', { locale: getLocaleOption(locale) })
-    const year = isThisYear(zonedFrom) ? '' : `, ${format(zonedFrom, 'yyyy')}`
+    const month = formatInTimeZone(rangeFrom, timezone, 'LLL', {
+      locale: getLocaleOption(locale)
+    })
+    const year = isThisYear(rangeFrom) ? '' : `, ${format(rangeFrom, 'yyyy')}`
 
     return `${dayOfMonthFrom}-${dayOfMonthTo} ${month}${year}`
   }

--- a/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
+++ b/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
@@ -4,6 +4,7 @@ import {
 } from '#ui/internals/InputWrapper'
 import { ArrowRight } from '@phosphor-icons/react'
 import classNames from 'classnames'
+import { endOfDay } from 'date-fns/endOfDay'
 import { forwardRef, useEffect } from 'react'
 import { InputDate } from '../InputDate'
 import {
@@ -74,7 +75,10 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
         }
 
         if (fromDate > toDate) {
-          onChange([fromDate, fromDate])
+          onChange([
+            fromDate,
+            showTimeSelect === true ? fromDate : toEndOfDay(fromDate)
+          ])
         }
       },
       [fromDate]
@@ -111,7 +115,10 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
           <InputDate
             value={toDate}
             onChange={(newDate) => {
-              onChange([fromDate, newDate])
+              onChange([
+                fromDate,
+                showTimeSelect === true ? newDate : toEndOfDay(newDate)
+              ])
             }}
             placeholder={toPlaceholder}
             minDate={fromDate ?? undefined}
@@ -129,5 +136,13 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
     )
   }
 )
+
+// quick helper to set the time to the end of the day compatible with nullable date
+function toEndOfDay(date: Date | null): Date | null {
+  if (date == null) {
+    return null
+  }
+  return endOfDay(date)
+}
 
 InputDateRange.displayName = 'InputDateRange'


### PR DESCRIPTION
Closes commercelayer/issues-app#324

## What I did

In `formatDateRange` we were wrongly modified range using timezone offset.
Instead we can safely rely on `formatInTimeZone` imported form `date-fns-tz`.

Also test cases where not correctly defined. New cases added should better cover proper usage.

I've also updated the `InputDateRange` component that now sets as `to` date the end of the day, unless `showTimeSelect` is active.
 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
