### PR TITLE
Set `timezone` in `InputDate` components

### DIFF
--- a/packages/app-elements/src/ui/forms/RuleEngine/Condition/ConditionValue.tsx
+++ b/packages/app-elements/src/ui/forms/RuleEngine/Condition/ConditionValue.tsx
@@ -1,3 +1,4 @@
+import { useTokenProvider } from '#providers/TokenProvider'
 import { Input } from '#ui/forms/Input'
 import { InputDate } from '#ui/forms/InputDate'
 import { InputDateRange } from '#ui/forms/InputDateRange'
@@ -37,6 +38,7 @@ export function ConditionValue({
 }): React.ReactNode {
   const { setPath } = useRuleEngine()
   const { infos } = useResourcePathInfos(item)
+  const { user } = useTokenProvider()
   const pathKey = `${pathPrefix}.value`
 
   if (item == null) {
@@ -191,6 +193,7 @@ export function ConditionValue({
           onChange={(date) => {
             setPath(pathKey, date?.toJSON())
           }}
+          timezone={user?.timezone}
         />
       )
     }

--- a/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/FieldTimeRange.tsx
@@ -121,6 +121,7 @@ export function FieldTimeRange({ item }: FieldTimeRangeProps): JSX.Element {
               label={t('common.from')}
               isClearable
               preventOpenOnFocus
+              timezone={user?.timezone}
             />
           </Spacer>
           <Spacer bottom='14'>
@@ -130,6 +131,7 @@ export function FieldTimeRange({ item }: FieldTimeRangeProps): JSX.Element {
               minDate={timeFrom ?? undefined}
               isClearable
               preventOpenOnFocus
+              timezone={user?.timezone}
             />
           </Spacer>
         </PageLayout>


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Set `timezone` prop with user timezone in `InputDate` components used in elements components.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
