### PR TITLE
Enforce tests for lazy component

### DIFF
--- a/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputDateRange/InputDateRange.test.tsx
@@ -40,7 +40,7 @@ const setup = ({ id, ...rest }: SetupProps): SetupResult => {
 
 describe('InputDateRange', () => {
   test('Should be rendered', async () => {
-    const { element, findByPlaceholderText } = setup({
+    const { element, getByPlaceholderText } = setup({
       id: 'date-picker',
       fromPlaceholder: 'select starting date',
       toPlaceholder: 'select ending date',
@@ -48,8 +48,18 @@ describe('InputDateRange', () => {
     })
     expect(element).toBeInTheDocument()
 
-    const inputFrom = await findByPlaceholderText('select starting date')
-    const inputTo = await findByPlaceholderText('select ending date')
+    // waiting for lazy load component
+    await waitFor(
+      () => {
+        expect(getByPlaceholderText('select starting date')).toBeInTheDocument()
+      },
+      {
+        timeout: 5000
+      }
+    )
+
+    const inputFrom = getByPlaceholderText('select starting date')
+    const inputTo = getByPlaceholderText('select ending date')
     expect(inputFrom).toBeInTheDocument()
     expect(inputTo).toBeInTheDocument()
     expect(inputFrom.getAttribute('placeholder')).toBe('select starting date')


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced tests by adding a `waitFor` directive to await correctly the render of `InputDateRange` lazy component after some tests related to it started failing randomly.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
