### PR TITLE
Show full country name in Address component

### DIFF
--- a/packages/app-elements/src/ui/composite/Address.tsx
+++ b/packages/app-elements/src/ui/composite/Address.tsx
@@ -1,12 +1,17 @@
 import { t } from '#providers/I18NProvider'
 import { Button } from '#ui/atoms/Button'
 import { Hr } from '#ui/atoms/Hr'
-import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
+import {
+  SkeletonTemplate,
+  withSkeletonTemplate
+} from '#ui/atoms/SkeletonTemplate'
 import { Spacer } from '#ui/atoms/Spacer'
 import { Text } from '#ui/atoms/Text'
+import { useCountryList } from '#ui/internals/useCountryList'
 import { type Address as AddressType } from '@commercelayer/sdk'
 import { Note, PencilSimple, Phone } from '@phosphor-icons/react'
 import isEmpty from 'lodash-es/isEmpty'
+import { useMemo } from 'react'
 
 export interface AddressProps {
   /**
@@ -53,6 +58,13 @@ export interface AddressProps {
  */
 export const Address = withSkeletonTemplate<AddressProps>(
   ({ address, title, showBillingInfo = false, showNotes = true, onEdit }) => {
+    const { countries, isLoading } = useCountryList()
+    const countryCode = address?.country_code
+    const countryName = useMemo(
+      () => countries?.find((c) => c.value === countryCode)?.label,
+      [countries, countryCode]
+    )
+
     return (
       <>
         <div className='w-full flex gap-4 space-between'>
@@ -90,7 +102,10 @@ export const Address = withSkeletonTemplate<AddressProps>(
                   {address.line_1} {address.line_2}
                   <br />
                   {address.city} {address.state_code} {address.zip_code} (
-                  {address.country_code})
+                  <SkeletonTemplate isLoading={isLoading}>
+                    {countryName ?? countryCode}
+                  </SkeletonTemplate>
+                  )
                 </Text>
 
                 {address.billing_info != null && showBillingInfo ? (

--- a/packages/app-elements/src/ui/internals/useCountryList.ts
+++ b/packages/app-elements/src/ui/internals/useCountryList.ts
@@ -1,0 +1,38 @@
+import useSWR from 'swr'
+
+export interface CountryOption {
+  value: string
+  label: string
+}
+
+const fetcher = async (url: string): Promise<CountryOption[]> => {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error('Failed to fetch countries')
+  return await res.json()
+}
+
+/**
+ * Custom hook to fetch and manage a static list of countries.
+ * Utilizes SWR for data fetching with disabled revalidation, as the country list is static.
+ * Returns an array of { value, label } objects suitable for use in select inputs.
+ */
+export function useCountryList(): {
+  countries: CountryOption[] | undefined
+  isLoading: boolean
+  error: any
+} {
+  const { data, isLoading, error } = useSWR<CountryOption[]>(
+    'https://data.commercelayer.app/assets/lists/countries.json',
+    fetcher,
+    {
+      revalidateOnFocus: false,
+      revalidateIfStale: false
+    }
+  )
+
+  return {
+    countries: data,
+    isLoading,
+    error
+  }
+}

--- a/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAddress/ResourceAddressFormFields.tsx
@@ -6,6 +6,7 @@ import { HookedInput } from '#ui/forms/Input/HookedInput'
 import { type InputSelectValue } from '#ui/forms/InputSelect'
 import { HookedInputSelect } from '#ui/forms/InputSelect/HookedInputSelect'
 import { HookedInputTextArea } from '#ui/forms/InputTextArea'
+import { useCountryList } from '#ui/internals/useCountryList'
 import React, { type JSX, useEffect, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
 import { z } from 'zod'
@@ -215,20 +216,15 @@ const FieldRow = ({
 }
 
 const SelectCountry: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
-  const [countries, setCountries] = useState<InputSelectValue[] | undefined>()
   const [forceTextInput, setForceTextInput] = useState(false)
+  const { countries, isLoading, error } = useCountryList()
 
   useEffect(() => {
-    void fetch('https://data.commercelayer.app/assets/lists/countries.json')
-      .then<InputSelectValue[]>(async (res) => await res.json())
-      .then((data) => {
-        setCountries(data)
-      })
-      .catch(() => {
-        // error fetching states, fallback to text input
-        setForceTextInput(true)
-      })
-  }, [])
+    if (error != null) {
+      // error fetching countries, fallback to text input
+      setForceTextInput(true)
+    }
+  }, [error])
 
   if (forceTextInput) {
     return (
@@ -246,7 +242,7 @@ const SelectCountry: React.FC<{ namePrefix: string }> = ({ namePrefix }) => {
       key={countries?.length}
       initialValues={countries ?? []}
       pathToValue='value'
-      isLoading={countries == null}
+      isLoading={isLoading || countries == null}
     />
   )
 }


### PR DESCRIPTION
Closes commercelayer/issues-app#335

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

In the Address and ResourceAddress component, instead of showing country code, we now display the full country name.
To do so I've moved the get countries api call from the address edit form, into a shared hook to be used also in the address display component.

[Storybook preview](https://deploy-preview-942--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceaddress--docs)

<img width="319" alt="image" src="https://github.com/user-attachments/assets/1e462a9a-8216-414c-9811-b47e7fed360d" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
