### PR TITLE
Remove the `id` when duplicating a rule

### DIFF
--- a/packages/app-elements/src/ui/forms/RuleEngine/RuleEngineComponent.tsx
+++ b/packages/app-elements/src/ui/forms/RuleEngine/RuleEngineComponent.tsx
@@ -232,6 +232,7 @@ function RuleEditorComponent(props: RuleEngineProps): React.JSX.Element {
                               const ruleIndex = value.rules?.length ?? 0
                               setPath(`rules.${ruleIndex}`, {
                                 ...rule,
+                                id: undefined,
                                 name: `${rule.name} (copy)`,
                               })
                               setSelectedRuleIndex(ruleIndex)


### PR DESCRIPTION
## What I did

I did the fix: remove the `id` when duplicating a rule. This is to avoid having duplica IDs.
