### PR TITLE
Remove unwanted path in docs tsconfig

### DIFF
--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -25,8 +25,7 @@
       "#providers/*": ["../app-elements/src/providers/*"],
       "#styles/*": ["../app-elements/src/styles/*"],
       "#ui/*": ["../app-elements/src/ui/*"],
-      "#utils/*": ["../app-elements/src/utils/*"],
-      "#node_modules/*": ["../app-elements/node_modules/*"]
+      "#utils/*": ["../app-elements/src/utils/*"]
     }
   },
   "include": [".storybook/*.tsx", "src"]


### PR DESCRIPTION
Closes #1128 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Removed unwanted path in `tsconfig.json` file of `docs` package.

This path was introduced in a previous project tsconfig refactor and it wasn't removed during a further tsconfig improvement section.