### PR TITLE
Add `successVariant` prop to ConfirmDialog for customizable toast types

### DIFF
--- a/packages/app-elements/src/hooks/useConfirmDialog.tsx
+++ b/packages/app-elements/src/hooks/useConfirmDialog.tsx
@@ -34,6 +34,10 @@ interface ConfirmDialogProps {
   errorMessage?: string
   /** Optional success message shown when the action completes successfully */
   successMessage?: string
+  /**
+   * Toast variant used for the success message. Defaults to `"default"`.
+   */
+  successVariant?: "default" | "success" | "error"
 }
 
 /**
@@ -51,6 +55,7 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
   confirm,
   errorMessage,
   successMessage,
+  successVariant = "default",
 }) => {
   const [isPending, setIsPending] = useState(false)
 
@@ -60,7 +65,7 @@ const ConfirmDialog: FC<ConfirmDialogProps> = ({
     try {
       await confirm.onClick()
       if (successMessage) {
-        toast(successMessage, { type: "success" })
+        toast(successMessage, { type: successVariant })
       }
     } catch (err) {
       const parsedMessage = parseApiError(err)


### PR DESCRIPTION
Closes #1112

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Fulfilled toast has `default` variant, instead of success, but it can also be overridden when needed.

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
