### PR TITLE
Update `Tag` style to prevent text from overflowing its line box

### DIFF
--- a/packages/app-elements/src/ui/atoms/Tag.tsx
+++ b/packages/app-elements/src/ui/atoms/Tag.tsx
@@ -27,6 +27,7 @@ export const Tag: FC<TagProps> = ({ icon, children, className, ...rest }) => {
       className={cn([
         className,
         "flex gap-2 items-center select-none",
+        "wrap-anywhere",
         "text-black text-sm",
         "px-4 py-1",
         "rounded border border-solid border-gray-200",

--- a/packages/docs/src/stories/atoms/Tag.stories.tsx
+++ b/packages/docs/src/stories/atoms/Tag.stories.tsx
@@ -10,3 +10,27 @@ export default setup
 const Template: StoryFn<typeof Tag> = (args) => <Tag {...args}>logo-pink</Tag>
 
 export const Default = Template.bind({})
+
+/**
+ * This component uses the CSS `overflow-wrap: anywhere` property to prevent text from overflowing its line box.
+ */
+export const WrapAnywhere = () => (
+  <>
+    <Tag>
+      this:is:a:long:text:that:should:break:because:we:are:using:the:break:all:css:property:is:it:breaking?:can:you:read:this:text?
+    </Tag>
+    <br />
+    <Tag>
+      this-is-a-long-text-that-should-break-because-we-are-using-the-break-all-css-property-is-it-breaking?-can-you-read-this-text?
+    </Tag>
+    <br />
+    <Tag>
+      this_is_a_long_text_that_should_break_because_we_are_using_the_break_all_css_property_is_it_breaking?_can_you_read_this_text?
+    </Tag>
+    <br />
+    <Tag>
+      this is a long text that should break because we are using the break all
+      css property is it breaking? can you read this text?
+    </Tag>
+  </>
+)

--- a/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputSelect.stories.tsx
@@ -231,6 +231,42 @@ WithSeparator.args = {
   isClearable: true,
 }
 
+/**
+ * This component uses the CSS `overflow-wrap: anywhere` property to prevent text from overflowing its line box.
+ */
+export const WrapAnywhere = Template.bind({})
+WrapAnywhere.args = {
+  label: "Search resource or type for new value",
+  initialValues: fullList,
+  placeholder: "Type something...",
+  defaultValue: [
+    {
+      label:
+        "this:is:a:long:text:that:should:break:because:we:are:using:the:break:all:css:property:is:it:breaking?:can:you:read:this:text?",
+      value: "custom-value",
+    },
+    {
+      label:
+        "this-is-a-long-text-that-should-break-because-we-are-using-the-break-all-css-property-is-it-breaking?-can-you-read-this-text?",
+      value: "custom-value",
+    },
+    {
+      label:
+        "this_is_a_long_text_that_should_break_because_we_are_using_the_break_all_css_property_is_it_breaking?_can_you_read_this_text?",
+      value: "custom-value",
+    },
+    {
+      label:
+        "this is a long text that should break because we are using the break all css property is it breaking? can you read this text?",
+      value: "custom-value",
+    },
+  ],
+  isMulti: true,
+  isSearchable: true,
+  isClearable: false,
+  isCreatable: true,
+}
+
 export const WithError = Template.bind({})
 WithError.args = {
   label: "Search resource",


### PR DESCRIPTION
Closes commercelayer/issues-app#440

## What I did

I added the `overflow-wrap: anywhere` property to prevent text from overflowing its line box to the `Tag` component.

## How to test

https://deploy-preview-985--commercelayer-app-elements.netlify.app/?path=/docs/atoms-tag--docs#wrap-anywhere

