### PR TITLE
`RuleEngine` can handle datetime fields with proper Date component

### DIFF
--- a/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
+++ b/packages/app-elements/src/ui/forms/CodeEditor/fetchCoreResourcesSuggestions.ts
@@ -239,15 +239,23 @@ export async function atPath(
       if (className == null) {
         const field = acc.resource?.fields.find(([key]) => key === attr)?.[1]
 
+        if (field == null) {
+          return acc
+        }
+
+        let fieldType = field.type
+
+        if (fieldType === "string" && field?.format === "datetime") {
+          fieldType = "datetime"
+        }
+
         return {
           ...acc,
-          field:
-            field != null
-              ? {
-                  ...field,
-                  name: attr,
-                }
-              : undefined,
+          field: {
+            ...field,
+            type: fieldType,
+            name: attr,
+          },
         }
       }
 

--- a/packages/app-elements/src/ui/forms/RuleEngine/Condition/ConditionMatcher.tsx
+++ b/packages/app-elements/src/ui/forms/RuleEngine/Condition/ConditionMatcher.tsx
@@ -26,10 +26,6 @@ export function ConditionMatcher({
     fieldType = guessFieldType((item as ItemWithValue | null)?.value)
   }
 
-  if (fieldType === "string" && infos?.field?.format === "datetime") {
-    fieldType = "datetime"
-  }
-
   const resourceId = infos?.resource?.id
 
   const AGGREGATED_RESOURCE = ["tag"]


### PR DESCRIPTION
Related to commercelayer/issues-app#605

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I improved field type inference in `fetchCoreResourcesSuggestions.ts` to treat string fields with a `format` of `datetime` as actual datetime fields, ensuring correct UI behavior.