### PR TITLE
Integrate toast notifications for API error handling

### DIFF
--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -239,7 +239,7 @@ export {
   type TimelineEvent,
   type TimelineProps,
 } from "#ui/composite/Timeline"
-export { ToastContainer, toast } from "#ui/composite/Toast"
+export { isToastInitialized, ToastContainer, toast } from "#ui/composite/Toast"
 export {
   Toolbar,
   type ToolbarItem,

--- a/packages/app-elements/src/ui/composite/Toast.tsx
+++ b/packages/app-elements/src/ui/composite/Toast.tsx
@@ -1,5 +1,6 @@
 import classNames from "classnames"
 import type React from "react"
+import { useEffect } from "react"
 import {
   type Id,
   ToastContainer as OriginalToastContainer,
@@ -9,7 +10,20 @@ import {
 } from "react-toastify"
 import { Icon } from "#ui/atoms/Icon"
 
+// Function to check if toast is initialized
+export const isToastInitialized = (): boolean => {
+  return document.body.hasAttribute("data-toast-initialized")
+}
+
 export const ToastContainer = (): React.JSX.Element => {
+  // Add data attribute when component mounts
+  useEffect(() => {
+    document.body.setAttribute("data-toast-initialized", "true")
+    return () => {
+      document.body.removeAttribute("data-toast-initialized")
+    }
+  }, [])
+
   return (
     <OriginalToastContainer
       newestOnTop

--- a/packages/app-elements/src/ui/forms/ReactHookForm/setApiFormErrors.ts
+++ b/packages/app-elements/src/ui/forms/ReactHookForm/setApiFormErrors.ts
@@ -173,16 +173,15 @@ export function setApiFormErrors({
   })
 
   if (errorByTypes.others.length > 0) {
+    const message = errorByTypes.others.join(". ")
     if (isToastInitialized()) {
-      errorByTypes.others.forEach((message) => {
-        toast(message, {
-          type: "error",
-        })
+      toast(message, {
+        type: "error",
       })
     } else {
       setError(API_ERROR_FIELD_NAME, {
         type: "server",
-        message: errorByTypes.others.join(". "),
+        message,
       })
     }
   }

--- a/packages/app-elements/src/ui/forms/ReactHookForm/setApiFormErrors.ts
+++ b/packages/app-elements/src/ui/forms/ReactHookForm/setApiFormErrors.ts
@@ -1,4 +1,5 @@
 import type { UseFormSetError } from "react-hook-form"
+import { isToastInitialized, toast } from "#ui/composite/Toast"
 
 interface ApiError {
   /**
@@ -172,9 +173,17 @@ export function setApiFormErrors({
   })
 
   if (errorByTypes.others.length > 0) {
-    setError(API_ERROR_FIELD_NAME, {
-      type: "server",
-      message: errorByTypes.others.join(". "),
-    })
+    if (isToastInitialized()) {
+      errorByTypes.others.forEach((message) => {
+        toast(message, {
+          type: "error",
+        })
+      })
+    } else {
+      setError(API_ERROR_FIELD_NAME, {
+        type: "server",
+        message: errorByTypes.others.join(". "),
+      })
+    }
   }
 }


### PR DESCRIPTION
## What I did

- Improved Toast component with a new utils to check if the ToastContainer has been mounted in the app (when mounted it adds a data attribute to the body tag)
- If ToastContainer is mouted, `<HookedValidationApiError>` triggers a toast instead of showing inline error when a field is not matched from the api error response


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
