### PR TITLE
Prevent date picker to be hidden by other elements

### DIFF
--- a/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.css
+++ b/packages/app-elements/src/ui/forms/InputDate/InputDateComponent.css
@@ -16,6 +16,7 @@
 .react-datepicker-popper {
   min-width: 370px;
   text-align: center;
+  z-index: 30;
 }
 
 .react-datepicker-popper .react-datepicker__triangle {


### PR DESCRIPTION
Closes commercelayer/issues-app#348

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've set same z-index value used in dropdown to date-picker.
This prevents other elements like code editor to overlap the picker menu.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
