### PR TITLE
Add `useConfirmDialog` hook to show a confirmation modal for disruptive actions

### DIFF
--- a/packages/app-elements/src/helpers/errors.test.ts
+++ b/packages/app-elements/src/helpers/errors.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+import { parseApiError } from "./errors"
+
+// Build an error that match Core errors and satisfies CommerceLayerStatic.isApiError at runtime.
+function makeApiError(
+  message: string,
+  errors: any[],
+): Error & { errors: any[] } {
+  const err = Object.assign(new Error(message), {
+    name: "ApiError",
+    type: "response",
+    errors,
+  })
+  return err
+}
+
+describe("parseApiError", () => {
+  it("returns an empty array when err is null", () => {
+    expect(parseApiError(null)).toEqual([])
+  })
+
+  it("returns an empty array when err is undefined", () => {
+    expect(parseApiError(undefined)).toEqual([])
+  })
+
+  it("returns err.errors when err is a real ApiError with an errors array", () => {
+    const apiErrors = [
+      {
+        title: "Locked resource",
+        detail: "Failed to destroy SkuListItem with id=1286",
+        code: "LOCKED",
+        status: "423",
+      },
+      {
+        title: "Record Not Found",
+        detail:
+          "The requested resource was not not found. Please double-check the resource id.",
+        code: "RECORD_NOT_FOUND",
+        status: 404,
+      },
+    ]
+    const err = makeApiError("Unprocessable Entity", apiErrors)
+    const result = parseApiError(err)
+    expect(result).toEqual(apiErrors)
+  })
+
+  it("returns a generic error when err is a real ApiError but errors is not an array", () => {
+    const err = makeApiError("Something broke", null as any)
+    const result = parseApiError(err)
+    expect(result).toEqual([
+      {
+        code: "Generic error",
+        detail: "Something broke",
+        status: "500",
+        title: "Something broke",
+      },
+    ])
+  })
+
+  it("returns a generic error with message when err is a plain Error", () => {
+    const result = parseApiError(new Error("Network failure"))
+    expect(result).toEqual([
+      {
+        code: "Generic error",
+        detail: "Network failure",
+        status: "500",
+        title: "Network failure",
+      },
+    ])
+  })
+
+  it("returns the default fallback error when err has no message", () => {
+    const result = parseApiError({})
+    expect(result).toEqual([
+      {
+        code: "Generic error",
+        detail: "Something went wrong. Please try again.",
+        status: "500",
+        title: "Generic error",
+      },
+    ])
+  })
+
+  it("uses the custom fallback when provided and err has no message", () => {
+    const result = parseApiError({}, "Custom fallback message")
+    expect(result).toEqual([
+      {
+        code: "Generic error",
+        detail: "Custom fallback message",
+        status: "500",
+        title: "Generic error",
+      },
+    ])
+  })
+})

--- a/packages/app-elements/src/helpers/errors.ts
+++ b/packages/app-elements/src/helpers/errors.ts
@@ -1,0 +1,30 @@
+import { CommerceLayerStatic } from "@commercelayer/sdk"
+
+export interface ApiError {
+  code: string
+  detail: string
+  status: string
+  title: string
+}
+
+export function parseApiError(
+  err: any,
+  fallback: string = "Something went wrong. Please try again.",
+): ApiError[] {
+  if (err == null) {
+    return []
+  }
+
+  if (CommerceLayerStatic.isApiError(err) && Array.isArray(err.errors)) {
+    return err.errors
+  } else {
+    return [
+      {
+        code: "Generic error",
+        detail: err.message ?? fallback,
+        status: "500",
+        title: err.message ?? "Generic error",
+      },
+    ]
+  }
+}

--- a/packages/app-elements/src/hooks/useConfirmDialog.tsx
+++ b/packages/app-elements/src/hooks/useConfirmDialog.tsx
@@ -1,0 +1,170 @@
+import { type FC, useCallback, useState } from "react"
+import { parseApiError } from "#helpers/errors"
+import { Button, type ButtonProps } from "#ui/atoms/Button"
+import { Icon, type IconProps } from "#ui/atoms/Icon"
+import { Text } from "#ui/atoms/Text"
+import { Modal } from "#ui/composite/Modal"
+import { toast } from "#ui/composite/Toast"
+
+interface ConfirmDialogConfirmProps {
+  /** Label for the confirm button */
+  label: string
+  /** Button variant. Use `"danger"` for destructive actions and `"primary"` for generic confirmations. */
+  variant?: ButtonProps["variant"]
+  /** Async action to execute on confirm */
+  onClick: () => Promise<unknown>
+}
+
+interface ConfirmDialogProps {
+  /** Controls visibility of the dialog */
+  show: boolean
+  /** Called when the dialog should close */
+  onClose: () => void
+  /** Icon name to display at the top of the dialog (from the Icon component set) */
+  icon: IconProps["name"]
+  /** Main title shown in the dialog body. */
+  title: string
+  /** Optional extra content rendered below the title. */
+  description?: React.ReactNode
+  /** Configuration for the confirm (primary action) button */
+  confirm: ConfirmDialogConfirmProps
+  /**
+   * Message shown in the error toast when `confirm.onClick` rejects and overrides the API errors.
+   */
+  errorMessage?: string
+  /** Optional success message shown when the action completes successfully */
+  successMessage?: string
+}
+
+/**
+ * Blocking confirmation dialog built on top of `Modal`.
+ * The user can only interact via the confirm or cancel buttons — backdrop clicks and
+ * Escape key are disabled. Both buttons are disabled while the async confirm action
+ * is pending. On error the dialog closes and an error toast is shown automatically.
+ */
+const ConfirmDialog: FC<ConfirmDialogProps> = ({
+  show,
+  onClose,
+  icon,
+  title,
+  description,
+  confirm,
+  errorMessage,
+  successMessage,
+}) => {
+  const [isPending, setIsPending] = useState(false)
+
+  const handleConfirm = async (): Promise<void> => {
+    if (isPending) return
+    setIsPending(true)
+    try {
+      await confirm.onClick()
+      if (successMessage) {
+        toast(successMessage, { type: "success" })
+      }
+    } catch (err) {
+      const parsedMessage = parseApiError(err)
+        .map((e) => e.detail)
+        .join(". ")
+      const msg =
+        errorMessage ?? (parsedMessage.trim() || "Something went wrong")
+      toast(msg, { type: "error" })
+    } finally {
+      setIsPending(false)
+      onClose()
+    }
+  }
+
+  const handleCancel = (): void => {
+    if (isPending) return
+    onClose()
+  }
+
+  return (
+    <Modal show={show} onClose={onClose} size="x-small">
+      <Modal.Body>
+        <div className="flex flex-col items-center text-center">
+          <Icon name={icon} size={32} className="mt-3.5 mb-4 text-gray-400" />
+          <Text weight="medium" className="text-balance">
+            {title}
+          </Text>
+          <Text variant="info" size="small">
+            {description}
+          </Text>
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button
+          variant={confirm.variant ?? "primary"}
+          onClick={() => void handleConfirm()}
+          disabled={isPending}
+          fullWidth
+        >
+          {confirm.label}
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={handleCancel}
+          disabled={isPending}
+          fullWidth
+        >
+          Cancel
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  )
+}
+
+type ConfirmDialogRendererProps = Omit<ConfirmDialogProps, "show" | "onClose">
+
+interface ConfirmDialogHook {
+  /**
+   * Opens the dialog.
+   */
+  show: () => void
+  /**
+   * The dialog renderer. Mount it in your component tree and pass it the
+   * `icon`, `title`, `description`, `confirm` (and optional `errorMessage`) props.
+   * Visibility is fully managed by the hook — you only need to call `show()`.
+   *
+   * @example
+   * const { show, ConfirmDialog } = useConfirmDialog()
+   *
+   * return (
+   *     <>
+   *       <Button onClick={show}>Delete</Button>
+   *       <ConfirmDialog
+   *        icon="trash"
+   *        title="Delete item"
+   *        description="Are you sure you want to delete this item?"
+   *        confirm={{ label: "Delete", variant: "danger", onClick: handleDelete }}
+   *       />
+   *     </>
+   * )
+   */
+  ConfirmDialog: FC<ConfirmDialogRendererProps>
+}
+
+export function useConfirmDialog(): ConfirmDialogHook {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => {
+    setIsOpen(true)
+  }, [])
+
+  const close = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  const ConfirmDialogRenderer = useCallback<FC<ConfirmDialogRendererProps>>(
+    (props) => {
+      return <ConfirmDialog {...props} show={isOpen} onClose={close} />
+    },
+    [isOpen, close],
+  )
+
+  return {
+    show: open,
+    ConfirmDialog: ConfirmDialogRenderer,
+  }
+}

--- a/packages/app-elements/src/main.ts
+++ b/packages/app-elements/src/main.ts
@@ -47,6 +47,7 @@ export {
   timeSeparator,
 } from "#helpers/date"
 export { downloadJsonAsFile } from "#helpers/downloadJsonAsFile"
+export { type ApiError, parseApiError } from "#helpers/errors"
 export { maskGiftCardCode } from "#helpers/giftCards"
 export { isMock, isMockedId } from "#helpers/mocks"
 export { computeFullname, formatDisplayName } from "#helpers/name"
@@ -76,6 +77,7 @@ export {
 export { useAppLinking } from "#helpers/useAppLinking"
 // Hooks
 export { useClickAway } from "#hooks/useClickAway"
+export { useConfirmDialog } from "#hooks/useConfirmDialog"
 export { useDelayShow } from "#hooks/useDelayShow"
 export { useEditMetadataOverlay } from "#hooks/useEditMetadataOverlay"
 export { useEditTagsOverlay } from "#hooks/useEditTagsOverlay"

--- a/packages/docs/src/stories/hooks/useConfirmDialog.stories.tsx
+++ b/packages/docs/src/stories/hooks/useConfirmDialog.stories.tsx
@@ -1,0 +1,149 @@
+import {
+  Description,
+  Primary,
+  Stories,
+  Subtitle,
+  Title,
+} from "@storybook/addon-docs/blocks"
+import type { Meta, StoryFn } from "@storybook/react-vite"
+import { useConfirmDialog } from "#hooks/useConfirmDialog"
+import { Button } from "#ui/atoms/Button"
+import { ToastContainer } from "#ui/composite/Toast"
+
+/**
+ * Hook that returns a blocking confirmation dialog along with a `show()` method to open it.
+ * Visibility is fully managed internally — the dialog can only be dismissed via the confirm
+ * or cancel buttons (backdrop click and Escape key are disabled).
+ *
+ * The confirm action is an async function; both buttons are disabled while it is pending.
+ * If the async action rejects, an error toast is shown automatically and the dialog closes.
+ *
+ * Example usage:
+ * ```tsx
+ * const { show, ConfirmDialog } = useConfirmDialog()
+ *
+ * return (
+ *   <>
+ *     <Button onClick={show}>Delete</Button>
+ *     <ConfirmDialog
+ *       icon="trash"
+ *       title="Delete item"
+ *       description="Are you sure you want to delete this item?"
+ *       confirm={{ label: "Delete", variant: "danger", onClick: handleDelete }}
+ *     />
+ *   </>
+ * )
+ * ```
+ */
+const setup: Meta = {
+  title: "Hooks/useConfirmDialog",
+  args: {},
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      page: () => (
+        <>
+          <Title />
+          <Subtitle />
+          <Description />
+          <ToastContainer />
+          <Primary />
+          <Stories includePrimary={false} />
+        </>
+      ),
+      source: {
+        type: "code",
+      },
+    },
+  },
+}
+export default setup
+
+/**
+ * Delete confirmation dialog. Use `variant="danger"` for destructive actions.
+ */
+export const DeleteAction: StoryFn = () => {
+  const { show, ConfirmDialog } = useConfirmDialog()
+
+  return (
+    <div>
+      <Button variant="danger" onClick={show}>
+        Delete item
+      </Button>
+      <ConfirmDialog
+        icon="trash"
+        title="Delete promotion Welcome Discount 10?"
+        description="This action can’t be undone."
+        confirm={{
+          label: "Delete",
+          variant: "danger",
+          onClick: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+          },
+        }}
+        successMessage="Promotion deleted!"
+      />
+    </div>
+  )
+}
+
+/**
+ * Confirm action dialog. Use `variant="primary"` (the default) for non-destructive confirmations.
+ */
+export const ConfirmAction: StoryFn = () => {
+  const { show, ConfirmDialog } = useConfirmDialog()
+
+  return (
+    <div>
+      <Button onClick={show}>Capture payment</Button>
+      <ConfirmDialog
+        icon="check"
+        title="Do you want to capture the payment of $100.00 for order #12345?"
+        confirm={{
+          label: "Capture",
+          variant: "primary",
+          onClick: async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1500))
+          },
+        }}
+        successMessage="Payment captured!"
+      />
+    </div>
+  )
+}
+
+/**
+ * When the async confirm action rejects, the dialog closes and an error toast is shown.
+ * A custom `errorMessage` can be provided — either a static string or a function receiving
+ * the caught error.
+ */
+export const AsyncError: StoryFn = () => {
+  const { show, ConfirmDialog } = useConfirmDialog()
+
+  return (
+    <div>
+      <Button onClick={show}>Trigger failing action</Button>
+      <ConfirmDialog
+        icon="warning"
+        title="Confirm action"
+        description="This action will fail. Confirm to see the error toast."
+        confirm={{
+          label: "Confirm",
+          variant: "primary",
+          onClick: async () => {
+            await new Promise((_, reject) =>
+              setTimeout(() => reject(new Error("Server error")), 1500),
+            )
+          },
+        }}
+        errorMessage="This is a custom error message."
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
Related to commercelayer/issues-app#588

## Summary

Introduces a reusable hook (`useConfirmDialog`), designed for delete and confirm flows that must prevent any other interaction until the user explicitly chooses.

I've also moved the `parseApiError` helpers from dashboard-apps to elements to be reused inside the new `ConfirmDialog`

---
**Behaviour:**
- Backdrop click and Escape are disabled — only Confirm/Cancel can dismiss
- Both buttons are disabled while the async confirm is in-flight
- Always closes on settle (success or error)
- On error: fires an `error` toast then closes

### `useModalDialog` (new hook)
Follows the existing `useOverlay` family convention.

```tsx
const { show, ConfirmDialog } = useConfirmDialog()

return (
  <>
    <Button onClick={show}>Delete</Button>
    <ConfirmDialog
      icon="trash"
      title="Delete item"
      description="Are you sure? This cannot be undone."
      confirm={{ label: "Delete", variant: "danger", onClick: handleDelete }}
    />
  </>
)
```
