### PR TITLE
Enforce word break in `PageHeading` title

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
@@ -97,7 +97,7 @@ const PageHeading = withSkeletonTemplate<PageHeadingProps>(
           </div>
         )}
         <div className='flex items-center justify-between'>
-          <h1 className='font-semibold text-2xl md:text-title leading-title break-words'>
+          <h1 className='font-semibold text-2xl md:text-title leading-title break-all'>
             {title}
           </h1>
           {navigationButton == null && toolbar != null ? (

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`PageLayout > Should be rendered 1`] = `
         class="flex items-center justify-between"
       >
         <h1
-          class="font-semibold text-2xl md:text-title leading-title break-words"
+          class="font-semibold text-2xl md:text-title leading-title break-all"
         >
           Page title
         </h1>

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`PageSkeleton > Should be rendered 1`] = `
                 class="flex items-center justify-between"
               >
                 <h1
-                  class="font-semibold text-2xl md:text-title leading-title break-words"
+                  class="font-semibold text-2xl md:text-title leading-title break-all"
                 >
                   <span
                     class="select-none !border-gray-50 pointer-events-none animate-pulse !bg-gray-50 rounded text-transparent [&>*]:invisible object-out-of-bounds"


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforce word break in `PageHeading` title to avoid the overlap of long titles.

### Unwanted behavior
<img width="600" alt="Screenshot 2025-04-02 alle 19 39 56" src="https://github.com/user-attachments/assets/ae4cbd7d-2703-4361-a3d9-bfc006206113" />

### Wanted behavior
<img width="600" alt="Screenshot 2025-04-02 alle 19 40 36" src="https://github.com/user-attachments/assets/970276f6-f636-44c3-86ad-d41cf92845a0" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
