### PR TITLE
Highlight errors in timeline

### DIFF
--- a/packages/app-elements/src/ui/composite/Timeline.tsx
+++ b/packages/app-elements/src/ui/composite/Timeline.tsx
@@ -7,13 +7,15 @@ import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { StatusIcon } from '#ui/atoms/StatusIcon'
 import { Text } from '#ui/atoms/Text'
 import { Input } from '#ui/forms/Input'
+import cn from 'classnames'
+import { isEmpty } from 'lodash-es'
 import { Fragment, useMemo, type JSX, type ReactNode } from 'react'
-
 export interface TimelineEvent {
   date: string
   author?: string
   message: ReactNode
   note?: string
+  variant?: 'warning'
 }
 
 type EventWithIcon = TimelineEvent & {
@@ -92,8 +94,17 @@ export const Timeline = withSkeletonTemplate<TimelineProps>(
                             {event.author}{' '}
                           </Text>
                         )}
-                        <Text variant='info'>
-                          {event.message} ·{' '}
+                        <Text>
+                          <span
+                            className={cn({
+                              'text-orange-700':
+                                event.variant === 'warning' &&
+                                isEmpty(event.note)
+                            })}
+                          >
+                            {event.message}
+                          </span>{' '}
+                          ·{' '}
                           {formatDate({
                             format: 'timeWithSeconds',
                             isoDate: event.date,
@@ -114,7 +125,14 @@ export const Timeline = withSkeletonTemplate<TimelineProps>(
                         data-testid='timeline-event-note'
                         className='w-full mt-1'
                       >
-                        {event.note}
+                        <div
+                          className={cn('text-sm', {
+                            'text-orange-700 font-semibold':
+                              event.variant === 'warning'
+                          })}
+                        >
+                          {event.note}
+                        </div>
                       </Card>
                     </div>
                   )}
@@ -129,6 +147,10 @@ export const Timeline = withSkeletonTemplate<TimelineProps>(
 )
 
 function getIcon(event: TimelineEvent): JSX.Element {
+  if (event.variant === 'warning') {
+    return <StatusIcon name='warning' background='orange' gap='small' />
+  }
+
   if (event.note != null) {
     return <StatusIcon name='chatCircle' background='black' gap='small' />
   }

--- a/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceOrderTimeline.tsx
@@ -4,7 +4,7 @@ import { isAttachmentValidNote, referenceOrigins } from '#helpers/attachments'
 import { isMockedId } from '#helpers/mocks'
 import { orderTransactionIsAnAsyncCapture } from '#helpers/transactions'
 import { useCoreApi, useCoreSdkProvider } from '#providers/CoreSdkProvider'
-import { t } from '#providers/I18NProvider'
+import { useTranslation } from '#providers/I18NProvider'
 import { useTokenProvider } from '#providers/TokenProvider'
 import { withSkeletonTemplate } from '#ui/atoms/SkeletonTemplate'
 import { Text } from '#ui/atoms/Text'
@@ -134,6 +134,7 @@ export const ResourceOrderTimeline =
 
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const useTimelineReducer = (order: Order) => {
+  const { t } = useTranslation()
   const [orderId, setOrderId] = useState<string>(order.id)
   const {
     canAccess,
@@ -362,6 +363,10 @@ const useTimelineReducer = (order: Order) => {
             type: 'add',
             payload: {
               date: transaction.created_at,
+              variant:
+                isFailedCapture || isFailedAuthorization
+                  ? 'warning'
+                  : undefined,
               message: transaction.succeeded ? (
                 <>
                   {t('common.timeline.resources.payment_of_was', {

--- a/packages/docs/src/mocks/data/orders.js
+++ b/packages/docs/src/mocks/data/orders.js
@@ -236,8 +236,10 @@ const order = {
         related: 'https://mock.localhost/api/orders/NMWYhbGorj/transactions'
       },
       data: [
-        { type: 'authorizations', id: 'nKZkPUDBVj' },
-        { type: 'captures', id: 'kyAnxUgegE' }
+        { type: 'authorizations', id: 'nKZkPUDBVj' }, // success
+        { type: 'authorizations', id: 'authFailed' }, // failed
+        { type: 'captures', id: 'kyAnxUgegE' }, // success
+        { type: 'captures', id: 'vcAnxfaiLc' } // failed
       ]
     },
     authorizations: {
@@ -1773,6 +1775,7 @@ const orderDetail = http.get(
           },
           meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
         },
+        // success authorization
         {
           id: 'nKZkPUDBVj',
           type: 'authorizations',
@@ -1857,6 +1860,93 @@ const orderDetail = http.get(
           },
           meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
         },
+        // failed authorization
+        {
+          id: 'authFailed',
+          type: 'authorizations',
+          links: {
+            self: 'https://mock.localhost/api/authorizations/authFailed'
+          },
+          attributes: {
+            number: '2485862/T/001',
+            currency_code: 'EUR',
+            amount_cents: 15400,
+            amount_float: 154.0,
+            formatted_amount: '€154,00',
+            succeeded: false,
+            message: null,
+            error_code: 'Error',
+            error_detail:
+              'Could not process the authorization due to unknown error',
+            token: 'pi_3N8LhsK5j6INEBBI0JicoLOo',
+            gateway_transaction_id: 'pi_3N8LhsK5j6INEBBI0JicoLOo',
+            created_at: '2023-05-16T11:06:20.964Z',
+            updated_at: '2023-05-16T11:06:20.964Z',
+            reference: null,
+            reference_origin: null,
+            metadata: {},
+            cvv_code: null,
+            cvv_message: null,
+            avs_code: null,
+            avs_message: null,
+            fraud_review: null,
+            capture_amount_cents: 0,
+            capture_amount_float: 0.0,
+            formatted_capture_amount: '€0,00',
+            capture_balance_cents: 0,
+            capture_balance_float: 0.0,
+            formatted_capture_balance: '€0,00',
+            void_balance_cents: 15400,
+            void_balance_float: 154.0,
+            formatted_void_balance: '€154,00'
+          },
+          relationships: {
+            order: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/order',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/order'
+              }
+            },
+            attachments: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/attachments',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/attachments'
+              }
+            },
+            versions: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/versions',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/versions'
+              }
+            },
+            captures: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/captures',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/captures'
+              }
+            },
+            voids: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/voids',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/voids'
+              }
+            },
+            events: {
+              links: {
+                self: 'https://mock.localhost/api/authorizations/authFailed/relationships/events',
+                related:
+                  'https://mock.localhost/api/authorizations/authFailed/events'
+              }
+            }
+          },
+          meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+        },
+        // success capture
         {
           id: 'kyAnxUgegE',
           type: 'captures',
@@ -1926,6 +2016,82 @@ const orderDetail = http.get(
               links: {
                 self: 'https://mock.localhost/api/captures/kyAnxUgegE/relationships/events',
                 related: 'https://mock.localhost/api/captures/kyAnxUgegE/events'
+              }
+            }
+          },
+          meta: { mode: 'test', organization_id: 'WXlEOFrjnr' }
+        },
+        // failed capture
+        {
+          id: 'vcAnxfaiLc',
+          type: 'captures',
+          links: {
+            self: 'https://mock.localhost/api/captures/vcAnxfaiLc'
+          },
+          attributes: {
+            number: '2485862/T/002',
+            currency_code: 'EUR',
+            amount_cents: 15400,
+            amount_float: 154.0,
+            formatted_amount: '€154,00',
+            succeeded: false,
+            message:
+              'This PaymentIntent could not be captured because it has a status of canceled. Only a PaymentIntent with one of the following statuses may be captured: requires_capture.',
+            error_code: null,
+            error_detail: null,
+            token: 'pi_3N8LhsK5j6INEBBsaI0JicoLOo',
+            gateway_transaction_id: 'pi_3N8LhsK5asdj6INEBBI0JicoLOo',
+            created_at: '2023-05-16T14:18:20.368Z',
+            updated_at: '2023-05-16T14:18:20.368Z',
+            reference: null,
+            reference_origin: null,
+            metadata: {},
+            refund_amount_cents: 15400,
+            refund_amount_float: 154.0,
+            formatted_refund_amount: '€154,00',
+            refund_balance_cents: 15400,
+            refund_balance_float: 154.0,
+            formatted_refund_balance: '€154,00'
+          },
+          relationships: {
+            order: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/order',
+                related: 'https://mock.localhost/api/captures/vcAnxfaiLc/order'
+              }
+            },
+            attachments: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/attachments',
+                related:
+                  'https://mock.localhost/api/captures/vcAnxfaiLc/attachments'
+              }
+            },
+            versions: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/versions',
+                related:
+                  'https://mock.localhost/api/captures/vcAnxfaiLc/versions'
+              }
+            },
+            reference_authorization: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/reference_authorization',
+                related:
+                  'https://mock.localhost/api/captures/vcAnxfaiLc/reference_authorization'
+              }
+            },
+            refunds: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/refunds',
+                related:
+                  'https://mock.localhost/api/captures/vcAnxfaiLc/refunds'
+              }
+            },
+            events: {
+              links: {
+                self: 'https://mock.localhost/api/captures/vcAnxfaiLc/relationships/events',
+                related: 'https://mock.localhost/api/captures/vcAnxfaiLc/events'
               }
             }
           },

--- a/packages/docs/src/stories/composite/Timeline.stories.tsx
+++ b/packages/docs/src/stories/composite/Timeline.stories.tsx
@@ -90,6 +90,17 @@ Default.args = {
         month: 0,
         date: 1,
         hours: 12,
+        minutes: 15,
+        seconds: 0
+      }).toJSON(),
+      message: 'Capture failed',
+      variant: 'warning'
+    },
+    {
+      date: set(new Date(), {
+        month: 0,
+        date: 1,
+        hours: 12,
         minutes: 23,
         seconds: 28
       }).toJSON(),


### PR DESCRIPTION
Closes commercelayer/issues-app#357

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've added a `warning` variant on `Timeline` events.
In this way we can highlight failed captures or authorizations in the order's timeline (`ResourceOrderTimeline`)

[Preview](https://deploy-preview-952--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceordertimeline--docs)

<img width="742" alt="image" src="https://github.com/user-attachments/assets/8ea32faf-18c7-4d99-8c9d-1023b653020e" />

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
