### PR TITLE
Expose `role` from `/tokeninfo` in TokenProvider

### DIFF
--- a/packages/app-elements/src/providers/TokenProvider/MockTokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/MockTokenProvider.tsx
@@ -34,6 +34,7 @@ export function MockTokenProvider({
     canUser: (_action, _resource) => true,
     canAccess: () => true,
     emitInvalidAuth: () => {},
+    role: null,
   }
 
   return (

--- a/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/TokenProvider.tsx
@@ -30,6 +30,7 @@ import type {
   TokenProviderAuthUser,
   TokenProviderClAppSlug,
   TokenProviderExtras,
+  TokenProviderRole,
   TokenProviderRoleActions,
 } from "./types"
 import { makeDashboardUrl } from "./url"
@@ -44,6 +45,7 @@ export interface TokenProviderValue {
   ) => boolean
   canAccess: (appSlug: TokenProviderClAppSlug) => boolean
   emitInvalidAuth: (reason: string) => void
+  role: TokenProviderRole | null
 }
 
 export interface TokenProviderProps {
@@ -129,6 +131,7 @@ export const AuthContext = createContext<TokenProviderValue>({
   emitInvalidAuth: () => undefined,
   settings: initialTokenProviderState.settings,
   user: null,
+  role: null,
 })
 
 export const useTokenProvider = (): TokenProviderValue => {
@@ -294,6 +297,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
             user: tokenInfo.user ?? userFromExtras,
             rolePermissions: tokenInfo.permissions ?? {},
             accessibleApps: tokenInfo.accessibleApps ?? [],
+            role: tokenInfo.role,
           },
         })
       })()
@@ -304,6 +308,7 @@ export const TokenProvider: React.FC<TokenProviderProps> = ({
   const value: TokenProviderValue = {
     settings: _state.settings,
     user: _state.user,
+    role: _state.role,
     canUser,
     canAccess,
     emitInvalidAuth,

--- a/packages/app-elements/src/providers/TokenProvider/index.tsx
+++ b/packages/app-elements/src/providers/TokenProvider/index.tsx
@@ -9,6 +9,7 @@ export type {
   TokenProviderClAppSlug,
   TokenProviderExtras,
   TokenProviderPermissionItem,
+  TokenProviderRole,
   TokenProviderRoleActions,
   TokenProviderRolePermissions,
   TokenProviderTokenApplicationKind,

--- a/packages/app-elements/src/providers/TokenProvider/reducer.ts
+++ b/packages/app-elements/src/providers/TokenProvider/reducer.ts
@@ -1,4 +1,7 @@
-import type { TokenProviderClAppSlug } from "#providers/TokenProvider"
+import type {
+  TokenProviderClAppSlug,
+  TokenProviderRole,
+} from "#providers/TokenProvider"
 import type {
   TokenProviderAuthSettings,
   TokenProviderAuthUser,
@@ -13,6 +16,7 @@ interface TokenProviderInternalState {
   accessibleApps: TokenProviderClAppSlug[]
   settings: TokenProviderAuthSettings
   user: TokenProviderAuthUser | null
+  role: TokenProviderRole | null
 }
 
 export const initialTokenProviderState: TokenProviderInternalState = {
@@ -31,6 +35,7 @@ export const initialTokenProviderState: TokenProviderInternalState = {
     dashboardUrl: "https://dashboard.commercelayer.io/",
   },
   user: null,
+  role: null,
 }
 
 type Action =
@@ -42,6 +47,7 @@ type Action =
         user: TokenProviderAuthUser | null
         rolePermissions: TokenProviderRolePermissions
         accessibleApps: TokenProviderClAppSlug[]
+        role: TokenProviderRole | null
       }
     }
 

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -62,6 +62,12 @@ export type TokenProviderRolePermissions = Partial<
   Record<ListableResourceType | "organizations", TokenProviderPermissionItem>
 >
 
+export type TokenProviderRole = {
+  id: string
+  kind: string
+  name: string
+}
+
 interface CoreApiOwnerUser {
   type: "User"
   id: string

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.test.ts
@@ -47,6 +47,12 @@ describe("isValidTokenForCurrentApp", () => {
     expect(tokenInfo.organizationSlug).toBe("giuseppe-imports")
 
     expect(tokenInfo.user).toBeNull()
+
+    expect(tokenInfo.role).toEqual({
+      id: "integration",
+      kind: "admin",
+      name: "Admin",
+    })
   })
 
   test('should extract proper data from `tokeninfo` endpoint for any other kind (other than "integration")', async () => {

--- a/packages/app-elements/src/providers/TokenProvider/validateToken.ts
+++ b/packages/app-elements/src/providers/TokenProvider/validateToken.ts
@@ -3,7 +3,10 @@ import type { ListableResourceType } from "@commercelayer/sdk"
 import fetch from "cross-fetch"
 import isEmpty from "lodash-es/isEmpty"
 import { computeFullname, formatDisplayName } from "#helpers/name"
-import type { TokenProviderTokenApplicationKind } from "#providers/TokenProvider"
+import type {
+  TokenProviderRole,
+  TokenProviderTokenApplicationKind,
+} from "#providers/TokenProvider"
 import { getInfoFromJwt, type ParsedScopes } from "./getInfoFromJwt"
 import type {
   Mode,
@@ -40,6 +43,7 @@ interface ValidToken {
   accessibleApps?: TokenProviderClAppSlug[]
   user: TokenProviderAuthUser | null
   scopes?: ParsedScopes
+  role: TokenProviderRole | null
 }
 interface InvalidToken {
   isValidToken: false
@@ -79,7 +83,7 @@ export async function isValidTokenForCurrentApp({
 
   try {
     const tokenInfo:
-      | (Omit<TokenProviderTokenInfo, "application" | "role" | "token"> & {
+      | (Omit<TokenProviderTokenInfo, "application" | "token"> & {
           token: { test: boolean }
         })
       | null =
@@ -88,6 +92,11 @@ export async function isValidTokenForCurrentApp({
             permissions: {},
             token: {
               test: jwtInfo.mode !== "live",
+            },
+            role: {
+              id: "integration",
+              kind: "admin",
+              name: "Admin",
             },
           }
         : await fetchTokenInfo({
@@ -154,6 +163,7 @@ export async function isValidTokenForCurrentApp({
             }
           : null,
       scopes: jwtInfo.scopes,
+      role: tokenInfo?.role ?? null,
     }
   } catch {
     return {


### PR DESCRIPTION
## What I did

`TokenProvider` context now exposes the user role, if present

```ts
const { role } = useTokenProvider()
```

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
