### PR TITLE
Remove double outline in InputSelect component on focus-visible

### DIFF
--- a/packages/app-elements/src/styles/global.css
+++ b/packages/app-elements/src/styles/global.css
@@ -233,7 +233,7 @@
     -moz-box-shadow: inset 0 0 0 1px var(--color-gray-200);
   }
   
-  input:focus-visible,
+  input:focus-visible:not([id^="react-select"]),
   textarea:focus-visible,
   div[role="textbox"]:focus,
   .form-input:focus,


### PR DESCRIPTION
Closes commercelayer/issues-app#433

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've fixed a wrong style being applied to input inside the react-select component (on focus-visibile)

[Preview](https://deploy-preview-979--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputselect--docs)


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
