### PR TITLE
Update path in tsconfig

### DIFF
--- a/packages/app-elements/src/ui/forms/InputSelect/GenericAsyncComponent.tsx
+++ b/packages/app-elements/src/ui/forms/InputSelect/GenericAsyncComponent.tsx
@@ -8,6 +8,7 @@ import type {
   InputActionMeta,
   InputProps,
   MultiValue,
+  OptionsOrGroups,
   SelectInstance,
   SingleValue,
   StylesConfig,
@@ -15,7 +16,6 @@ import type {
 import type AsyncSelect from "react-select/async"
 import type AsyncCreatableSelect from "react-select/async-creatable"
 import type { SetRequired } from "type-fest"
-import type { AsyncAdditionalProps } from "#node_modules/react-select/dist/declarations/src/useAsync"
 import type {
   GroupedSelectValues,
   InputSelectProps,
@@ -23,6 +23,33 @@ import type {
 } from "./InputSelect"
 import components from "./overrides"
 import { isSingleValueSelected } from "./utils"
+
+interface AsyncAdditionalProps<Option, Group extends GroupBase<Option>> {
+  /**
+   * The default set of options to show before the user starts searching. When
+   * set to `true`, the results for loadOptions('') will be autoloaded.
+   */
+  defaultOptions?: OptionsOrGroups<Option, Group> | boolean
+  /**
+   * If cacheOptions is truthy, then the loaded data will be cached. The cache
+   * will remain until `cacheOptions` changes value.
+   */
+  cacheOptions?: any
+  /**
+   * Function that returns a promise, which is the set of options to be used
+   * once the promise resolves.
+   */
+  loadOptions?: (
+    inputValue: string,
+    callback: (options: OptionsOrGroups<Option, Group>) => void,
+    // biome-ignore lint/suspicious/noConfusingVoidType: this comes from react-select types, I can't change it
+  ) => Promise<OptionsOrGroups<Option, Group>> | void
+  /**
+   * Will cause the select to be displayed in the loading state, even if the
+   * Async select is not currently waiting for loadOptions to resolve
+   */
+  isLoading?: boolean
+}
 
 export interface GenericAsyncSelectComponentProps
   extends Omit<

--- a/packages/app-elements/tsconfig.json
+++ b/packages/app-elements/tsconfig.json
@@ -24,8 +24,7 @@
       "#providers/*": ["./src/providers/*"],
       "#styles/*": ["./src/styles/*"],
       "#ui/*": ["./src/ui/*"],
-      "#utils/*": ["./src/utils/*"],
-      "#node_modules/*": ["./node_modules/*"]
+      "#utils/*": ["./src/utils/*"]
     }
   },
   "include": ["vite.config.js", "src", "mocks"],


### PR DESCRIPTION
## What I did

I removed `#node_modules` path alias from tsconfig and added missing interface from react-select.

There was an imported interface in `InputSelect` that was not properly exposed by the library. We decided to copy it internally and remove the weird import statement.
```
"#node_modules/react-select/dist/declarations/src/useAsync"
```


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
