### PR TITLE
Enforce message in `MarketWithCurrencySelector` component

### DIFF
--- a/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
+++ b/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
@@ -2,7 +2,7 @@ import type { ListResponse, Market, Resource } from "@commercelayer/sdk"
 import cn from "classnames"
 import isEmpty from "lodash-es/isEmpty"
 import isString from "lodash-es/isString"
-import type { FC } from "react"
+import { type FC, useEffect, useState } from "react"
 import { useFormContext } from "react-hook-form"
 import { currencyInputSelectOptions } from "#helpers/currencies"
 import { useCoreApi, useCoreSdkProvider } from "#providers/CoreSdkProvider"
@@ -47,6 +47,7 @@ export const HookedMarketWithCurrencySelector: FC<
     setValue,
     formState: { defaultValues },
   } = useFormContext()
+  const [hasMorePages, setHasMorePages] = useState(false)
   const defaultMarketId = defaultValues?.[fieldNameMarket]
   const defaultCurrencyCode = defaultValues?.[fieldNameCurrencyCode]
 
@@ -73,8 +74,11 @@ export const HookedMarketWithCurrencySelector: FC<
     ],
   )
 
-  const hasMorePages =
-    (data?.meta?.pageCount != null && data.meta.pageCount > 1) ?? false
+  useEffect(() => {
+    if (data?.meta?.pageCount != null) {
+      setHasMorePages(data.meta.pageCount > 1)
+    }
+  }, [data])
 
   const { data: defaultResource, isLoading: isLoadingDefaultResource } =
     useCoreApi(
@@ -155,6 +159,7 @@ export const HookedMarketWithCurrencySelector: FC<
                     include: ["price_list"],
                   })
                   .then((res) => {
+                    setHasMorePages(res.meta.pageCount > 1)
                     return res.map((market) => ({
                       label: market.name,
                       value: market.id,

--- a/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
+++ b/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
@@ -1,7 +1,6 @@
 import type { Parcel as ParcelResource } from "@commercelayer/sdk"
 import { useCallback, useMemo, useState } from "react"
 import type { SetNonNullable, SetRequired } from "type-fest"
-import { T } from "vitest/dist/chunks/reporters.d.BFLkQcL6.js"
 import { formatDate, sortAndGroupByDate } from "#helpers/date"
 import {
   getAvatarSrcFromRate,


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Enforced `MarketWithCurrencySelector` component by fixing the current behavior or `hasMorePages` flag.
The flag is actually stuck to the initial state based on the page count of the first markets list request without being updated in callback of a search with keyword request.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
