### PR TITLE
Update requirements of page heading generated toolbar

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.test.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.test.tsx
@@ -78,7 +78,7 @@ describe('PageHeadingToolbar', () => {
   })
 
   it('Should not display the dropdown button when empty', async () => {
-    const { queryAllByTestId, queryByTestId } = render(
+    const { queryAllByTestId } = render(
       <PageHeadingToolbar
         buttons={[
           {
@@ -94,7 +94,6 @@ describe('PageHeadingToolbar', () => {
     )
 
     expect(queryAllByTestId('toolbar-button').length).toEqual(1)
-    expect(queryAllByTestId('toolbar-dropdown-button').length).toEqual(1)
-    expect(queryByTestId('toolbar-dropdown-button')).toHaveClass('md:hidden')
+    expect(queryAllByTestId('toolbar-dropdown-button').length).toEqual(0)
   })
 })

--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeadingToolbar.tsx
@@ -26,25 +26,37 @@ export interface PageHeadingToolbarProps {
  */
 export const PageHeadingToolbar = withSkeletonTemplate<PageHeadingToolbarProps>(
   ({ buttons = [], dropdownItems = [] }) => {
-    const dropdownMobileButtons: DropdownItemProps[] = buttons.map(
-      (button) => ({
+    // Initialize the toolbar items list with the buttons
+    const toolbarItems: ToolbarProps['items'] = buttons.map((button, idx) => {
+      const isShown =
+        (button.variant == null || button.variant === 'primary') && idx === 0
+      return {
         ...button,
-        label: button.label ?? '',
-        className: 'flex md:hidden'
+        // On mobile devices only the first primary button is shown outside the dropdown
+        className: !isShown ? 'hidden md:flex' : ''
+      }
+    })
+
+    // Calculate the list of buttons that will be shown as dropdown items in the dropdown
+    const buttonsForDropdown: DropdownItemProps[] = buttons
+      .filter(
+        (button, idx) =>
+          (button.variant != null && button.variant !== 'primary') || idx > 0
+      )
+      .map((button) => {
+        return {
+          ...button,
+          label: button.label ?? '',
+          className: 'md:hidden'
+        }
       })
-    )
-
     const [firstDropdownItemsGroup = [], ...otherDropdownItems] = dropdownItems
-
+    // Calculate the flat array of all dropdown items made of buttons and dropdown items
     const combinedDropdownItems = [
-      dropdownMobileButtons.concat(firstDropdownItemsGroup)
+      buttonsForDropdown.concat(firstDropdownItemsGroup)
     ].concat(otherDropdownItems)
 
-    const toolbarItems: ToolbarProps['items'] = buttons.map((button) => ({
-      ...button,
-      className: 'hidden md:flex'
-    }))
-
+    // Add dropdown to toolbar items
     if (combinedDropdownItems.flat().length > 0) {
       toolbarItems.push({
         icon: 'dotsThree',

--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -14,6 +14,8 @@ export interface DropdownProps
   dropdownLabel?: React.ReactNode
   /** List of links and actions. You can use a combination of `DropdownItem` and `DropdownDivider` components. */
   dropdownItems: React.ReactNode
+  /** Additional class name for the dropdown container. */
+  className?: string
 }
 
 /**
@@ -28,7 +30,8 @@ export const Dropdown: React.FC<DropdownProps> = ({
   menuHeader,
   dropdownItems,
   menuPosition = 'bottom-right',
-  menuWidth
+  menuWidth,
+  className
 }) => {
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -95,7 +98,7 @@ export const Dropdown: React.FC<DropdownProps> = ({
     <div
       ref={isExpanded ? clickAwayRef : undefined}
       onBlur={handleBlur}
-      className='relative'
+      className={cn('relative', className)}
     >
       {dropdownButton}
       {isExpanded && (

--- a/packages/app-elements/src/ui/composite/Toolbar.tsx
+++ b/packages/app-elements/src/ui/composite/Toolbar.tsx
@@ -87,6 +87,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
               </Button>
             }
             dropdownItems={dropdownItemsHtml}
+            className={item.className}
             data-testid='toolbar-dropdown'
           />
         )

--- a/packages/docs/src/stories/composite/PageLayout.stories.tsx
+++ b/packages/docs/src/stories/composite/PageLayout.stories.tsx
@@ -1,4 +1,5 @@
 import { PageLayout } from '#ui/composite/PageLayout'
+import { SearchBar } from '#ui/composite/SearchBar'
 
 import { type Meta, type StoryFn } from '@storybook/react'
 
@@ -12,7 +13,7 @@ const setup: Meta<typeof PageLayout> = {
 export default setup
 
 const Template: StoryFn<typeof PageLayout> = (args) => (
-  <PageLayout {...args}>Page content here...</PageLayout>
+  <PageLayout {...args}>{args.children ?? 'Page content here...'}</PageLayout>
 )
 
 export const Default = Template.bind({})
@@ -24,6 +25,53 @@ Default.args = {
     onClick: () => undefined
   },
   mode: 'test'
+}
+
+export const WithSimpleToolbar = Template.bind({})
+WithSimpleToolbar.args = {
+  title: 'Resources',
+  gap: 'none',
+  toolbar: {
+    buttons: [
+      {
+        label: 'Add new',
+        icon: 'plus',
+        size: 'small',
+        variant: 'primary',
+        onClick: () => {
+          alert('Add new clicked!')
+        }
+      },
+      {
+        label: 'Search',
+        icon: 'plus',
+        size: 'small',
+        variant: 'primary',
+        onClick: () => {
+          alert('Search clicked!')
+        }
+      },
+      {
+        label: 'Delete',
+        icon: 'trash',
+        size: 'small',
+        variant: 'secondary',
+        onClick: () => {
+          alert('Add new clicked!')
+        }
+      }
+    ]
+  },
+  children: (
+    <div className='mt-4 mb-14'>
+      <SearchBar
+        placeholder='Cerca...'
+        isLoading={false}
+        initialValue=''
+        onSearch={() => {}}
+      />
+    </div>
+  )
 }
 
 export const WithToolbar = Template.bind({})


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

According to design team I updated the requirements of page heading generated toolbar:
- The first primary button defined in `buttons` attribute of `toolbar` prop will always be visible (desktop + mobile). Now it is visible only on desktop viewport.
- The dropdown wrapper should disappear along with the inner dropdown if it is not visible to avoid the wrapper to be considered as part of the flex elements and the given gap.

While updating the implementation according to the requirement part of the code was improved in terms of documentation and readability.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
