### PR TITLE
Add `star` icon with `fill` weight

### DIFF
--- a/packages/app-elements/src/ui/atoms/Icon/Icon.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/Icon.tsx
@@ -1,7 +1,7 @@
 import { useMemo, type ComponentPropsWithRef } from 'react'
 import { iconMapping } from './icons'
 
-type IconWeight = 'regular' | 'bold' | 'light'
+type IconWeight = 'regular' | 'bold' | 'light' | 'fill'
 
 export interface IconProps extends ComponentPropsWithRef<'svg'> {
   /**

--- a/packages/app-elements/src/ui/atoms/Icon/icons.tsx
+++ b/packages/app-elements/src/ui/atoms/Icon/icons.tsx
@@ -106,6 +106,7 @@ export const iconMapping = {
   sliders: phosphor.Sliders,
   squaresFour: phosphor.SquaresFour,
   stack: phosphor.Stack,
+  star: phosphor.Star,
   storefront: phosphor.Storefront,
   suitcaseSimple: phosphor.SuitcaseSimple,
   tag: phosphor.Tag,


### PR DESCRIPTION
## What I did

I added the `star` icon and the `fill` weight.

https://deploy-preview-962--commercelayer-app-elements.netlify.app/?path=/docs/atoms-icon--docs

<img width="66" alt="Screenshot 2025-07-01 alle 19 04 24" src="https://github.com/user-attachments/assets/5e53204f-c4d6-4395-8d6d-ee41228510b1" />
