### PR TITLE
Add `useTrackingDetails` as sharable component

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -426,3 +426,4 @@ export {
   type UseResourceListConfig,
   useResourceList,
 } from "#ui/resources/useResourceList"
+export { useTrackingDetails } from "#ui/resources/useTrackingDetails"

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -40,7 +40,7 @@ export interface ResourceListItemProps {
   /**
    * Optional override for the right slot. When provided, it replaces any computed right content.
    */
-  rightContentOverride?: JSX.Element
+  rightContentOverride?: JSX.Element | null
 }
 
 type ResourceListItemConfig = Omit<ResourceListItemProps, "resource"> &

--- a/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/ResourceListItem.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react"
+import { type JSX, useMemo } from "react"
 import { useTranslation } from "react-i18next"
 import { useCoreApi } from "#providers/CoreSdkProvider"
 import { useTokenProvider } from "#providers/TokenProvider"
@@ -37,6 +37,10 @@ export interface ResourceListItemProps {
    * Optional setting to show right content, if available, instead of right arrow
    */
   showRightContent?: boolean
+  /**
+   * Optional override for the right slot. When provided, it replaces any computed right content.
+   */
+  rightContentOverride?: JSX.Element
 }
 
 type ResourceListItemConfig = Omit<ResourceListItemProps, "resource"> &
@@ -48,6 +52,7 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
     description,
     icon,
     rightContent,
+    rightContentOverride,
     bottomContent,
     href,
     onClick,
@@ -90,9 +95,11 @@ const ResourceListItemComponent = withSkeletonTemplate<ResourceListItemConfig>(
           {bottomContent && <div className="mt-2">{bottomContent}</div>}
         </div>
         <div>
-          {showRightContent
-            ? rightContent
-            : isClickable && <StatusIcon name="caretRight" />}
+          {rightContentOverride != null
+            ? rightContentOverride
+            : showRightContent
+              ? rightContent
+              : isClickable && <StatusIcon name="caretRight" />}
         </div>
       </ListItem>
     )

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -5,38 +5,29 @@ import type {
 import { FileIcon, PackageIcon } from "@phosphor-icons/react"
 import cn from "classnames"
 import isEmpty from "lodash-es/isEmpty"
-import { useCallback, useMemo } from "react"
+import { useMemo } from "react"
 import type { SetNonNullable, SetRequired } from "type-fest"
-import { formatDate, sortAndGroupByDate } from "#helpers/date"
 import {
   getAvatarSrcFromRate,
   getParcelTrackingDetail,
-  getParcelTrackingDetails,
   getShipmentRate,
   hasBeenPurchased,
   hasSingleTracking,
   type Rate,
-  type TrackingDetail,
 } from "#helpers/tracking"
-import { useOverlay } from "#hooks/useOverlay"
 import { t, useTranslation } from "#providers/I18NProvider"
-import { useTokenProvider } from "#providers/TokenProvider"
 import { A } from "#ui/atoms/A"
 import { Avatar } from "#ui/atoms/Avatar"
-import { Badge } from "#ui/atoms/Badge"
 import { Button } from "#ui/atoms/Button"
 import { Hr } from "#ui/atoms/Hr"
-import { Section } from "#ui/atoms/Section"
 import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
 import { Spacer } from "#ui/atoms/Spacer"
-import { Stack } from "#ui/atoms/Stack"
 import { StatusIcon } from "#ui/atoms/StatusIcon"
-import { Steps } from "#ui/atoms/Steps"
 import { Text } from "#ui/atoms/Text"
 import { CardDialog } from "#ui/composite/CardDialog"
-import { PageLayout } from "#ui/composite/PageLayout"
 import { FlexRow } from "#ui/internals/FlexRow"
 import { ResourceLineItems } from "./ResourceLineItems"
+import { useTrackingDetails } from "./useTrackingDetails"
 
 type SetNonNullableRequired<
   BaseType,
@@ -259,14 +250,14 @@ const Tracking = withSkeletonTemplate<{
   showEstimatedDelivery: boolean
 }>(({ parcel, rate, showEstimatedDelivery = false }) => {
   const trackingDetails = getParcelTrackingDetail(parcel)
-  const { TrackingDetailsOverlay, openTrackingDetails } = useTrackingDetails(
+  const { TrackingDetailsModal, openTrackingDetails } = useTrackingDetails(
     parcel,
     rate,
   )
 
   return (
     <>
-      <TrackingDetailsOverlay />
+      <TrackingDetailsModal />
       {trackingDetails?.status != null ? (
         <FlexRow className="mt-4">
           <Text variant="info">{t("common.status")}</Text>
@@ -302,209 +293,6 @@ const Tracking = withSkeletonTemplate<{
           <Text variant="info">{t("common.estimated_delivery")}</Text>
           <Text weight="semibold">{rate.formatted_delivery_date}</Text>
         </FlexRow>
-      )}
-    </>
-  )
-})
-
-const useTrackingDetails = (parcel: ParcelResource, rate?: Rate) => {
-  const {
-    Overlay,
-    open: openTrackingDetails,
-    close,
-  } = useOverlay({
-    queryParam: `tracking-${parcel.tracking_number ?? ""}`,
-  })
-
-  const TrackingDetailsOverlay = useCallback(() => {
-    return (
-      parcel.tracking_number != null && (
-        <Overlay>
-          <PageLayout
-            title={`${t("common.tracking")} #${parcel.tracking_number}`}
-            navigationButton={{
-              label: "Back",
-              onClick: () => {
-                close()
-              },
-            }}
-          >
-            <TrackingDetails parcel={parcel} rate={rate} />
-          </PageLayout>
-        </Overlay>
-      )
-    )
-  }, [Overlay, close, parcel])
-
-  return { TrackingDetailsOverlay, openTrackingDetails }
-}
-
-const TrackingDetails = withSkeletonTemplate<{
-  parcel: ParcelResource
-  rate?: Rate
-}>(({ parcel, rate }) => {
-  const { user } = useTokenProvider()
-
-  interface Event {
-    date: string
-    tracking: TrackingDetail
-  }
-
-  const groupedEvents = useMemo(() => {
-    const events: Event[] = getParcelTrackingDetails(parcel)
-      .filter(
-        (
-          tracking,
-        ): tracking is SetNonNullableRequired<
-          typeof tracking,
-          "datetime" | "message"
-        > => tracking.datetime != null && tracking.message != null,
-      )
-      .map((tracking) => ({
-        date: tracking.datetime,
-        tracking,
-      }))
-
-    return sortAndGroupByDate(events)
-  }, [parcel])
-
-  const lastEvent = Object.values(groupedEvents)[0]?.[0] as Event | undefined
-
-  return (
-    <>
-      <Steps
-        steps={[
-          {
-            label: t("common.tracking_details.tracking_pre_transit"),
-            active: lastEvent?.tracking.status === "pre_transit",
-          },
-          {
-            label: t("common.tracking_details.tracking_in_transit"),
-            active: lastEvent?.tracking.status === "in_transit",
-          },
-          {
-            label: t("common.tracking_details.tracking_out_for_delivery"),
-            active: lastEvent?.tracking.status === "out_for_delivery",
-          },
-          {
-            label: t("common.tracking_details.tracking_delivered"),
-            active: lastEvent?.tracking.status === "delivered",
-          },
-        ]}
-      />
-      <Spacer top="12" bottom="14">
-        <Stack>
-          <div>
-            <Spacer bottom="2">
-              <Text size="small" tag="div" variant="info" weight="semibold">
-                {t("common.tracking_details.courier")}
-              </Text>
-            </Spacer>
-            {rate != null && (
-              <Avatar
-                src={getAvatarSrcFromRate(rate)}
-                alt="Adyen"
-                border="none"
-                shape="circle"
-                size="x-small"
-                className="inline-block align-middle"
-              />
-            )}{" "}
-            <span className="text-lg font-semibold text-black pl-1.5">
-              {rate?.carrier}
-            </span>
-          </div>
-          <div>
-            <Spacer bottom="2">
-              <Text size="small" tag="div" variant="info" weight="semibold">
-                {t("common.tracking_details.estimated_delivery_date")}
-              </Text>
-            </Spacer>
-            <div className="text-lg font-semibold text-black">
-              {formatDate({
-                isoDate: rate?.delivery_date,
-                format: "date",
-                timezone: user?.timezone,
-                locale: user?.locale,
-              })}
-            </div>
-          </div>
-        </Stack>
-      </Spacer>
-
-      {lastEvent != null && (
-        <Section
-          title="Detailed view"
-          border="none"
-          actionButton={
-            <Text size="small" variant="info">
-              {t("common.tracking_details.last_update")}:{" "}
-              <Text weight="bold">
-                {formatDate({
-                  isoDate: lastEvent.date,
-                  format: "full",
-                  timezone: user?.timezone,
-                  locale: user?.locale,
-                })}
-              </Text>
-            </Text>
-          }
-        >
-          <div className="rounded-md bg-gray-50 p-6 pb-2">
-            {Object.entries(groupedEvents).map(([date, eventsByDate]) => (
-              <div key={date}>
-                <Badge
-                  data-testid="timeline-date-group"
-                  className="rounded-full bg-gray-200 py-1 px-3 font-bold"
-                  variant="secondary"
-                >
-                  {date}
-                </Badge>
-                <table className="mt-4 mb-6 ml-1 w-full h-full">
-                  <tbody>
-                    {eventsByDate.map((event) => (
-                      <tr key={event.date}>
-                        <td valign="top" align="right" className="pt-4">
-                          <div className="text-gray-400 text-xs font-bold">
-                            {formatDate({
-                              format: "time",
-                              isoDate: event.date,
-                              timezone: user?.timezone,
-                              locale: user?.locale,
-                            })}
-                          </div>
-                        </td>
-                        <td valign="top" className="pt-4 px-4">
-                          <div className="flex flex-col items-center gap-1.5 pt-[3px] h-full">
-                            <div className="rounded-full bg-gray-300 w-3 h-3" />
-                            {event.position !== "first" && (
-                              <div className="bg-[#E6E7E7] w-px grow" />
-                            )}
-                          </div>
-                        </td>
-                        <td valign="top" className="pt-4 w-full pb-6">
-                          <div className="text-black font-semibold -mt-[3px]">
-                            {event.tracking.message}
-                          </div>
-                          <div className="text-gray-500 text-sm font-semibold">
-                            {event.tracking.tracking_location != null
-                              ? `${event.tracking.tracking_location.city}${
-                                  event.tracking.tracking_location.country !=
-                                  null
-                                    ? `, ${event.tracking.tracking_location.country}`
-                                    : ""
-                                }`
-                              : ""}
-                          </div>
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            ))}
-          </div>
-        </Section>
       )}
     </>
   )

--- a/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
+++ b/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
@@ -1,6 +1,7 @@
 import type { Parcel as ParcelResource } from "@commercelayer/sdk"
 import { useCallback, useMemo, useState } from "react"
 import type { SetNonNullable, SetRequired } from "type-fest"
+import { T } from "vitest/dist/chunks/reporters.d.BFLkQcL6.js"
 import { formatDate, sortAndGroupByDate } from "#helpers/date"
 import {
   getAvatarSrcFromRate,
@@ -12,6 +13,7 @@ import { t } from "#providers/I18NProvider"
 import { useTokenProvider } from "#providers/TokenProvider"
 import { Avatar } from "#ui/atoms/Avatar"
 import { Badge } from "#ui/atoms/Badge"
+import { CopyToClipboard } from "#ui/atoms/CopyToClipboard"
 import { Section } from "#ui/atoms/Section"
 import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
 import { Spacer } from "#ui/atoms/Spacer"
@@ -28,7 +30,14 @@ export const useTrackingDetails = (parcel: ParcelResource, rate?: Rate) => {
       parcel.tracking_number != null && (
         <Modal show={show} onClose={() => setShow(false)} size="large">
           <Modal.Header>
-            {`${t("common.tracking")} #${parcel.tracking_number}`}
+            <div className="flex gap-1 items-center group pr-7">
+              {`${t("common.tracking")} ${parcel.tracking_number}`}
+              <CopyToClipboard
+                value={parcel.tracking_number}
+                showValue={false}
+                className="hidden group-hover:inline-block"
+              />
+            </div>
           </Modal.Header>
           <Modal.Body>
             <TrackingDetails parcel={parcel} rate={rate} />
@@ -118,7 +127,7 @@ const TrackingDetails = withSkeletonTemplate<{
               />
             )}{" "}
             <span className="text-lg font-semibold text-black pl-1.5">
-              {rate?.carrier}
+              {rate?.carrier ?? <Text variant="info">N/A</Text>}
             </span>
           </div>
           <div>
@@ -128,12 +137,16 @@ const TrackingDetails = withSkeletonTemplate<{
               </Text>
             </Spacer>
             <div className="text-lg font-semibold text-black">
-              {formatDate({
-                isoDate: rate?.delivery_date,
-                format: "date",
-                timezone: user?.timezone,
-                locale: user?.locale,
-              })}
+              {rate?.delivery_date != null ? (
+                formatDate({
+                  isoDate: rate.delivery_date,
+                  format: "date",
+                  timezone: user?.timezone,
+                  locale: user?.locale,
+                })
+              ) : (
+                <Text variant="info">N/A</Text>
+              )}
             </div>
           </div>
         </Stack>

--- a/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
+++ b/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
@@ -1,0 +1,220 @@
+import type { Parcel as ParcelResource } from "@commercelayer/sdk"
+import { useCallback, useMemo, useState } from "react"
+import type { SetNonNullable, SetRequired } from "type-fest"
+import { formatDate, sortAndGroupByDate } from "#helpers/date"
+import {
+  getAvatarSrcFromRate,
+  getParcelTrackingDetails,
+  type Rate,
+  type TrackingDetail,
+} from "#helpers/tracking"
+import { t } from "#providers/I18NProvider"
+import { useTokenProvider } from "#providers/TokenProvider"
+import { Avatar } from "#ui/atoms/Avatar"
+import { Badge } from "#ui/atoms/Badge"
+import { Section } from "#ui/atoms/Section"
+import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
+import { Spacer } from "#ui/atoms/Spacer"
+import { Stack } from "#ui/atoms/Stack"
+import { Steps } from "#ui/atoms/Steps"
+import { Text } from "#ui/atoms/Text"
+import { Modal } from "#ui/composite/Modal"
+
+export const useTrackingDetails = (parcel: ParcelResource, rate?: Rate) => {
+  const [show, setShow] = useState(false)
+
+  const TrackingDetailsModal = useCallback(() => {
+    return (
+      parcel.tracking_number != null && (
+        <Modal show={show} onClose={() => setShow(false)} size="large">
+          <Modal.Header>
+            {`${t("common.tracking")} #${parcel.tracking_number}`}
+          </Modal.Header>
+          <Modal.Body>
+            <TrackingDetails parcel={parcel} rate={rate} />
+          </Modal.Body>
+        </Modal>
+      )
+    )
+  }, [show, parcel, rate])
+
+  const openTrackingDetails = useCallback(() => setShow(true), [])
+
+  return { TrackingDetailsModal, openTrackingDetails }
+}
+
+const TrackingDetails = withSkeletonTemplate<{
+  parcel: ParcelResource
+  rate?: Rate
+}>(({ parcel, rate }) => {
+  const { user } = useTokenProvider()
+
+  interface Event {
+    date: string
+    tracking: TrackingDetail
+  }
+
+  const groupedEvents = useMemo(() => {
+    const events: Event[] = getParcelTrackingDetails(parcel)
+      .filter(
+        (
+          tracking,
+        ): tracking is SetNonNullableRequired<
+          typeof tracking,
+          "datetime" | "message"
+        > => tracking.datetime != null && tracking.message != null,
+      )
+      .map((tracking) => ({
+        date: tracking.datetime,
+        tracking,
+      }))
+
+    return sortAndGroupByDate(events)
+  }, [parcel])
+
+  const lastEvent = Object.values(groupedEvents)[0]?.[0] as Event | undefined
+
+  return (
+    <>
+      <Steps
+        steps={[
+          {
+            label: t("common.tracking_details.tracking_pre_transit"),
+            active: lastEvent?.tracking.status === "pre_transit",
+          },
+          {
+            label: t("common.tracking_details.tracking_in_transit"),
+            active: lastEvent?.tracking.status === "in_transit",
+          },
+          {
+            label: t("common.tracking_details.tracking_out_for_delivery"),
+            active: lastEvent?.tracking.status === "out_for_delivery",
+          },
+          {
+            label: t("common.tracking_details.tracking_delivered"),
+            active: lastEvent?.tracking.status === "delivered",
+          },
+        ]}
+      />
+      <Spacer top="12" bottom="14">
+        <Stack>
+          <div>
+            <Spacer bottom="2">
+              <Text size="small" tag="div" variant="info" weight="semibold">
+                {t("common.tracking_details.courier")}
+              </Text>
+            </Spacer>
+            {rate != null && (
+              <Avatar
+                src={getAvatarSrcFromRate(rate)}
+                alt="Adyen"
+                border="none"
+                shape="circle"
+                size="x-small"
+                className="inline-block align-middle"
+              />
+            )}{" "}
+            <span className="text-lg font-semibold text-black pl-1.5">
+              {rate?.carrier}
+            </span>
+          </div>
+          <div>
+            <Spacer bottom="2">
+              <Text size="small" tag="div" variant="info" weight="semibold">
+                {t("common.tracking_details.estimated_delivery_date")}
+              </Text>
+            </Spacer>
+            <div className="text-lg font-semibold text-black">
+              {formatDate({
+                isoDate: rate?.delivery_date,
+                format: "date",
+                timezone: user?.timezone,
+                locale: user?.locale,
+              })}
+            </div>
+          </div>
+        </Stack>
+      </Spacer>
+
+      {lastEvent != null && (
+        <Section
+          title="Detailed view"
+          border="none"
+          actionButton={
+            <Text size="small" variant="info">
+              {t("common.tracking_details.last_update")}:{" "}
+              <Text weight="bold">
+                {formatDate({
+                  isoDate: lastEvent.date,
+                  format: "full",
+                  timezone: user?.timezone,
+                  locale: user?.locale,
+                })}
+              </Text>
+            </Text>
+          }
+        >
+          <div className="rounded-md bg-gray-50 p-6 pb-2">
+            {Object.entries(groupedEvents).map(([date, eventsByDate]) => (
+              <div key={date}>
+                <Badge
+                  data-testid="timeline-date-group"
+                  className="rounded-full bg-gray-200 py-1 px-3 font-bold"
+                  variant="secondary"
+                >
+                  {date}
+                </Badge>
+                <table className="mt-4 mb-6 ml-1 w-full h-full">
+                  <tbody>
+                    {eventsByDate.map((event) => (
+                      <tr key={event.date}>
+                        <td valign="top" align="right" className="pt-4">
+                          <div className="text-gray-400 text-xs font-bold">
+                            {formatDate({
+                              format: "time",
+                              isoDate: event.date,
+                              timezone: user?.timezone,
+                              locale: user?.locale,
+                            })}
+                          </div>
+                        </td>
+                        <td valign="top" className="pt-4 px-4">
+                          <div className="flex flex-col items-center gap-1.5 pt-[3px] h-full">
+                            <div className="rounded-full bg-gray-300 w-3 h-3" />
+                            {event.position !== "first" && (
+                              <div className="bg-[#E6E7E7] w-px grow" />
+                            )}
+                          </div>
+                        </td>
+                        <td valign="top" className="pt-4 w-full pb-6">
+                          <div className="text-black font-semibold -mt-[3px]">
+                            {event.tracking.message}
+                          </div>
+                          <div className="text-gray-500 text-sm font-semibold">
+                            {event.tracking.tracking_location != null
+                              ? `${event.tracking.tracking_location.city}${
+                                  event.tracking.tracking_location.country !=
+                                  null
+                                    ? `, ${event.tracking.tracking_location.country}`
+                                    : ""
+                                }`
+                              : ""}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ))}
+          </div>
+        </Section>
+      )}
+    </>
+  )
+})
+
+type SetNonNullableRequired<
+  BaseType,
+  Keys extends keyof BaseType,
+> = SetRequired<SetNonNullable<BaseType, Keys>, Keys>

--- a/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
+++ b/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
@@ -69,8 +69,11 @@ const TrackingDetails = withSkeletonTemplate<{
         tracking,
       }))
 
-    return sortAndGroupByDate(events)
-  }, [parcel])
+    return sortAndGroupByDate(events, {
+      timezone: user?.timezone,
+      locale: user?.locale,
+    })
+  }, [parcel, user?.locale, user?.timezone])
 
   const lastEvent = Object.values(groupedEvents)[0]?.[0] as Event | undefined
 
@@ -107,7 +110,7 @@ const TrackingDetails = withSkeletonTemplate<{
             {rate != null && (
               <Avatar
                 src={getAvatarSrcFromRate(rate)}
-                alt="Adyen"
+                alt={rate.carrier}
                 border="none"
                 shape="circle"
                 size="x-small"

--- a/packages/docs/src/stories/resources/useTrackingDetails.stories.tsx
+++ b/packages/docs/src/stories/resources/useTrackingDetails.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryFn } from "@storybook/react-vite"
+import type { JSX } from "react"
+import { getShipmentRate } from "#helpers/tracking"
+import { Button } from "#ui/atoms/Button"
+import {
+  parcelWithTracking1,
+  shipmentWithSingleParcelSingleTracking,
+} from "#ui/resources/ResourceShipmentParcels.mocks"
+import { useTrackingDetails } from "#ui/resources/useTrackingDetails"
+
+const setup: Meta = {
+  title: "Resources/useTrackingDetails",
+  parameters: {
+    layout: "padded",
+  },
+}
+export default setup
+
+/**
+ * Click the button to open the tracking details modal. Shows full tracking history with carrier info.
+ */
+export const Default: StoryFn = (): JSX.Element => {
+  const rate = getShipmentRate(shipmentWithSingleParcelSingleTracking)
+  const { TrackingDetailsModal, openTrackingDetails } = useTrackingDetails(
+    parcelWithTracking1,
+    rate,
+  )
+
+  return (
+    <div>
+      <TrackingDetailsModal />
+      <Button onClick={openTrackingDetails}>Track shipment</Button>
+    </div>
+  )
+}


### PR DESCRIPTION
Related to commercelayer/issues-app#25

## What I did

`useTrackingDetails` is now a standalone component, before it was used only internally in `ResourceShipmentParcel`.
It's also rendered within a Modal (it was an Overlay).

<img width="689" height="702" alt="image" src="https://github.com/user-attachments/assets/fe1db700-94a6-4888-8b1c-d9cd7c5e4be1" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
