### PR TITLE
Avoid showing broken images when notFound (`Avatar`)

### DIFF
--- a/packages/app-elements/src/ui/atoms/Avatar.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.tsx
@@ -1,5 +1,5 @@
 import cn from 'classnames'
-import { type JSX } from 'react'
+import { useState, type JSX } from 'react'
 import { presets } from './Avatar.utils'
 
 type SrcPreset = keyof typeof presets
@@ -47,13 +47,20 @@ export function Avatar({
   className,
   ...rest
 }: AvatarProps): JSX.Element {
+  const [hasOnLoadError, setHasOnLoadError] = useState<boolean>(false)
+  const hasError =
+    hasOnLoadError || (!srcIsValidUrl(src) && !srcIsValidPreset(src))
+
   return (
     <img
       {...rest}
+      onError={() => {
+        setHasOnLoadError(true)
+      }}
       src={
         srcIsValidPreset(src)
           ? presets[src]
-          : srcIsValidUrl(src)
+          : srcIsValidUrl(src) && !hasOnLoadError
             ? src
             : placeholderSvg
       }
@@ -73,12 +80,8 @@ export function Avatar({
           'border-gray-100': border == null,
           'border-transparent': border === 'none' || srcIsValidPreset(src),
           // placeholder
-          'p-1':
-            !srcIsValidPreset(src) &&
-            !srcIsValidUrl(src) &&
-            (size === 'normal' || size === 'large'),
-          'p-0.5':
-            !srcIsValidPreset(src) && !srcIsValidUrl(src) && size !== 'normal'
+          'p-1': hasError && (size === 'normal' || size === 'large'),
+          'p-0.5': hasError && size !== 'normal'
         },
         className
       )}

--- a/packages/docs/src/stories/atoms/Avatar.stories.tsx
+++ b/packages/docs/src/stories/atoms/Avatar.stories.tsx
@@ -39,13 +39,20 @@ UndefinedSource.args = {
   alt: 'The image is not present'
 }
 
+/** When `src` prop is set to an non-existing image source, then a placeholder will be shown. */
+export const OnLoadError = Template.bind({})
+OnLoadError.args = {
+  alt: 'The image is not present',
+  src: 'https://commercelayer.io/non-existing.svg'
+}
+
 /** The image is scaled to maintain its aspect ratio while fitting within the element's content box. */
 export const AspectRatio: StoryFn = (_args) => {
   return (
     <>
-      <Avatar src='https://via.placeholder.com/50x80' alt='Portrait' />
-      <Avatar src='https://via.placeholder.com/80x50' alt='Landscape' />
-      <Avatar src='https://via.placeholder.com/40x40' alt='Small' />
+      <Avatar src='https://placehold.co/50x80' alt='Portrait' />
+      <Avatar src='https://placehold.co/80x50' alt='Landscape' />
+      <Avatar src='https://placehold.co/40x40' alt='Small' />
     </>
   )
 }


### PR DESCRIPTION
## What I did

Avoid showing broken images when notFound.

## How to test

https://deploy-preview-926--commercelayer-app-elements.netlify.app/?path=/docs/atoms-avatar--docs
