### PR TITLE
Improve async capture check

### DIFF
--- a/packages/app-elements/src/helpers/transactions.ts
+++ b/packages/app-elements/src/helpers/transactions.ts
@@ -9,10 +9,14 @@ import isEmpty from "lodash-es/isEmpty"
 export function orderTransactionIsAnAsyncCapture(
   transaction: Authorization | Void | Capture | Refund,
 ): boolean {
+  const isAsyncMessage =
+    isEmpty(transaction.message) ||
+    ["pending", "received"].includes(transaction.message?.toLowerCase() ?? "")
+
   return (
     transaction.type === "captures" &&
     !transaction.succeeded &&
-    isEmpty(transaction.message) &&
+    isAsyncMessage &&
     isEmpty(transaction.error_code)
   )
 }


### PR DESCRIPTION
## What I did

To determine whether a capture was asynchronous, the logic previously checked for an empty message when succeeded was `false`. The core API now returns additional states such as `Pending` or `received` for asynchronous captures. 
This PR updates the evaluation logic to account for these new message values from the core API.




## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
