### PR TITLE
Enhance `ResourceMetadata` component

### DIFF
--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.test.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.test.tsx
@@ -33,11 +33,13 @@ describe("ResourceMetadata", () => {
     ).toContain("Doe")
   })
 
-  it("should not render  of object entries with non string values", async () => {
+  it("should render in a different way object entries with non string values", async () => {
     const { queryByTestId } = await setup()
-
     expect(
       queryByTestId("ResourceMetadata-item-gdpr_preferences"),
-    ).not.toBeInTheDocument()
+    ).toBeVisible()
+    expect(
+      queryByTestId("ResourceMetadata-value-gdpr_preferences")?.innerHTML,
+    ).toContain("[...]")
   })
 })

--- a/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceMetadata/ResourceMetadata.tsx
@@ -9,10 +9,10 @@ import { useCoreApi } from "#providers/CoreSdkProvider"
 import { t } from "#providers/I18NProvider"
 import { useTokenProvider } from "#providers/TokenProvider"
 import { Button } from "#ui/atoms/Button"
+import { Card } from "#ui/atoms/Card"
 import { Icon } from "#ui/atoms/Icon"
 import { Section } from "#ui/atoms/Section"
 import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
-import { Spacer } from "#ui/atoms/Spacer"
 import { Text } from "#ui/atoms/Text"
 
 interface MetadataOverlay
@@ -58,11 +58,6 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
           ],
     )
 
-    const isUpdatable =
-      Object.entries(resourceData?.metadata ?? []).filter(([, metadataValue]) =>
-        isUpdatableType(metadataValue),
-      ).length > 0
-
     if (isLoading) {
       return null
     }
@@ -71,6 +66,7 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
       <div>
         <Section
           title="Metadata"
+          border="none"
           actionButton={
             <div className="flex items-center gap-2">
               <Button
@@ -101,34 +97,37 @@ export const ResourceMetadata = withSkeletonTemplate<ResourceMetadataProps>(
             </div>
           }
         >
-          {isUpdatable ? (
-            Object.entries(resourceData?.metadata ?? []).map(
+          <Card gap="6" overflow="visible" backgroundColor="light">
+            {Object.entries(resourceData?.metadata ?? []).map(
               ([metadataKey, metadataValue], idx) => {
-                if (!isUpdatableType(metadataValue)) return null
-
                 return (
                   <div
                     // biome-ignore lint/suspicious/noArrayIndexKey: Using index as key is acceptable here since items are static
                     key={idx}
-                    className="grid grid-cols-2 py-4 border-b border-gray-100"
+                    className="flex w-full px-1"
                     data-testid={`ResourceMetadata-item-${metadataKey}`}
                   >
-                    <Text variant="info">{metadataKey}</Text>
                     <Text
-                      weight="semibold"
+                      size="small"
+                      variant="info"
+                      className="font-mono mr-2"
+                    >
+                      {metadataKey}:
+                    </Text>
+                    <Text
+                      size="small"
+                      className="font-mono"
                       data-testid={`ResourceMetadata-value-${metadataKey}`}
                     >
-                      {metadataValue.toString()}
+                      {isUpdatableType(metadataValue)
+                        ? metadataValue.toString()
+                        : "[...]"}
                     </Text>
                   </div>
                 )
               },
-            )
-          ) : (
-            <Spacer top="4">
-              <Text variant="info">{t("common.no_metadata")}.</Text>
-            </Spacer>
-          )}
+            )}
+          </Card>
         </Section>
         <JsonOverlay title="Metadata" json={resourceData?.metadata ?? {}} />
         <EditMetadataOverlay


### PR DESCRIPTION
Closes commercelayer/issues-app/issues/484

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I modified the `ResourceMetadata` component to:
- simply metadata preview with a code-like rendering, according to updated design.
- show in preview complex metadata keys with generic `[...]` value.

<img width="900" alt="Screenshot 2025-11-17 alle 16 39 39" src="https://github.com/user-attachments/assets/061d4b84-4fd5-4d92-a407-aced3000af1b" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
