### PR TITLE
Fix translation of returns timeline string

### DIFF
--- a/packages/app-elements/src/locales/en.ts
+++ b/packages/app-elements/src/locales/en.ts
@@ -552,9 +552,9 @@ const en = {
         delete_error: 'Could not cancel this return',
         info: 'Info',
         timeline_requested_return:
-          '{{email}} requested the return of {{count} item',
+          '{{email}} requested the return of {{count}} item',
         timeline_requested_return_other:
-          '{{email}} requested the return of {{count} items',
+          '{{email}} requested the return of {{count}} items',
         timeline_shipped: 'Return was <strong>shipped</strong>',
         timeline_received: 'Return was <strong>received</strong>',
         timeline_cancelled: 'Return was <strong>cancelled</strong>',


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fixed a copy error in a translation of returns timeline string.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
