### PR TITLE
Set `additionalInfos` in ResourceListItem > shipments to work either with stock location or shipping method

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/shipments.tsx
@@ -26,10 +26,12 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
     resource,
     awaitingStockTransfer
   )
-  const stockLocationName =
+  const additionalInfos =
     resource.stock_location?.name != null
       ? `${t('common.from')} ${resource.stock_location.name} `
-      : ''
+      : resource.shipping_method?.name != null
+        ? `${resource.shipping_method.name} `
+        : ''
   const number = resource.number != null ? `#${resource.number}` : ''
 
   return {
@@ -43,7 +45,7 @@ export const shipmentToProps: ResourceToProps<Shipment> = ({
           timezone: user?.timezone,
           locale: user?.locale
         })}
-        additionalInfos={stockLocationName}
+        additionalInfos={additionalInfos}
       />
     ),
     icon:


### PR DESCRIPTION
## What I did

When `stock_location` is not available in `ResourceListItem` for `shipments`,  it will display the shipping method name.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
