### PR TITLE
Prevent firing of API requests with mocked resource ids

### DIFF
--- a/packages/app-elements/src/helpers/mocks.test.ts
+++ b/packages/app-elements/src/helpers/mocks.test.ts
@@ -1,0 +1,40 @@
+import type { Resource } from '@commercelayer/sdk'
+import { describe, expect, it } from 'vitest'
+import { isMock, isMockedId } from './mocks'
+
+describe('isMockedId', () => {
+  it('returns true for ids starting with "fake-"', () => {
+    expect(isMockedId('fake-123')).toBe(true)
+    expect(isMockedId('fake-abc')).toBe(true)
+    expect(isMockedId('fake-')).toBe(true)
+  })
+
+  it('returns false for ids not starting with "fake-"', () => {
+    expect(isMockedId('real-123')).toBe(false)
+    expect(isMockedId('123-fake')).toBe(false)
+    expect(isMockedId('')).toBe(false)
+    expect(isMockedId('fak-e123')).toBe(false)
+  })
+})
+
+describe('isMock', () => {
+  it('returns true if resource.id starts with "fake-"', () => {
+    const resource: Resource = {
+      id: 'fake-456',
+      type: 'orders',
+      created_at: '',
+      updated_at: ''
+    }
+    expect(isMock(resource)).toBe(true)
+  })
+
+  it('returns false if resource.id does not start with "fake-"', () => {
+    const resource: Resource = {
+      id: 'order-789',
+      type: 'orders',
+      created_at: '',
+      updated_at: ''
+    }
+    expect(isMock(resource)).toBe(false)
+  })
+})

--- a/packages/app-elements/src/helpers/mocks.ts
+++ b/packages/app-elements/src/helpers/mocks.ts
@@ -1,0 +1,9 @@
+import { type Resource } from '@commercelayer/sdk'
+
+export const isMockedId = (id: string): boolean => {
+  return id.startsWith('fake-')
+}
+
+export const isMock = (resource: Resource): boolean => {
+  return isMockedId(resource.id)
+}

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -22,6 +22,7 @@ export {
   timeSeparator
 } from '#helpers/date'
 export { downloadJsonAsFile } from '#helpers/downloadJsonAsFile'
+export { isMock, isMockedId } from '#helpers/mocks'
 export { computeFullname, formatDisplayName } from '#helpers/name'
 export {
   formatResourceName,

--- a/packages/app-elements/src/ui/resources/ResourceAttachments/ResourceAttachments.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceAttachments/ResourceAttachments.tsx
@@ -1,4 +1,5 @@
 import { formatDateWithPredicate } from '#helpers/date'
+import { isMockedId } from '#helpers/mocks'
 import { useCoreApi } from '#providers/CoreSdkProvider'
 import { useTranslation } from '#providers/I18NProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
@@ -25,7 +26,7 @@ export const ResourceAttachments =
       const { data: resource } = useCoreApi(
         resourceType,
         'retrieve',
-        resourceId == null || isEmpty(resourceId)
+        resourceId == null || isEmpty(resourceId) || isMockedId(resourceId)
           ? null
           : [
               resourceId,

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -1,3 +1,4 @@
+import { isMockedId } from '#helpers/mocks'
 import {
   type EditMetadataOverlayProps,
   useEditMetadataOverlay
@@ -45,12 +46,14 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
     const { data: resourceData, isLoading } = useCoreApi(
       resourceType,
       'retrieve',
-      [
-        resourceId,
-        {
-          fields: ['metadata']
-        }
-      ]
+      isMockedId(resourceId)
+        ? null
+        : [
+            resourceId,
+            {
+              fields: ['metadata']
+            }
+          ]
     )
 
     const isUpdatable =

--- a/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
@@ -1,6 +1,7 @@
 import { getOrderTransactionName } from '#dictionaries/orders'
 import { navigateTo } from '#helpers/appsNavigation'
 import { isAttachmentValidNote, referenceOrigins } from '#helpers/attachments'
+import { isMockedId } from '#helpers/mocks'
 import { orderTransactionIsAnAsyncCapture } from '#helpers/transactions'
 import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
 import { t } from '#providers/I18NProvider'
@@ -34,7 +35,7 @@ export const ResourceOrderTimeline =
       } = useCoreApi(
         'orders',
         'retrieve',
-        orderId == null || isEmpty(orderId)
+        orderId == null || isEmpty(orderId) || isMockedId(orderId)
           ? null
           : [
               orderId,

--- a/packages/app-elements/src/ui/resources/ResourceTags.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceTags.tsx
@@ -1,3 +1,4 @@
+import { isMockedId } from '#helpers/mocks'
 import {
   type EditTagsOverlayProps,
   useEditTagsOverlay
@@ -64,7 +65,7 @@ export const ResourceTags = withSkeletonTemplate<ResourceTagsProps>(
     const { data: resourceTags } = useCoreApi(
       resourceType,
       'tags',
-      resourceId == null || isEmpty(resourceId)
+      resourceId == null || isEmpty(resourceId) || isMockedId(resourceId)
         ? null
         : [
             resourceId,


### PR DESCRIPTION
## What I did

I've added `isMockedId` and `isMock` helpers to be used to block api requests with mocked ids.


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
