### PR TITLE
Show full metadata JSON

### DIFF
--- a/packages/app-elements/src/hooks/useViewJsonOverlay.tsx
+++ b/packages/app-elements/src/hooks/useViewJsonOverlay.tsx
@@ -1,0 +1,49 @@
+import { type FC, useCallback } from "react"
+import { useOverlay } from "#hooks/useOverlay"
+import { Icon } from "#ui/atoms/Icon"
+import { Text } from "#ui/atoms/Text"
+import { CodeEditor } from "#ui/forms/CodeEditor/CodeEditorComponent"
+
+interface OverlayProps {
+  title: string
+  json: JSON
+}
+
+interface ViewJsonOverlayHook {
+  showJsonOverlay: () => void
+  JsonOverlay: FC<OverlayProps>
+}
+
+export function useViewJsonOverlay(): ViewJsonOverlayHook {
+  const { Overlay, open, close } = useOverlay()
+
+  const OverlayComponent: ViewJsonOverlayHook["JsonOverlay"] = useCallback(
+    ({ title, json }) => {
+      return (
+        <Overlay drawer onBackdropClick={close}>
+          <div className="flex flex-col h-full">
+            <div className="bg-white p-6 flex justify-between">
+              <Text weight="semibold">{title}</Text>
+              <button type="button" onClick={close}>
+                <Icon name="x" weight="bold" />
+              </button>
+            </div>
+            <CodeEditor
+              language="json"
+              defaultValue={JSON.stringify(json, null, 2)}
+              readOnly
+              height={"100%"}
+              noRounding
+            />
+          </div>
+        </Overlay>
+      )
+    },
+    [Overlay],
+  )
+
+  return {
+    showJsonOverlay: open,
+    JsonOverlay: OverlayComponent,
+  }
+}

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -81,6 +81,7 @@ export { useEditTagsOverlay } from "#hooks/useEditTagsOverlay"
 export { useIsChanged } from "#hooks/useIsChanged"
 export { useOnBlurFromContainer } from "#hooks/useOnBlurFromContainer"
 export { useOverlay } from "#hooks/useOverlay"
+export { useViewJsonOverlay } from "#hooks/useViewJsonOverlay"
 // Providers
 export {
   CoreSdkProvider,

--- a/packages/app-elements/src/ui/internals/Overlay.tsx
+++ b/packages/app-elements/src/ui/internals/Overlay.tsx
@@ -131,7 +131,8 @@ export const Overlay: React.FC<OverlayProps> = ({
             "bg-gray-50": backgroundColor === "light",
             "bg-white": backgroundColor == null,
             "inset-0 w-full": !drawer,
-            "top-0 right-0 bottom-0 w-1/2 animate-slide-in-right": drawer,
+            "top-0 right-0 bottom-0 w-full md:w-1/2 animate-slide-in-right":
+              drawer,
           },
         )}
         data-testid="overlay"

--- a/packages/app-elements/src/ui/internals/Overlay.tsx
+++ b/packages/app-elements/src/ui/internals/Overlay.tsx
@@ -4,7 +4,7 @@ import { createPortal } from "react-dom"
 import { Container } from "#ui/atoms/Container"
 import { Spacer } from "#ui/atoms/Spacer"
 
-export interface OverlayProps {
+export type OverlayProps = {
   /**
    * The content of the overlay.
    **/
@@ -19,12 +19,6 @@ export interface OverlayProps {
   backgroundColor?: "light"
 
   /**
-   * Set the overlay to full width
-   * @default false
-   */
-  fullWidth?: boolean
-
-  /**
    * Class name for the overlay container
    */
   contentClassName?: string
@@ -33,7 +27,30 @@ export interface OverlayProps {
    * Style object for the overlay container
    */
   contentStyle?: React.CSSProperties
-}
+} & (
+  | {
+      /**
+       * Set the overlay to full width
+       * @default false
+       */
+      fullWidth?: boolean
+      drawer?: never
+      onBackdropClick?: never
+    }
+  | {
+      /**
+       * Set the overlay to be displayed as a drawer on the right side of the screen.
+       * @default false
+       */
+      drawer: true
+      /**
+       * Callback function to be called when the backdrop is clicked.
+       * This is useful for closing the overlay when clicking outside of it.
+       */
+      onBackdropClick: () => void
+      fullWidth?: never
+    }
+)
 
 export const Overlay: React.FC<OverlayProps> = ({
   footer,
@@ -42,6 +59,8 @@ export const Overlay: React.FC<OverlayProps> = ({
   contentClassName,
   contentStyle,
   fullWidth = false,
+  drawer = false,
+  onBackdropClick,
   ...rest
 }) => {
   const element = useRef<HTMLDivElement | null>(null)
@@ -65,8 +84,20 @@ export const Overlay: React.FC<OverlayProps> = ({
   )
 
   const content = (
-    <div className={contentClassName} style={contentStyle}>
-      <Spacer bottom={fullWidth ? undefined : "14"}>{children}</Spacer>
+    <div
+      className={cn(contentClassName, {
+        "h-full": drawer,
+      })}
+      style={contentStyle}
+    >
+      <Spacer
+        bottom={fullWidth || drawer ? undefined : "14"}
+        className={cn({
+          "h-full": drawer,
+        })}
+      >
+        {children}
+      </Spacer>
       {footer != null && (
         <div
           className={cn("w-full sticky bottom-0 pb-8", {
@@ -82,22 +113,37 @@ export const Overlay: React.FC<OverlayProps> = ({
   )
 
   return createPortal(
-    <div
-      ref={element}
-      role="dialog"
-      className={cn(
-        "overlay-container",
-        "fixed inset-0 z-50 w-full h-full  overflow-y-auto outline-none",
-        {
-          "bg-gray-50": backgroundColor === "light",
-          "bg-white": backgroundColor == null,
-        },
+    <>
+      {drawer && (
+        <div
+          aria-hidden
+          className="fixed inset-0 bg-gray-900 animate-backdrop-fade-in"
+          onClick={onBackdropClick}
+        />
       )}
-      data-testid="overlay"
-      {...rest}
-    >
-      {fullWidth ? content : <Container minHeight={false}>{content}</Container>}
-    </div>,
+      <div
+        ref={element}
+        role="dialog"
+        className={cn(
+          "overlay-container",
+          "fixed z-50 h-full overflow-y-auto outline-none",
+          {
+            "bg-gray-50": backgroundColor === "light",
+            "bg-white": backgroundColor == null,
+            "inset-0 w-full": !drawer,
+            "top-0 right-0 bottom-0 w-1/2 animate-slide-in-right": drawer,
+          },
+        )}
+        data-testid="overlay"
+        {...rest}
+      >
+        {fullWidth || drawer ? (
+          content
+        ) : (
+          <Container minHeight={false}>{content}</Container>
+        )}
+      </div>
+    </>,
     document.body,
   )
 }

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -4,6 +4,7 @@ import {
   type EditMetadataOverlayProps,
   useEditMetadataOverlay,
 } from "#hooks/useEditMetadataOverlay"
+import { useViewJsonOverlay } from "#hooks/useViewJsonOverlay"
 import { useCoreApi } from "#providers/CoreSdkProvider"
 import { t } from "#providers/I18NProvider"
 import { useTokenProvider } from "#providers/TokenProvider"
@@ -40,6 +41,7 @@ export const isUpdatableType = (value: any): value is UpdatableType => {
 export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
   ({ resourceType, resourceId, overlay }) => {
     const { Overlay: EditMetadataOverlay, show } = useEditMetadataOverlay()
+    const { JsonOverlay, showJsonOverlay } = useViewJsonOverlay()
 
     const { canUser } = useTokenProvider()
 
@@ -70,22 +72,33 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
         <Section
           title="Metadata"
           actionButton={
-            canUser("update", resourceType) && (
+            <div className="flex items-center gap-2">
               <Button
                 variant="secondary"
                 size="mini"
-                alignItems="center"
-                aria-label={t("common.edit_resource", {
-                  resource: t("common.metadata").toLowerCase(),
-                })}
                 onClick={() => {
-                  show()
+                  showJsonOverlay()
                 }}
               >
-                <Icon name="pencilSimple" size="16" />
-                {t("common.edit")}
+                View JSON
               </Button>
-            )
+              {canUser("update", resourceType) && (
+                <Button
+                  variant="secondary"
+                  size="mini"
+                  alignItems="center"
+                  aria-label={t("common.edit_resource", {
+                    resource: t("common.metadata").toLowerCase(),
+                  })}
+                  onClick={() => {
+                    show()
+                  }}
+                >
+                  <Icon name="pencilSimple" size="16" />
+                  {t("common.edit")}
+                </Button>
+              )}
+            </div>
           }
         >
           {isUpdatable ? (
@@ -117,6 +130,10 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
             </Spacer>
           )}
         </Section>
+        <JsonOverlay
+          title="Metadata"
+          json={JSON.parse(JSON.stringify(resourceData?.metadata ?? {}))}
+        />
         <EditMetadataOverlay
           title={overlay?.title}
           resourceId={resourceId}

--- a/packages/app-elements/tailwind.config.cjs
+++ b/packages/app-elements/tailwind.config.cjs
@@ -190,6 +190,22 @@ module.exports = {
       fontWeight: {
         inherit: "inherit",
       },
+      keyframes: {
+        "slide-in-right": {
+          "0%": { transform: "translateX(100%)", opacity: "0" },
+          "100%": { transform: "translateX(0)", opacity: "1" },
+        },
+        "backdrop-fade-in": {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "0.3" },
+        },
+      },
+      animation: {
+        "slide-in-right":
+          "slide-in-right 0.2s cubic-bezier(0.4, 0, 0.2, 1) both",
+        "backdrop-fade-in":
+          "backdrop-fade-in 0.2s cubic-bezier(0.4, 0, 0.2, 1) both",
+      },
     },
   },
   plugins: [require("@tailwindcss/forms")],

--- a/packages/docs/src/stories/hooks/useOverlay.stories.tsx
+++ b/packages/docs/src/stories/hooks/useOverlay.stories.tsx
@@ -204,6 +204,44 @@ export const OverlayWithBackgroundVariant: StoryFn = () => {
 }
 
 /**
+ * Overlay can be used as a drawer opening from the right side of the screen.
+ * It can be closed by clicking on the backdrop.
+ **/
+export const OverlayAsDrawer: StoryFn = () => {
+  const { Overlay, open, close } = useOverlay()
+
+  return (
+    <div>
+      <Button onClick={open}>Open overlay</Button>
+      <Overlay
+        drawer
+        onBackdropClick={close}
+        footer={
+          <Button onClick={close} fullWidth>
+            close
+          </Button>
+        }
+      >
+        <div style={{ padding: "16px" }}>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            fringilla, leo vel blandit consequat, arcu tellus tristique ipsum,
+            vel accumsan risus urna in ante. Morbi iaculis elit mattis dolor
+            laoreet rhoncus. Aliquam interdum vel dui nec dapibus.
+          </p>
+          <p>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse
+            fringilla, leo vel blandit consequat, arcu tellus tristique ipsum,
+            vel accumsan risus urna in ante. Morbi iaculis elit mattis dolor
+            laoreet rhoncus. Aliquam interdum vel dui nec dapibus.
+          </p>
+        </div>
+      </Overlay>
+    </div>
+  )
+}
+
+/**
  * Sometimes you may want to use the Overlay in full width mode.
  * In this case, you'll need to manage internal padding and margins
  * to ensure the content is displayed correctly.


### PR DESCRIPTION
Related to commercelayer/issues-app#273

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

- [x] Overlay now can be opened as `drawer` (sliding-in from the right of the screen) [PREVIEW](https://deploy-preview-971--commercelayer-app-elements.netlify.app/?path=/docs/hooks-useoverlay--docs#overlay-as-drawer)
- [x] The new overlay as drawer is used  to show full metadata object in a read-only code editor [PREVIEW](https://deploy-preview-971--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourcemetadata--docs)
- [ ] Adjust mobile view

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
