### PR TITLE
Allow to handle manual tracking number on ResourceShipmentParcel

### DIFF
--- a/packages/app-elements/src/ui/atoms/Steps.test.tsx
+++ b/packages/app-elements/src/ui/atoms/Steps.test.tsx
@@ -47,12 +47,12 @@ describe("Steps", () => {
       />,
     )
 
-    expect(getByText("Step 1").previousSibling).toHaveClass("bg-primary")
+    expect(getByText("Step 1").previousSibling).toHaveClass("bg-brand")
     expect(getByText("Step 1").previousSibling).not.toHaveClass(
       "after:bg-white",
     )
     expect(getByText("Step 2").previousSibling).toHaveClass(
-      "bg-primary after:bg-white",
+      "bg-brand after:bg-white",
     )
     expect(getByText("Step 3").previousSibling).toHaveClass("bg-gray-100")
     expect(getByText("Step 3").previousSibling).not.toHaveClass(
@@ -71,12 +71,12 @@ describe("Steps", () => {
       />,
     )
 
-    expect(getByText("Step 1").previousSibling).toHaveClass("bg-primary")
+    expect(getByText("Step 1").previousSibling).toHaveClass("bg-brand")
     expect(getByText("Step 1").previousSibling).not.toHaveClass(
       "after:bg-white",
     )
     expect(getByText("Step 2").previousSibling).toHaveClass(
-      "bg-primary after:bg-white",
+      "bg-brand after:bg-white",
     )
     expect(getByText("Step 3").previousSibling).toHaveClass("bg-gray-100")
     expect(getByText("Step 3").previousSibling).not.toHaveClass(

--- a/packages/app-elements/src/ui/atoms/Steps.tsx
+++ b/packages/app-elements/src/ui/atoms/Steps.tsx
@@ -40,7 +40,7 @@ export const Steps: React.FC<StepsProps> = ({ steps }) => {
       }}
       className={cn(
         "flex justify-between text-xs w-full items-center rounded",
-        `h-2 mb-8 bg-linear-to-r from-gray-100 from-50% to-primary to-50% bg-size-[200%]`,
+        `h-2 mb-8 bg-linear-to-r from-gray-100 from-50% to-brand to-50% bg-size-[200%]`,
       )}
     >
       {steps.map(fixActive).map((step, index) => {
@@ -67,7 +67,7 @@ export const Steps: React.FC<StepsProps> = ({ steps }) => {
               className={cn(
                 "w-6 h-6 rounded-full flex justify-center items-center",
                 {
-                  "bg-primary": step.active === true,
+                  "bg-brand": step.active === true,
                   "bg-gray-100": step.active !== true,
                   "after:bg-white after:w-3 after:h-3 after:block after:rounded-full":
                     activePosition === "active",

--- a/packages/app-elements/src/ui/atoms/__snapshots__/Steps.test.tsx.snap
+++ b/packages/app-elements/src/ui/atoms/__snapshots__/Steps.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Steps > Should be rendered 1`] = `
 <div>
   <ul
-    class="flex justify-between text-xs w-full items-center rounded h-2 mb-8 bg-linear-to-r from-gray-100 from-50% to-primary to-50% bg-size-[200%]"
+    class="flex justify-between text-xs w-full items-center rounded h-2 mb-8 bg-linear-to-r from-gray-100 from-50% to-brand to-50% bg-size-[200%]"
   >
     <li
       class="relative text-gray-300 font-medium"

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
@@ -455,7 +455,7 @@ export const shipmentWithSingleParcelSingleTracking = createShipment({
 
 export const shipmentWithSingleParcelSingleTrackingNoCarrier = createShipment({
   id: "shipment-with-single-parcel-single-tracking",
-  status: "ready_to_ship",
+  status: "packing",
   purchaseStartedAt: "2023-07-11",
   selectedRateId: "rate_dhl_1111",
   parcels: [
@@ -473,10 +473,20 @@ export const shipmentWithNoCarrierAndManualShipping = createShipment({
   purchaseStartedAt: null,
   selectedRateId: undefined,
   parcels: [
+    // existing tracking number (can be updated)
     {
       ...parcelWithTracking1,
       tracking_details: [],
-      // tracking_status: "delivered",
+      tracking_status: undefined,
+      shipping_label_url: undefined,
+    },
+    // no tracking number (can be added)
+    {
+      ...parcelWithTracking2,
+      tracking_details: [],
+      tracking_status: undefined,
+      tracking_number: undefined,
+      shipping_label_url: undefined,
     },
   ],
 })

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.mocks.tsx
@@ -455,7 +455,7 @@ export const shipmentWithSingleParcelSingleTracking = createShipment({
 
 export const shipmentWithSingleParcelSingleTrackingNoCarrier = createShipment({
   id: "shipment-with-single-parcel-single-tracking",
-  status: "packing",
+  status: "ready_to_ship",
   purchaseStartedAt: "2023-07-11",
   selectedRateId: "rate_dhl_1111",
   parcels: [
@@ -463,6 +463,20 @@ export const shipmentWithSingleParcelSingleTrackingNoCarrier = createShipment({
       ...parcelWithTracking1,
       tracking_details: [],
       tracking_status: "delivered",
+    },
+  ],
+})
+
+export const shipmentWithNoCarrierAndManualShipping = createShipment({
+  id: "shipment-with-no-carrier-and-manual-shipping",
+  status: "ready_to_ship",
+  purchaseStartedAt: null,
+  selectedRateId: undefined,
+  parcels: [
+    {
+      ...parcelWithTracking1,
+      tracking_details: [],
+      // tracking_status: "delivered",
     },
   ],
 })

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -74,6 +74,8 @@ export const ResourceShipmentParcels =
             const allowManualTrackingNumber =
               !hasBeenPurchased(shipment) &&
               isEmpty(parcel.tracking_status) &&
+              isEmpty(parcel.tracking_details) &&
+              !hasCarrier &&
               (shipment.status === "ready_to_ship" ||
                 shipment.status === "shipped" ||
                 shipment.status === "delivered")
@@ -84,9 +86,7 @@ export const ResourceShipmentParcels =
                 rate={rate}
                 showEstimatedDelivery={!singleTracking}
                 onTrackingNumberUpdate={
-                  allowManualTrackingNumber && onTrackingNumberUpdate != null
-                    ? onTrackingNumberUpdate
-                    : undefined
+                  allowManualTrackingNumber ? onTrackingNumberUpdate : undefined
                 }
                 parcel={
                   singleTracking && hasCarrier
@@ -280,7 +280,6 @@ const Tracking = withSkeletonTemplate<{
   parcel: ParcelResource
   rate?: Rate
   showEstimatedDelivery: boolean
-  allowTrackingNumberUpdate?: boolean
   onTrackingNumberUpdate?: OnTrackingNumberUpdate
 }>(
   ({ parcel, rate, showEstimatedDelivery = false, onTrackingNumberUpdate }) => {
@@ -375,9 +374,12 @@ const AddTrackingNumberModal: FC<{
             disabled={isUpdating}
             onClick={async () => {
               setIsUpdating(true)
-              await onTrackingNumberUpdate(parcel.id, trackingNumber)
-              setIsUpdating(false)
-              setShow(false)
+              try {
+                await onTrackingNumberUpdate(parcel.id, trackingNumber)
+              } finally {
+                setShow(false)
+                setIsUpdating(false)
+              }
             }}
           >
             Save

--- a/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceShipmentParcels.tsx
@@ -5,7 +5,7 @@ import type {
 import { FileIcon, PackageIcon } from "@phosphor-icons/react"
 import cn from "classnames"
 import isEmpty from "lodash-es/isEmpty"
-import { useMemo } from "react"
+import { type FC, useMemo, useState } from "react"
 import type { SetNonNullable, SetRequired } from "type-fest"
 import {
   getAvatarSrcFromRate,
@@ -25,6 +25,8 @@ import { Spacer } from "#ui/atoms/Spacer"
 import { StatusIcon } from "#ui/atoms/StatusIcon"
 import { Text } from "#ui/atoms/Text"
 import { CardDialog } from "#ui/composite/CardDialog"
+import { Modal } from "#ui/composite/Modal"
+import { Input } from "#ui/forms/Input"
 import { FlexRow } from "#ui/internals/FlexRow"
 import { ResourceLineItems } from "./ResourceLineItems"
 import { useTrackingDetails } from "./useTrackingDetails"
@@ -33,6 +35,11 @@ type SetNonNullableRequired<
   BaseType,
   Keys extends keyof BaseType,
 > = SetRequired<SetNonNullable<BaseType, Keys>, Keys>
+
+type OnTrackingNumberUpdate = (
+  parcelId: string,
+  trackingNumber: string,
+) => Promise<void>
 
 function hasPackage(
   parcel: ParcelResource,
@@ -43,11 +50,12 @@ function hasPackage(
 export interface ResourceShipmentParcelsProps {
   shipment: ShipmentResource
   onRemoveParcel?: (parcelId: string) => void
+  onTrackingNumberUpdate?: OnTrackingNumberUpdate
 }
 
 export const ResourceShipmentParcels =
   withSkeletonTemplate<ResourceShipmentParcelsProps>(
-    ({ shipment, onRemoveParcel }) => {
+    ({ shipment, onRemoveParcel, onTrackingNumberUpdate }) => {
       const singleTracking = hasSingleTracking(shipment)
       const rate = getShipmentRate(shipment)
       const hasCarrier = rate != null
@@ -63,11 +71,23 @@ export const ResourceShipmentParcels =
               return null
             }
 
+            const allowManualTrackingNumber =
+              !hasBeenPurchased(shipment) &&
+              isEmpty(parcel.tracking_status) &&
+              (shipment.status === "ready_to_ship" ||
+                shipment.status === "shipped" ||
+                shipment.status === "delivered")
+
             return (
               <Parcel
                 key={parcel.id}
                 rate={rate}
                 showEstimatedDelivery={!singleTracking}
+                onTrackingNumberUpdate={
+                  allowManualTrackingNumber && onTrackingNumberUpdate != null
+                    ? onTrackingNumberUpdate
+                    : undefined
+                }
                 parcel={
                   singleTracking && hasCarrier
                     ? {
@@ -106,56 +126,67 @@ const Parcel = withSkeletonTemplate<{
   rate?: Rate
   showEstimatedDelivery?: boolean
   onRemove?: () => void
-}>(({ parcel, rate, showEstimatedDelivery = false, onRemove }) => {
-  const { t } = useTranslation()
-  const itemsLength =
-    parcel.parcel_line_items?.reduce((sum, item) => sum + item.quantity, 0) ?? 0
+  onTrackingNumberUpdate?: OnTrackingNumberUpdate
+}>(
+  ({
+    parcel,
+    rate,
+    showEstimatedDelivery = false,
+    onRemove,
+    onTrackingNumberUpdate,
+  }) => {
+    const { t } = useTranslation()
+    const itemsLength =
+      parcel.parcel_line_items?.reduce((sum, item) => sum + item.quantity, 0) ??
+      0
 
-  return (
-    <CardDialog
-      data-testid={`parcel-box-${parcel.id}`}
-      onClose={onRemove}
-      title={parcel.package.name}
-      icon={<PackageIcon size={42} className="text-gray-300" weight="thin" />}
-      footer={
-        parcel.shipping_label_url == null ? undefined : (
-          <PrintLabel href={parcel.shipping_label_url} />
-        )
-      }
-    >
-      {parcel.parcel_line_items != null && (
-        <ResourceLineItems items={parcel.parcel_line_items} size="small" />
-      )}
-      <Spacer top="6">
-        <Text size="small">
-          <FlexRow>
-            <Text variant="info">{t("common.parcel_total")}</Text>
-            <Text weight="semibold">
-              {t("apps.shipments.details.parcel_item", {
-                count: itemsLength,
-              })}
-            </Text>
-          </FlexRow>
-          <Spacer top="4">
+    return (
+      <CardDialog
+        data-testid={`parcel-box-${parcel.id}`}
+        onClose={onRemove}
+        title={parcel.package.name}
+        icon={<PackageIcon size={42} className="text-gray-300" weight="thin" />}
+        footer={
+          parcel.shipping_label_url == null ? undefined : (
+            <PrintLabel href={parcel.shipping_label_url} />
+          )
+        }
+      >
+        {parcel.parcel_line_items != null && (
+          <ResourceLineItems items={parcel.parcel_line_items} size="small" />
+        )}
+        <Spacer top="6">
+          <Text size="small">
             <FlexRow>
-              <Text variant="info">{t("common.parcel_weight")}</Text>
+              <Text variant="info">{t("common.parcel_total")}</Text>
               <Text weight="semibold">
-                {parcel.weight} {parcel.unit_of_weight}
+                {t("apps.shipments.details.parcel_item", {
+                  count: itemsLength,
+                })}
               </Text>
             </FlexRow>
-          </Spacer>
-          <Tracking
-            parcel={parcel}
-            rate={rate}
-            showEstimatedDelivery={showEstimatedDelivery}
-          />
-          <Attachments parcel={parcel} />
-          <CustomsInfo parcel={parcel} />
-        </Text>
-      </Spacer>
-    </CardDialog>
-  )
-})
+            <Spacer top="4">
+              <FlexRow>
+                <Text variant="info">{t("common.parcel_weight")}</Text>
+                <Text weight="semibold">
+                  {parcel.weight} {parcel.unit_of_weight}
+                </Text>
+              </FlexRow>
+            </Spacer>
+            <Tracking
+              parcel={parcel}
+              rate={rate}
+              showEstimatedDelivery={showEstimatedDelivery}
+              onTrackingNumberUpdate={onTrackingNumberUpdate}
+            />
+            <Attachments parcel={parcel} />
+            <CustomsInfo parcel={parcel} />
+          </Text>
+        </Spacer>
+      </CardDialog>
+    )
+  },
+)
 
 const Carrier = withSkeletonTemplate<{
   shipment: ShipmentResource
@@ -233,9 +264,10 @@ const Attachments = withSkeletonTemplate<{
               href={attachment.url ?? ""}
               target="_blank"
               rel="noopener"
-              className="flex items-center gap-1"
             >
-              <FileIcon weight="bold" /> {attachment.name}
+              <div className="flex items-center gap-1">
+                <FileIcon weight="bold" /> {attachment.name}
+              </div>
             </A>
           ))}
         </div>
@@ -248,55 +280,118 @@ const Tracking = withSkeletonTemplate<{
   parcel: ParcelResource
   rate?: Rate
   showEstimatedDelivery: boolean
-}>(({ parcel, rate, showEstimatedDelivery = false }) => {
-  const trackingDetails = getParcelTrackingDetail(parcel)
-  const { TrackingDetailsModal, openTrackingDetails } = useTrackingDetails(
-    parcel,
-    rate,
-  )
+  allowTrackingNumberUpdate?: boolean
+  onTrackingNumberUpdate?: OnTrackingNumberUpdate
+}>(
+  ({ parcel, rate, showEstimatedDelivery = false, onTrackingNumberUpdate }) => {
+    const trackingDetails = getParcelTrackingDetail(parcel)
+    const { TrackingDetailsModal, openTrackingDetails } = useTrackingDetails(
+      parcel,
+      rate,
+    )
 
+    return (
+      <>
+        <TrackingDetailsModal />
+        {trackingDetails?.status != null ? (
+          <FlexRow className="mt-4">
+            <Text variant="info">{t("common.status")}</Text>
+            <Text weight="semibold">{trackingDetails.status}</Text>
+          </FlexRow>
+        ) : parcel.tracking_status != null ? (
+          <FlexRow className="mt-4">
+            <Text variant="info">{t("common.status")}</Text>
+            <Text weight="semibold">{parcel.tracking_status}</Text>
+          </FlexRow>
+        ) : null}
+        {onTrackingNumberUpdate == null && parcel.tracking_number != null ? (
+          <FlexRow className="mt-4">
+            <Text variant="info">{t("common.tracking")}</Text>
+            <Text weight="semibold">
+              {trackingDetails != null ? (
+                <Button
+                  variant="link"
+                  onClick={() => {
+                    openTrackingDetails()
+                  }}
+                >
+                  {parcel.tracking_number}
+                </Button>
+              ) : (
+                parcel.tracking_number
+              )}
+            </Text>
+          </FlexRow>
+        ) : onTrackingNumberUpdate != null ? (
+          <FlexRow className="mt-4">
+            <Text variant="info">{t("common.tracking")}</Text>
+            <Text>
+              <AddTrackingNumberModal
+                parcel={parcel}
+                onTrackingNumberUpdate={onTrackingNumberUpdate}
+              />
+            </Text>
+          </FlexRow>
+        ) : null}
+        {showEstimatedDelivery && rate?.formatted_delivery_date != null && (
+          <FlexRow className="mt-4">
+            <Text variant="info">{t("common.estimated_delivery")}</Text>
+            <Text weight="semibold">{rate.formatted_delivery_date}</Text>
+          </FlexRow>
+        )}
+      </>
+    )
+  },
+)
+
+const AddTrackingNumberModal: FC<{
+  parcel: ParcelResource
+  onTrackingNumberUpdate: OnTrackingNumberUpdate
+}> = ({ parcel, onTrackingNumberUpdate }) => {
+  const [show, setShow] = useState(false)
+  const [isUpdating, setIsUpdating] = useState(false)
+  const [trackingNumber, setTrackingNumber] = useState(
+    parcel.tracking_number ?? "",
+  )
   return (
     <>
-      <TrackingDetailsModal />
-      {trackingDetails?.status != null ? (
-        <FlexRow className="mt-4">
-          <Text variant="info">{t("common.status")}</Text>
-          <Text weight="semibold">{trackingDetails.status}</Text>
-        </FlexRow>
-      ) : parcel.tracking_status != null ? (
-        <FlexRow className="mt-4">
-          <Text variant="info">{t("common.status")}</Text>
-          <Text weight="semibold">{parcel.tracking_status}</Text>
-        </FlexRow>
-      ) : null}
-      {parcel.tracking_number != null && (
-        <FlexRow className="mt-4">
-          <Text variant="info">{t("common.tracking")}</Text>
-          <Text weight="semibold">
-            {trackingDetails != null ? (
-              <Button
-                variant="link"
-                onClick={() => {
-                  openTrackingDetails()
-                }}
-              >
-                {parcel.tracking_number}
-              </Button>
-            ) : (
-              parcel.tracking_number
-            )}
-          </Text>
-        </FlexRow>
-      )}
-      {showEstimatedDelivery && rate?.formatted_delivery_date != null && (
-        <FlexRow className="mt-4">
-          <Text variant="info">{t("common.estimated_delivery")}</Text>
-          <Text weight="semibold">{rate.formatted_delivery_date}</Text>
-        </FlexRow>
-      )}
+      <Modal show={show} onClose={() => setShow(false)}>
+        <Modal.Header>Tracking information</Modal.Header>
+        <Modal.Body>
+          <Input
+            label="Tracking number"
+            value={trackingNumber}
+            onChange={(e) => setTrackingNumber(e.target.value)}
+            hint={{
+              text: "Insert tracking number from your carrier.",
+            }}
+          />
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            type="button"
+            variant="primary"
+            fullWidth
+            disabled={isUpdating}
+            onClick={async () => {
+              setIsUpdating(true)
+              await onTrackingNumberUpdate(parcel.id, trackingNumber)
+              setIsUpdating(false)
+              setShow(false)
+            }}
+          >
+            Save
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      <Button variant="link" onClick={() => setShow(true)}>
+        {isEmpty(parcel.tracking_number)
+          ? "Add tracking"
+          : parcel.tracking_number}
+      </Button>
     </>
   )
-})
+}
 
 const PrintLabel = withSkeletonTemplate<{ href: string }>(({ href }) => {
   return (

--- a/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
+++ b/packages/app-elements/src/ui/resources/useTrackingDetails.tsx
@@ -87,27 +87,29 @@ const TrackingDetails = withSkeletonTemplate<{
 
   return (
     <>
-      <Steps
-        steps={[
-          {
-            label: t("common.tracking_details.tracking_pre_transit"),
-            active: lastEvent?.tracking.status === "pre_transit",
-          },
-          {
-            label: t("common.tracking_details.tracking_in_transit"),
-            active: lastEvent?.tracking.status === "in_transit",
-          },
-          {
-            label: t("common.tracking_details.tracking_out_for_delivery"),
-            active: lastEvent?.tracking.status === "out_for_delivery",
-          },
-          {
-            label: t("common.tracking_details.tracking_delivered"),
-            active: lastEvent?.tracking.status === "delivered",
-          },
-        ]}
-      />
-      <Spacer top="12" bottom="14">
+      <div className="pt-10 pb-14">
+        <Steps
+          steps={[
+            {
+              label: t("common.tracking_details.tracking_pre_transit"),
+              active: lastEvent?.tracking.status === "pre_transit",
+            },
+            {
+              label: t("common.tracking_details.tracking_in_transit"),
+              active: lastEvent?.tracking.status === "in_transit",
+            },
+            {
+              label: t("common.tracking_details.tracking_out_for_delivery"),
+              active: lastEvent?.tracking.status === "out_for_delivery",
+            },
+            {
+              label: t("common.tracking_details.tracking_delivered"),
+              active: lastEvent?.tracking.status === "delivered",
+            },
+          ]}
+        />
+      </div>
+      <Spacer bottom="14">
         <Stack>
           <div>
             <Spacer bottom="2">

--- a/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
@@ -6,6 +6,7 @@ import {
   shipmentWithCustomsInfo,
   shipmentWithMultipleParcelsMultipleTrackings,
   shipmentWithMultipleParcelsSingleTracking,
+  shipmentWithNoCarrierAndManualShipping,
   shipmentWithoutParcels,
   shipmentWithoutTracking,
   shipmentWithoutTrackingDetails,
@@ -96,6 +97,19 @@ SingleParcelSingleTrackingWithoutCarrier.args = {
     alert(`removed parcel "${parcelId}"`)
   },
   shipment: shipmentWithSingleParcelSingleTrackingNoCarrier,
+}
+
+/**
+ * Shipment can be handled manually without purchasing a label and tracking information can be added or updated manually.
+ */
+export const SingleParcelManualTracking: StoryFn<
+  typeof ResourceShipmentParcels
+> = (args): JSX.Element => <ResourceShipmentParcels {...args} />
+SingleParcelManualTracking.args = {
+  onRemoveParcel: (parcelId) => {
+    alert(`removed parcel "${parcelId}"`)
+  },
+  shipment: shipmentWithNoCarrierAndManualShipping,
 }
 
 /**

--- a/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
+++ b/packages/docs/src/stories/resources/ResourceShipmentParcels.stories.tsx
@@ -102,12 +102,17 @@ SingleParcelSingleTrackingWithoutCarrier.args = {
 /**
  * Shipment can be handled manually without purchasing a label and tracking information can be added or updated manually.
  */
-export const SingleParcelManualTracking: StoryFn<
+export const ParcelsWithManualTracking: StoryFn<
   typeof ResourceShipmentParcels
 > = (args): JSX.Element => <ResourceShipmentParcels {...args} />
-SingleParcelManualTracking.args = {
+ParcelsWithManualTracking.args = {
   onRemoveParcel: (parcelId) => {
     alert(`removed parcel "${parcelId}"`)
+  },
+  onTrackingNumberUpdate: async (parcelId, trackingNumber) => {
+    alert(
+      `updated tracking number for parcel "${parcelId}" with "${trackingNumber}"`,
+    )
   },
   shipment: shipmentWithNoCarrierAndManualShipping,
 }


### PR DESCRIPTION
Related to commercelayer/issues-app#451

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did


If a shipment is manually marked as ready to ship, shipped, or delivered without a carrier or a shipping label purchased through EasyPost, an “Add tracking” button is displayed to allow the tracking number to be added manually.

Manually added tracking numbers can always be updated, as long as the shipment still meets the required criteria.

```
const allowManualTrackingNumber =
  !hasBeenPurchased(shipment) &&
  isEmpty(parcel.tracking_status) &&
  isEmpty(parcel.tracking_details) &&
  !hasCarrier &&
  (shipment.status === "ready_to_ship" ||
    shipment.status === "shipped" ||
    shipment.status === "delivered")
```
https://deploy-preview-1107--commercelayer-app-elements.netlify.app/?path=/docs/resources-resourceshipmentparcels--docs#parcels-with-manual-tracking

<img width="714" height="617" alt="image" src="https://github.com/user-attachments/assets/03ca8500-5181-401b-bac1-64ab7c544b67" />


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
