### PR TITLE
Increase pageSize of resource tags list

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -69,7 +69,8 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
         : [
             resourceId,
             {
-              fields: ['id', 'name']
+              fields: ['id', 'name'],
+              pageSize: 25
             }
           ]
     )


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/321

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Increased the `pageSize` of resource tags listed in `ResourceTags` component. This changes was made since some organizations are able to assign more then 10 (the actual default requests pageSize) tags to the resources.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
