### PR TITLE
Add support for timezone in `InputDate` and `InputDateRange` components

### DIFF
--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@commercelayer/js-auth": "^6.7.1",
     "@commercelayer/sdk": "6.33.0",
+    "@date-fns/tz": "^1.2.0",
     "@monaco-editor/react": "4.7.0",
     "@types/lodash-es": "^4.17.12",
     "@types/react": "^19.0.10",

--- a/packages/app-elements/src/helpers/date.ts
+++ b/packages/app-elements/src/helpers/date.ts
@@ -520,3 +520,12 @@ function i18n(localeCode: I18NLocale) {
   }
   return locale.en
 }
+
+/**
+ * Check if the given date is valid.
+ * @param date The date to check.
+ * @returns True if the date is valid, false otherwise.
+ */
+export function isDateValid(date: Date): boolean {
+  return date instanceof Date && !isNaN(date.getTime())
+}

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -15,6 +15,7 @@ export {
   getEventDateInfo,
   getIsoDateAtDayEdge,
   getIsoDateAtDaysBefore,
+  isDateValid,
   makeDateYearsRange,
   removeMillisecondsFromIsoDate,
   sortAndGroupByDate,

--- a/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
+++ b/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.tsx
@@ -15,7 +15,11 @@ import {
 export interface InputDateRangeProps
   extends Pick<
       InputDateProps,
-      'isClearable' | 'format' | 'autoPlaceholder' | 'showTimeSelect'
+      | 'isClearable'
+      | 'format'
+      | 'timezone'
+      | 'autoPlaceholder'
+      | 'showTimeSelect'
     >,
     InputWrapperBaseProps {
   /** a tuple that represents the [from, to] dates */
@@ -50,6 +54,7 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
       toPlaceholder,
       label,
       format,
+      timezone,
       autoPlaceholder,
       isClearable,
       onChange,
@@ -81,7 +86,7 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
           ])
         }
       },
-      [fromDate]
+      [fromDate, toDate]
     )
 
     const hasSingleLabels = fromLabel != null || toLabel != null
@@ -101,6 +106,7 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
             }}
             placeholder={fromPlaceholder}
             format={format}
+            timezone={timezone}
             wrapperClassName='flex-1'
             isClearable={isClearable}
             autoPlaceholder={autoPlaceholder}
@@ -123,6 +129,7 @@ export const InputDateRange = forwardRef<HTMLDivElement, InputDateRangeProps>(
             placeholder={toPlaceholder}
             minDate={fromDate ?? undefined}
             format={format}
+            timezone={timezone}
             wrapperClassName='flex-1'
             isClearable={isClearable}
             autoPlaceholder={autoPlaceholder}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@commercelayer/sdk':
         specifier: 6.33.0
         version: 6.33.0
+      '@date-fns/tz':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.52.2)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -939,6 +942,9 @@ packages:
     resolution: {integrity: sha512-UJnjoFsmxfKUdNYdWgOB0mWUypuLvAfQPH1+pyvRJs6euowbFkFC6P13w1l8mJyi3vxYMxc9kld5jZEGRQs6bw==}
     engines: {node: '>=18'}
 
+  '@date-fns/tz@1.2.0':
+    resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
+
   '@emnapi/core@1.3.1':
     resolution: {integrity: sha512-pVGjBIt1Y6gg3EJN8jTcfpP/+uuRksIo055oE/OBkDNcjZqVbfkWCksG1Jp4yZnj3iKWyWX8fdG/j6UDYPbFog==}
 
@@ -1279,7 +1285,7 @@ packages:
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
     peerDependencies:
-      '@types/react': '>=16'
+      '@types/react': 19.0.1
       react: '>=16'
 
   '@microsoft/api-extractor-model@7.30.4':
@@ -7335,6 +7341,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.3
 
   '@csstools/css-tokenizer@3.0.3': {}
+
+  '@date-fns/tz@1.2.0': {}
 
   '@emnapi/core@1.3.1':
     dependencies:


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for customizable timezone in `InputDate` and `InputDateRange` components via dedicated `timezone` prop.

At the moment the `InputDate` components are only supporting the user's browser timezone according to the default behavior of the `react-datepicker` package which does not provide an out of the box way to configure a `timezone`.
Many issues were opened inside the project's repository but none of them was considered to provide an official solution.

This feature aims to rework the standard behavior of the `react-datepicker` to support a customizable `timezone` used to render the selected date time and update as well the selected value.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
