### PR TITLE
Add border to gift cards Avatar

### DIFF
--- a/packages/app-elements/src/ui/atoms/Avatar.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.tsx
@@ -78,7 +78,8 @@ export function Avatar({
           'rounded-full': shape === 'circle',
           // border
           'border-gray-100': border == null,
-          'border-transparent': border === 'none' || srcIsValidPreset(src),
+          'border-transparent':
+            border === 'none' || (srcIsValidPreset(src) && src !== 'gift_card'),
           // placeholder
           'p-1': hasError && (size === 'normal' || size === 'large'),
           'p-0.5': hasError && size !== 'normal'


### PR DESCRIPTION
Related to commercelayer/issues-app#415
## What I did

Always show Avatar border for gift card preset

<img width="97" height="87" alt="image" src="https://github.com/user-attachments/assets/7a81e8c3-7453-42aa-8625-30147a6bf4c6" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
