### PR TITLE
Add SkeletonTemplate support to Dropdown

### DIFF
--- a/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/Dropdown.tsx
@@ -4,6 +4,7 @@ import { Children, cloneElement, useMemo, useState } from "react"
 import { useClickAway } from "#hooks/useClickAway"
 import { useOnBlurFromContainer } from "#hooks/useOnBlurFromContainer"
 import { Button } from "#ui/atoms/Button"
+import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
 import type { DropdownMenuProps } from "#ui/composite/Dropdown/DropdownMenu"
 import { isSpecificJsxTag, isSpecificReactComponent } from "#utils/children"
 import { DropdownMenu } from "./DropdownMenu"
@@ -25,108 +26,113 @@ export interface DropdownProps
  * - `DropdownItem`: The trigger that handles dropdown selection.
  * - `DropdownDivider`: A visual separator for dropdown items.
  */
-export const Dropdown: React.FC<DropdownProps> = ({
-  dropdownLabel = <DotsThreeCircleIcon size={32} />,
-  menuHeader,
-  dropdownItems,
-  menuPosition = "bottom-right",
-  menuWidth,
-  className,
-}) => {
-  const [isExpanded, setIsExpanded] = useState(false)
+export const Dropdown = withSkeletonTemplate<DropdownProps>(
+  ({
+    dropdownLabel = <DotsThreeCircleIcon size={32} />,
+    menuHeader,
+    dropdownItems,
+    menuPosition = "bottom-right",
+    menuWidth,
+    className,
+  }) => {
+    const [isExpanded, setIsExpanded] = useState(false)
 
-  function toggle(): void {
-    setIsExpanded(!isExpanded)
-  }
-
-  function close(): void {
-    setIsExpanded(false)
-  }
-
-  const clickAwayRef = useClickAway(close)
-
-  const closeDropdownMenuIfButtonClicked = (
-    e: React.MouseEvent<HTMLElement>,
-  ): void => {
-    const target = e.target as HTMLElement
-    if (target.closest("button")) {
-      close()
+    function toggle(): void {
+      setIsExpanded(!isExpanded)
     }
-  }
 
-  const handleBlur = useOnBlurFromContainer(close)
+    function close(): void {
+      setIsExpanded(false)
+    }
 
-  const dropdownButton = useMemo(() => {
-    if (
-      isSpecificReactComponent(dropdownLabel, [/^Button$/]) ||
-      isSpecificJsxTag(dropdownLabel, ["button"])
-    ) {
-      return cloneElement(dropdownLabel, {
-        "aria-haspopup": true,
-        "aria-expanded": isExpanded,
-        onClick: () => {
-          toggle()
-        },
-      })
+    const clickAwayRef = useClickAway(close)
+
+    const closeDropdownMenuIfButtonClicked = (
+      e: React.MouseEvent<HTMLElement>,
+    ): void => {
+      const target = e.target as HTMLElement
+      if (target.closest("button")) {
+        close()
+      }
+    }
+
+    const handleBlur = useOnBlurFromContainer(close)
+
+    const dropdownButton = useMemo(() => {
+      if (
+        isSpecificReactComponent(dropdownLabel, [/^Button$/]) ||
+        isSpecificJsxTag(dropdownLabel, ["button"])
+      ) {
+        return cloneElement(dropdownLabel, {
+          "aria-haspopup": true,
+          "aria-expanded": isExpanded,
+          onClick: () => {
+            toggle()
+          },
+        })
+      }
+
+      return (
+        <Button
+          variant="link"
+          aria-haspopup
+          aria-expanded={isExpanded}
+          className={cn("m-0 p-0 align-top", {
+            "text-black!": typeof dropdownLabel !== "string",
+            "no-underline! hover:underline!": typeof dropdownLabel === "string",
+          })}
+          onClick={() => {
+            toggle()
+          }}
+        >
+          {dropdownLabel}
+          {typeof dropdownLabel === "string" ? (
+            <CaretDownIcon
+              className="inline-block ml-1 -mt-0.5"
+              weight="bold"
+            />
+          ) : null}
+        </Button>
+      )
+    }, [dropdownLabel, isExpanded])
+
+    if (Children.count(dropdownItems) === 0) {
+      return null
     }
 
     return (
-      <Button
-        variant="link"
-        aria-haspopup
-        aria-expanded={isExpanded}
-        className={cn("m-0 p-0 align-top", {
-          "text-black!": typeof dropdownLabel !== "string",
-          "no-underline! hover:underline!": typeof dropdownLabel === "string",
-        })}
-        onClick={() => {
-          toggle()
-        }}
+      // biome-ignore lint/a11y/noStaticElementInteractions: Need to handle onBlur to close the dropdown
+      <div
+        ref={isExpanded ? clickAwayRef : undefined}
+        onBlur={handleBlur}
+        className={cn("relative", className)}
       >
-        {dropdownLabel}
-        {typeof dropdownLabel === "string" ? (
-          <CaretDownIcon className="inline-block ml-1 -mt-0.5" weight="bold" />
-        ) : null}
-      </Button>
-    )
-  }, [dropdownLabel, isExpanded])
-
-  if (Children.count(dropdownItems) === 0) {
-    return null
-  }
-
-  return (
-    // biome-ignore lint/a11y/noStaticElementInteractions: Need to handle onBlur to close the dropdown
-    <div
-      ref={isExpanded ? clickAwayRef : undefined}
-      onBlur={handleBlur}
-      className={cn("relative", className)}
-    >
-      {dropdownButton}
-      {isExpanded && (
-        // biome-ignore lint/a11y/noStaticElementInteractions: Using click handler to close the dropdown
-        // biome-ignore lint/a11y/useKeyWithClickEvents: Using click handler to close the dropdown
-        <div
-          className={cn("absolute z-30", {
-            "top-full mt-2 right-0": menuPosition === "bottom-right",
-            "top-full mt-2 left-0": menuPosition === "bottom-left",
-            "bottom-full mb-2 right-0": menuPosition === "top-right",
-            "bottom-full mb-2 left-0": menuPosition === "top-left",
-          })}
-          onClick={closeDropdownMenuIfButtonClicked}
-        >
-          <DropdownMenu
-            menuHeader={menuHeader}
-            menuPosition={menuPosition}
-            parentElementRef={clickAwayRef}
-            menuWidth={menuWidth}
+        {dropdownButton}
+        {isExpanded && (
+          // biome-ignore lint/a11y/noStaticElementInteractions: Using click handler to close the dropdown
+          // biome-ignore lint/a11y/useKeyWithClickEvents: Using click handler to close the dropdown
+          <div
+            className={cn("absolute z-30", {
+              "top-full mt-2 right-0": menuPosition === "bottom-right",
+              "top-full mt-2 left-0": menuPosition === "bottom-left",
+              "bottom-full mb-2 right-0": menuPosition === "top-right",
+              "bottom-full mb-2 left-0": menuPosition === "top-left",
+            })}
+            onClick={closeDropdownMenuIfButtonClicked}
           >
-            {dropdownItems}
-          </DropdownMenu>
-        </div>
-      )}
-    </div>
-  )
-}
+            <DropdownMenu
+              menuHeader={menuHeader}
+              menuPosition={menuPosition}
+              parentElementRef={clickAwayRef}
+              menuWidth={menuWidth}
+            >
+              {dropdownItems}
+            </DropdownMenu>
+          </div>
+        )}
+      </div>
+    )
+  },
+)
 
 Dropdown.displayName = "Dropdown"

--- a/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
+++ b/packages/app-elements/src/ui/composite/Dropdown/DropdownItem.tsx
@@ -64,7 +64,7 @@ export const DropdownItem = withSkeletonTemplate<DropdownItemProps>(
           "w-[calc(100%-1rem)]  bg-white text-black! py-1.5 pl-2.5 mx-2 text-sm font-medium flex items-center focus:outline-hidden!",
           {
             "pr-8": info == null,
-            "min-w-64 pr-6": info != null,
+            "min-w-[170px] pr-6": info != null,
           },
           className,
           {

--- a/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
+++ b/packages/docs/src/stories/atoms/SkeletonTemplate.stories.tsx
@@ -21,6 +21,7 @@ import { Spacer } from "#ui/atoms/Spacer"
 import { StatusIcon } from "#ui/atoms/StatusIcon"
 import { Table, Td, Th, Tr } from "#ui/atoms/Table"
 import { Text } from "#ui/atoms/Text"
+import { Dropdown, DropdownItem } from "#ui/composite/Dropdown"
 import { ListItem } from "#ui/composite/ListItem"
 
 const setup: Meta<typeof SkeletonTemplate> = {
@@ -60,6 +61,19 @@ const children = (
     </ForwardRefComponent>
     <Spacer top="4" bottom="4">
       <Hr />
+    </Spacer>
+    <Spacer top="4" bottom="4">
+      <Dropdown
+        dropdownLabel="Click me"
+        menuPosition="bottom-left"
+        dropdownItems={
+          <>
+            <DropdownItem label="All" info="32" />
+            <DropdownItem label="Enabled" info="30" />
+            <DropdownItem label="Disabled" info="2" />
+          </>
+        }
+      />
     </Spacer>
     <WithSkeletonComponentB>C</WithSkeletonComponentB>
     <ListItem


### PR DESCRIPTION
## What I did

- Add SkeletonTemplate support to Dropdown 
-  make DropdownItem smaller when used with `info`

<img width="492" height="217" alt="image" src="https://github.com/user-attachments/assets/1cf93e9a-b4b4-45eb-b186-7696b027382c" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
