### PR TITLE
Add link to the custom-app blog post

### DIFF
--- a/packages/docs/src/stories/getting-started/002.custom-apps.mdx
+++ b/packages/docs/src/stories/getting-started/002.custom-apps.mdx
@@ -15,6 +15,10 @@ After you made your changes and thoroughly tested your custom app, you can seaml
   style={{ marginBottom: '24px' }}
   />
 
+For a comprehensive walkthrough of the entire process, check out our detailed blog post [Adding a Custom App to Your Commerce Layer Dashboard](https://commercelayer.io/blog/adding-a-custom-app-to-your-commerce-layer-dashboard). This guide provides step-by-step instructions and practical examples to help you successfully integrate your custom applications into the Dashboard, ensuring they're accessible and functional for your entire team.
+
+Continue reading below for a quick overview of the key steps and important considerations when customizing and deploying your applications.
+
 ## How to customize an application
 
 We manage all the applications in the [dashboard-apps](https://github.com/commercelayer/dashboard-apps) monorepo. This allows you to run them all locally effortlessly. You can choose to customize and release a single application or all of them. It's up to you.


### PR DESCRIPTION
Closes #1004

## What I did

I added the link to our "Adding a custom app to your Commerce Layer dashboard" blog post.

https://deploy-preview-1005--commercelayer-app-elements.netlify.app/?path=/docs/getting-started-custom-apps--docs