### PR TITLE
Add icons support to Toolbar > dropdown items

### DIFF
--- a/packages/app-elements/src/ui/composite/Toolbar.tsx
+++ b/packages/app-elements/src/ui/composite/Toolbar.tsx
@@ -58,6 +58,7 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
               // biome-ignore lint/suspicious/noArrayIndexKey: Using index as key is acceptable here since the list is static and does not change.
               key={`dropdown-${gidx}-${idx}`}
               label={dropdownItem.label}
+              icon={dropdownItem.icon}
               className={dropdownItem.className}
               onClick={dropdownItemHandleClick}
               data-testid="toolbar-dropdown-item"
@@ -81,7 +82,6 @@ export const Toolbar = withSkeletonTemplate<ToolbarProps>(({ items }) => {
                 variant={item.variant}
                 disabled={item.disabled}
                 onClick={handleClick}
-                alignItems="center"
                 className={item.className}
                 data-testid="toolbar-dropdown-button"
               >

--- a/packages/docs/src/stories/composite/Toolbar.stories.tsx
+++ b/packages/docs/src/stories/composite/Toolbar.stories.tsx
@@ -47,18 +47,21 @@ Simple.args = {
         [
           {
             label: "Edit",
+            icon: "pencilSimple",
             onClick: () => {
               console.log("Edit")
             },
           },
           {
             label: "Set metadata",
+            icon: "treeView",
             onClick: () => {
               console.log("Set metadata")
             },
           },
           {
             label: "Disabled item",
+            icon: "eyeSlash",
             disabled: true,
             onClick: () => {
               console.log("Cannot click me")
@@ -68,6 +71,7 @@ Simple.args = {
         [
           {
             label: "Delete",
+            icon: "trash",
             onClick: () => {
               console.log("Delete")
             },


### PR DESCRIPTION
Closes #1109

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Now icons in toolbar dropdown are properly rendered.
<img width="300" height="219" alt="image" src="https://github.com/user-attachments/assets/2f2ae5c9-71a3-4928-8548-508e08cd4737" />



## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
