### PR TITLE
Alow to pass custom list title in `useResourceFilters`

### DIFF
--- a/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
+++ b/packages/app-elements/src/ui/resources/useResourceFilters/useResourceFilters.tsx
@@ -242,7 +242,11 @@ const makeFilteredList: (options: {
       <ResourceListComponent
         {...resourceListProps}
         type={type}
-        title={hideTitle === true ? undefined : t("common.all")}
+        title={
+          hideTitle === true
+            ? undefined
+            : (resourceListProps.title ?? t("common.all"))
+        }
         query={{
           ...query,
           filters: sdkFilters,


### PR DESCRIPTION
## What I did

It was not possibile to pass a custom title in `useResourceFilters`, but list was always rendering the default `All` title

<img width="383" height="217" alt="image" src="https://github.com/user-attachments/assets/a2a9dca5-d176-48c9-8a23-f8daf3cfd288" />

----

<img width="416" height="249" alt="image" src="https://github.com/user-attachments/assets/57e2f9c3-2565-402b-912a-c0b2c423d9dd" />



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
