### PR TITLE
Fix buttons alignment in `ResouceLineItems`

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tooltip.tsx
+++ b/packages/app-elements/src/ui/atoms/Tooltip.tsx
@@ -30,6 +30,11 @@ export interface TooltipProps {
    * If false or undefined, the tooltip will have a max-width of 280px and no minimum width.
    */
   minWidth?: boolean
+  /**
+   * Class name to be applied to the tooltip wrapper.
+   * Useful for custom styling.
+   */
+  className?: string
 }
 
 /**
@@ -46,6 +51,7 @@ export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
       direction = "top",
       minWidth = false,
       id = `${getSanitizedInnerText(label)}-${getSanitizedInnerText(content)}-${direction}`,
+      className,
     },
     ref,
   ): JSX.Element => {
@@ -54,7 +60,7 @@ export const Tooltip = forwardRef<TooltipRefProps, TooltipProps>(
         <span
           aria-description={getInnerText(content)}
           data-tooltip-id={id}
-          className="cursor-pointer"
+          className={cn("cursor-pointer", className)}
         >
           {label}
         </span>

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -133,6 +133,7 @@ const Edit = withSkeletonTemplate<{
               label={removeButton}
               content="Can't remove the last item"
               direction="top-end"
+              className="flex items-center"
             />
           ) : (
             removeButton

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/__snapshots__/ResourceLineItems.test.tsx.snap
@@ -177,7 +177,7 @@ exports[`ResourceLineItems > should disable the remove action when \`onSwap\` is
                 </button>
                 <span
                   aria-description="Can't remove the last item"
-                  class="cursor-pointer"
+                  class="cursor-pointer flex items-center"
                   data-tooltip-id="commonremove-cantremovethelastitem-top-end"
                 >
                   <button


### PR DESCRIPTION

## What I did

When "Remove" button is disabled it was not aligned with the "Swap" button.
This PR fixes this.

Was:
<img width="238" height="74" alt="image" src="https://github.com/user-attachments/assets/74d67fb6-13a1-4d7b-be0b-0a82c08cfa4e" />

Now:
<img width="253" height="62" alt="image" src="https://github.com/user-attachments/assets/e724e845-4844-4cac-8772-c953c75d09c9" />




## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
