### PR TITLE
Add missing type to export list

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -96,12 +96,14 @@ export {
   I18NProvider,
   i18nLocales,
   Trans,
+  type Translation,
   t,
   useTranslation,
 } from "#providers/I18NProvider"
 export {
   encodeExtras,
   MetaTags,
+  type ParsedScopes,
   TokenProvider,
   type TokenProviderAllowedApp,
   type TokenProviderAllowedAppKind,
@@ -138,7 +140,11 @@ export { Grid, type GridProps } from "#ui/atoms/Grid"
 export { Hint, type HintProps } from "#ui/atoms/Hint"
 export { Hr, type HrProps } from "#ui/atoms/Hr"
 export { Icon, type IconProps } from "#ui/atoms/Icon"
-export { PageHeading, type PageHeadingProps } from "#ui/atoms/PageHeading"
+export {
+  PageHeading,
+  type PageHeadingProps,
+  type PageHeadingToolbarProps,
+} from "#ui/atoms/PageHeading"
 export { Pagination, type PaginationProps } from "#ui/atoms/Pagination"
 export { Progress, type ProgressProps } from "#ui/atoms/Progress"
 export {
@@ -232,7 +238,11 @@ export {
   type TimelineProps,
 } from "#ui/composite/Timeline"
 export { ToastContainer, toast } from "#ui/composite/Toast"
-export { Toolbar, type ToolbarProps } from "#ui/composite/Toolbar"
+export {
+  Toolbar,
+  type ToolbarItem,
+  type ToolbarProps,
+} from "#ui/composite/Toolbar"
 // Forms
 export {
   CodeEditor,
@@ -300,6 +310,7 @@ export {
 } from "#ui/forms/InputResourceGroup"
 export {
   flatSelectValues,
+  type GroupedSelectValues,
   getDefaultValueFromFlatten,
   HookedInputSelect,
   type HookedInputSelectProps,
@@ -309,6 +320,7 @@ export {
   isGroupedSelectValues,
   isMultiValueSelected,
   isSingleValueSelected,
+  type PossibleSelectValue,
 } from "#ui/forms/InputSelect"
 export {
   HookedInputSimpleSelect,
@@ -401,6 +413,10 @@ export {
 } from "#ui/resources/ResourceTags"
 export {
   type FiltersInstructions,
+  type FormFullValues,
+  type MetricsFilters,
+  type UiFilterName,
+  type UiFilterValue,
   useResourceFilters,
 } from "#ui/resources/useResourceFilters"
 export {

--- a/packages/app-elements/src/providers/I18NProvider.tsx
+++ b/packages/app-elements/src/providers/I18NProvider.tsx
@@ -3,6 +3,7 @@ import resourcesToBackend from "i18next-resources-to-backend"
 import React, { type ReactNode, useEffect, useState } from "react"
 import { I18nextProvider, initReactI18next } from "react-i18next"
 import { LoadingPage } from "#ui/composite/Routes/Routes"
+import type en from "../locales/en"
 import { useTokenProvider } from "./TokenProvider"
 
 export { t } from "i18next"
@@ -10,6 +11,7 @@ export { Trans, useTranslation } from "react-i18next"
 
 export const i18nLocales = ["en-US", "it-IT"] as const
 export type I18NLocale = (typeof i18nLocales)[number]
+export type Translation = typeof en
 
 interface I18NProviderProps {
   /** Optional locale to use for i18n translations that will override the locale set in the user's token. */

--- a/packages/app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/index.tsx
@@ -1,4 +1,5 @@
 export { encodeExtras } from "./extras"
+export type { ParsedScopes } from "./getInfoFromJwt"
 export { MetaTags } from "./MetaTags"
 export { TokenProvider, useTokenProvider } from "./TokenProvider"
 export type {

--- a/packages/app-elements/src/ui/atoms/PageHeading/index.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/index.tsx
@@ -1,1 +1,2 @@
 export { PageHeading, type PageHeadingProps } from "./PageHeading"
+export type { PageHeadingToolbarProps } from "./PageHeadingToolbar"

--- a/packages/app-elements/src/ui/forms/InputSelect/index.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/index.tsx
@@ -3,9 +3,11 @@ export {
   type HookedInputSelectProps,
 } from "./HookedInputSelect"
 export {
+  type GroupedSelectValues,
   InputSelect,
   type InputSelectProps,
   type InputSelectValue,
+  type PossibleSelectValue,
 } from "./InputSelect"
 export {
   flatSelectValues,

--- a/packages/app-elements/src/ui/resources/useResourceFilters/index.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/index.tsx
@@ -1,2 +1,8 @@
-export type { FiltersInstructions } from "./types"
+export type { MetricsFilters } from "./adaptSdkToMetrics"
+export type {
+  FiltersInstructions,
+  FormFullValues,
+  UiFilterName,
+  UiFilterValue,
+} from "./types"
 export { useResourceFilters } from "./useResourceFilters"


### PR DESCRIPTION
## What I did

I've added some missing types to the list of exported definitions.
In this way there will be no reason of importing them for unsupported paths.


Example:
```diff
- import type { PageHeadingToolbarProps } from '@commercelayer/app-elements/dist/ui/atoms/PageHeading/PageHeadingToolbar'
+ import type { PageHeadingToolbarProps } from '@commercelayer/app-elements'
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
