### PR TITLE
Add script to flush Vitest snapshots

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "pnpm biome check",
     "lint:fix": "pnpm biome check --write",
     "test": "pnpm -r test",
+    "test:update": "pnpm --stream -r test:update",
     "test:watch": "pnpm --stream -r test:watch",
     "ts:check": "pnpm --stream -r ts:check",
     "dep:major": "pnpm dlx npm-check-updates",

--- a/packages/app-elements/package.json
+++ b/packages/app-elements/package.json
@@ -40,6 +40,7 @@
     "build:css-vendor": "pnpm dlx @tailwindcss/cli -i ./src/styles/vendor.css -o ./dist/vendor.css --minify",
     "lint:fix": "pnpm biome check --write",
     "test": "vitest run",
+    "test:update": "vitest run --update",
     "test:watch": "vitest",
     "ts:check": "tsc --noEmit",
     "generate:schema.order_rules": "curl -s https://core.commercelayer.io/api/public/schemas/order_rules | pnpx json-schema-to-typescript > ./src/ui/forms/RuleEngine/schema.order_rules.ts",


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added package.json script to launch the Vitest snapshots flush procedure in the meanwhile of tests execution.