### PR TITLE
Apply correct focus style on InputSelect component

### DIFF
--- a/packages/app-elements/src/styles/global.css
+++ b/packages/app-elements/src/styles/global.css
@@ -233,7 +233,7 @@
     -moz-box-shadow: inset 0 0 0 1px var(--color-gray-200);
   }
   
-  input:focus-visible:not([id^="react-select"]),
+  input:focus-visible:not(.no-focus),
   textarea:focus-visible,
   div[role="textbox"]:focus,
   .form-input:focus,

--- a/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/overrides.tsx
@@ -1,4 +1,5 @@
 import { XIcon } from "@phosphor-icons/react"
+import cn from "classnames"
 import { castArray } from "lodash-es"
 import type { JSX } from "react"
 import {
@@ -7,6 +8,7 @@ import {
   type DropdownIndicatorProps,
   type GroupBase,
   type GroupHeadingProps,
+  type InputProps,
   type MenuListProps,
   type MultiValueGenericProps,
 } from "react-select"
@@ -146,6 +148,15 @@ function MenuList(props: MenuListProps<InputSelectValue>): JSX.Element {
   )
 }
 
+function Input(props: InputProps<InputSelectValue>): JSX.Element {
+  const newProps = {
+    ...props,
+    // `.no-focus` prevent applying default styles from global.css
+    inputClassName: cn(props.inputClassName, "no-focus"),
+  }
+  return <components.Input {...newProps} />
+}
+
 const selectComponentOverrides = {
   DropdownIndicator,
   IndicatorSeparator: () => null,
@@ -155,6 +166,7 @@ const selectComponentOverrides = {
   MultiValueRemove,
   GroupHeading,
   MenuList,
+  Input,
 }
 
 export default selectComponentOverrides

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -54,6 +54,7 @@ Default.args = {
   isSearchable: true,
   isClearable: false,
   onBlur: () => {},
+  name: "resource",
 }
 
 /**


### PR DESCRIPTION
## What I did

I’ve applied a more precise rule to remove the double outline on the `InputSelect` component when using focus-visible.

The fix from #979 was not working correctly because it assumed all input selects had an `id` starting with `react-select`,
This assumption fails when an input has a name, as it overrides the default React Select id.

The new solution adds a `.no-focus` class to the input element, allowing it to bypass the globally defined focus-visible style.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
