### PR TITLE
Enhance promotion display status with priority and exclusivity labels

### DIFF
--- a/packages/app-elements/src/dictionaries/promotions.ts
+++ b/packages/app-elements/src/dictionaries/promotions.ts
@@ -10,10 +10,22 @@ interface PromotionDisplayStatus extends DisplayStatus {
 export function getPromotionDisplayStatus(
   promotion: Omit<Promotion, 'type' | 'promotion_rules'>
 ): PromotionDisplayStatus {
+  const labelSuffix = [
+    promotion.exclusive === true
+      ? t('resources.promotions.attributes.exclusive')
+      : undefined,
+    promotion.priority != null
+      ? `${t('resources.promotions.attributes.priority')}: ${promotion.priority}`
+      : undefined
+  ].filter((v): v is string => v != null)
+
+  const labelSuffixText =
+    labelSuffix.length > 0 ? ` · ${labelSuffix.join(' · ')}` : ''
+
   if (promotion.disabled_at != null) {
     return {
       status: 'disabled',
-      label: t('resources.promotions.attributes.status.disabled'),
+      label: `${t('resources.promotions.attributes.status.disabled')}${labelSuffixText}`,
       icon: 'minus',
       color: 'lightGray'
     }
@@ -30,7 +42,7 @@ export function getPromotionDisplayStatus(
   ) {
     return {
       status: 'used',
-      label: t('resources.promotions.attributes.status.expired'),
+      label: `${t('resources.promotions.attributes.status.expired')}${labelSuffixText}`,
       icon: 'flag',
       color: 'gray'
     }
@@ -40,7 +52,7 @@ export function getPromotionDisplayStatus(
     case 'past':
       return {
         status: 'expired',
-        label: t('resources.promotions.attributes.status.expired'),
+        label: `${t('resources.promotions.attributes.status.expired')}${labelSuffixText}`,
         icon: 'flag',
         color: 'gray'
       }
@@ -48,7 +60,7 @@ export function getPromotionDisplayStatus(
     case 'upcoming':
       return {
         status: 'upcoming',
-        label: t('apps.promotions.display_status.upcoming'),
+        label: `${t('apps.promotions.display_status.upcoming')}${labelSuffixText}`,
         icon: 'calendarBlank',
         color: 'gray'
       }
@@ -56,7 +68,7 @@ export function getPromotionDisplayStatus(
     case 'active':
       return {
         status: 'active',
-        label: t('resources.promotions.attributes.status.active'),
+        label: `${t('resources.promotions.attributes.status.active')}${labelSuffixText}`,
         icon: 'pulse',
         color: 'green'
       }

--- a/packages/app-elements/src/locales/en.ts
+++ b/packages/app-elements/src/locales/en.ts
@@ -126,6 +126,8 @@ const resources = {
     name: 'Promotion',
     name_other: 'Promotions',
     attributes: {
+      priority: 'Priority',
+      exclusive: 'Exclusive',
       status: {
         active: 'Active',
         disabled: 'Disabled',

--- a/packages/app-elements/src/locales/it.ts
+++ b/packages/app-elements/src/locales/it.ts
@@ -324,6 +324,8 @@ const it: typeof en = {
       name: 'Promozione',
       name_other: 'Promozioni',
       attributes: {
+        priority: 'Priorità',
+        exclusive: 'Esclusiva',
         status: {
           active: 'Attiva',
           disabled: 'Disabilitata',

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.mocks.ts
@@ -598,5 +598,39 @@ export const presetResourceListItem = {
       created_at: '',
       updated_at: '2023-06-10T06:38:44.964Z'
     }
+  },
+  promotionWithPriority: {
+    type: 'percentage_discount_promotions',
+    id: '',
+    created_at: '2024-10-21T17:22:42.054Z',
+    updated_at: '2024-10-22T09:06:14.517Z',
+    name: '12% on the second item',
+    starts_at: '2024-09-28T22:00:00.000Z',
+    expires_at: '2024-11-01T23:00:00.000Z',
+    percentage: 12,
+    priority: 1
+  },
+  promotionWithExclusive: {
+    type: 'percentage_discount_promotions',
+    id: '',
+    created_at: '2024-10-21T17:22:42.054Z',
+    updated_at: '2024-10-22T09:06:14.517Z',
+    name: '12% on the second item',
+    starts_at: '2024-09-28T22:00:00.000Z',
+    expires_at: '2024-11-01T23:00:00.000Z',
+    percentage: 12,
+    exclusive: true
+  },
+  promotionWithPriorityAndExclusive: {
+    type: 'percentage_discount_promotions',
+    id: '',
+    created_at: '2024-10-21T17:22:42.054Z',
+    updated_at: '2024-10-22T09:06:14.517Z',
+    name: '12% on the second item',
+    starts_at: '2024-09-28T22:00:00.000Z',
+    expires_at: '2024-11-01T23:00:00.000Z',
+    percentage: 12,
+    exclusive: true,
+    priority: 3
   }
 } satisfies Record<string, ResourceListItemProps['resource']>


### PR DESCRIPTION
## What I did

I enhanced promotion display status with priority and exclusivity labels

https://deploy-preview-959--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcelistitem--docs#promotions

<img width="662" src="https://github.com/user-attachments/assets/37a8cb9e-6e90-4983-8fc6-7f06e33e6784" />
