### PR TITLE
Ignore hidden filters options in field label count

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldOptions.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldOptions.tsx
@@ -21,7 +21,9 @@ export function FieldOptions({ item }: FieldProps): JSX.Element | null {
               ? computeFilterLabel({
                   label: item.label,
                   selectedCount: watch(item.sdk.predicate)?.length,
-                  totalCount: item.render.props.options.length
+                  totalCount: item.render.props.options.filter(
+                    (o) => o.isHidden !== true
+                  ).length
                 })
               : item.label
           }


### PR DESCRIPTION
## What I did

This pull request includes a change to the `FieldOptions` function in `FieldOptions.tsx` to improve how the total count of options is computed by excluding hidden options.

Changes in `FieldOptions` function:

* [`packages/app-elements/src/ui/resources/useResourceFilters/FieldOptions.tsx`](diffhunk://#diff-e569f1bc1b78544f8379bc987089ba58b5e41123a5e543c36ca09cb6a6b01a06L24-R26): Modified the `totalCount` calculation to filter out options where `isHidden` is `true`.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
