### PR TITLE
Improve the types for the `<Avatar>` src prop

### DIFF
--- a/packages/app-elements/src/ui/atoms/Avatar.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.test.tsx
@@ -49,7 +49,6 @@ describe("Avatar", () => {
   test("Should be rendered with a placeholder image when src is not defined", () => {
     const { element } = setup({
       id: "avatar",
-      // @ts-expect-error I want to test this scenario.
       src: undefined,
       alt: "Undefined source",
     })

--- a/packages/app-elements/src/ui/atoms/Avatar.tsx
+++ b/packages/app-elements/src/ui/atoms/Avatar.tsx
@@ -3,13 +3,13 @@ import { type JSX, useState } from "react"
 import { presets } from "./Avatar.utils"
 
 type SrcPreset = keyof typeof presets
-type SrcUrl = `https://${string}` | `data:image/${string}`
+type SrcUrl = string & {}
 
 export interface AvatarProps {
   /**
    * Image URL
    */
-  src: SrcPreset | SrcUrl
+  src: SrcPreset | SrcUrl | null | undefined
   /**
    * Alt text
    */
@@ -91,7 +91,7 @@ export function Avatar({
 }
 
 function srcIsValidPreset(src: AvatarProps["src"]): src is SrcPreset {
-  return Object.keys(presets).includes(src)
+  return src != null && Object.keys(presets).includes(src)
 }
 
 function srcIsValidUrl(

--- a/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceLineItems/ResourceLineItems.tsx
@@ -294,11 +294,7 @@ export const ResourceLineItems = withSkeletonTemplate<Props>(
                     align="center"
                     rowSpan={3}
                   >
-                    <Avatar
-                      size={size}
-                      src={imageUrl as `https://${string}`}
-                      alt={name ?? ""}
-                    />
+                    <Avatar size={size} src={imageUrl} alt={name ?? ""} />
                   </td>
                   <td
                     className={cn("pl-4", {
@@ -650,7 +646,7 @@ const Bundle = withSkeletonTemplate<{ code: LineItem["bundle_code"] }>(
             className="flex relative py-2 pl-4 before:absolute before:border-gray-100 before:left-0 before:h-4 before:w-4 before:top-[calc(50%-1rem)] before:border-b before:border-l before:rounded-bl-md after:absolute after:bg-gray-100 after:left-0 after:top-0 after:w-px after:h-full last:after:h-[calc(50%-1rem)]"
           >
             <Avatar
-              src={item.sku?.image_url as `https://${string}`}
+              src={item.sku?.image_url}
               size="x-small"
               alt={item.sku?.name ?? ""}
               className="ml-2"

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/skuListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/skuListItem.tsx
@@ -10,10 +10,7 @@ export const skuListItemToProps: ResourceToProps<SkuListItem> = ({
     name: resource.sku?.name ?? "",
     description: resource.sku?.code ?? "",
     icon: (
-      <Avatar
-        alt={resource.sku?.name ?? ""}
-        src={resource.sku?.image_url as `https://${string}`}
-      />
+      <Avatar alt={resource.sku?.name ?? ""} src={resource.sku?.image_url} />
     ),
     invertNameDescription: true,
     rightContent: (


### PR DESCRIPTION
closes commercelayer/issues-app#16

## What I did

I improved the types for the `<Avatar>` src prop. Now you're no longer forced to use **as &#96;https://${string}&#96;** when the incoming url is defined as `string | null | undefined`.