### PR TITLE
Show stock location in shipment list item

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
@@ -26,9 +26,9 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
     resource,
     awaitingStockTransfer
   )
-  const shipmentShippingMethodName =
-    resource.shipping_method?.name != null
-      ? `${resource.shipping_method.name} `
+  const stockLocationName =
+    resource.stock_location?.name != null
+      ? `${t('common.from')} ${resource.stock_location.name} `
       : ''
   const number = resource.number != null ? `#${resource.number}` : ''
 
@@ -43,7 +43,7 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
           timezone: user?.timezone,
           locale: user?.locale
         })}
-        additionalInfos={shipmentShippingMethodName}
+        additionalInfos={stockLocationName}
       />
     ),
     icon:


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/327

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Restored previous shipment `ResourceListItem` behavior to show stock location instead of shipping method.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
