### PR TITLE
Enforce default locale in currency formatting

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.tsx
+++ b/packages/app-elements/src/ui/forms/InputCurrency/InputCurrency.tsx
@@ -153,6 +153,7 @@ export const InputCurrency = forwardRef<HTMLInputElement, InputCurrencyProps>(
             decimalsLimit={decimalLength}
             decimalSeparator={currency.decimal_mark}
             groupSeparator={currency.thousands_separator}
+            intlConfig={{ locale: "en-US" }}
             placeholder={
               placeholder ??
               makePlaceholder(currency, defaultSign === "-" ? "-" : "")

--- a/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
+++ b/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
@@ -1,3 +1,4 @@
+import { formatValue } from "react-currency-input-field"
 import {
   type Currency,
   type CurrencyCode,
@@ -87,23 +88,14 @@ export function formatCentsToCurrency(
     stripZeroDecimals && unit % 1 === 0
       ? unit.toFixed(0)
       : unit.toFixed(decimalLength)
+  const value = `${fixedDecimals}`.replace(".", currency.decimal_mark)
 
-  // Split on '.' (toFixed always uses '.' as decimal separator)
-  const [integerPart = "", fractionalPart] = fixedDecimals.split(".")
-
-  // Apply thousands separator directly - no Intl.NumberFormat locale dependency
-  const formattedInteger =
-    currency.thousands_separator !== ""
-      ? integerPart.replace(
-          /\B(?=(\d{3})+(?!\d))/g,
-          currency.thousands_separator,
-        )
-      : integerPart
-
-  const formattedValue =
-    fractionalPart !== undefined
-      ? `${formattedInteger}${currency.decimal_mark}${fractionalPart}`
-      : formattedInteger
+  const formattedValue = formatValue({
+    value,
+    decimalSeparator: currency.decimal_mark,
+    groupSeparator: currency.thousands_separator,
+    intlConfig: { locale: "en-US" },
+  })
 
   return addCurrencySymbol({ formattedValue, currency })
 }

--- a/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
+++ b/packages/app-elements/src/ui/forms/InputCurrency/utils.ts
@@ -1,4 +1,3 @@
-import { formatValue } from "react-currency-input-field"
 import {
   type Currency,
   type CurrencyCode,
@@ -88,13 +87,23 @@ export function formatCentsToCurrency(
     stripZeroDecimals && unit % 1 === 0
       ? unit.toFixed(0)
       : unit.toFixed(decimalLength)
-  const value = `${fixedDecimals}`.replace(".", currency.decimal_mark)
 
-  const formattedValue = formatValue({
-    value,
-    decimalSeparator: currency.decimal_mark,
-    groupSeparator: currency.thousands_separator,
-  })
+  // Split on '.' (toFixed always uses '.' as decimal separator)
+  const [integerPart = "", fractionalPart] = fixedDecimals.split(".")
+
+  // Apply thousands separator directly - no Intl.NumberFormat locale dependency
+  const formattedInteger =
+    currency.thousands_separator !== ""
+      ? integerPart.replace(
+          /\B(?=(\d{3})+(?!\d))/g,
+          currency.thousands_separator,
+        )
+      : integerPart
+
+  const formattedValue =
+    fractionalPart !== undefined
+      ? `${formattedInteger}${currency.decimal_mark}${fractionalPart}`
+      : formattedInteger
 
   return addCurrencySymbol({ formattedValue, currency })
 }


### PR DESCRIPTION
## What I did

I've added `intlConfig: { locale: "en-US" }` to react-currency-input configuration.
This allows us to always have the same locale base, in all environments to apply the currency formatting.

In latest versions `react-currency-input` use internally user's locale and this leads to different formatting rules especially for thousands separator.
 

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
