### PR TITLE
Add `cardId` prop to InputCheckboxGroup

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
@@ -48,6 +48,10 @@ interface Props extends Pick<InputWrapperBaseProps, "feedback"> {
    * Callback triggered when the user checks/unchecks an option or changes the quantity
    */
   onChange: (selected: SelectedItem[]) => void
+  /**
+   * set a unique id for the card element, useful for testing or accessibility purposes
+   **/
+  cardId?: string
 }
 
 /**
@@ -60,7 +64,15 @@ interface Props extends Pick<InputWrapperBaseProps, "feedback"> {
  * <span type="info">Quantity for each option item has a min/max range, to prevent selecting less or more than the allowed number.</span>
  */
 export const InputCheckboxGroup = withSkeletonTemplate<Props>(
-  ({ options, defaultValues = [], onChange, title, isLoading, feedback }) => {
+  ({
+    options,
+    defaultValues = [],
+    onChange,
+    title,
+    isLoading,
+    feedback,
+    cardId,
+  }) => {
     const [_state, dispatch] = useReducer(
       reducer,
       makeInitialState({ options, defaultValues }),
@@ -108,6 +120,7 @@ export const InputCheckboxGroup = withSkeletonTemplate<Props>(
           gap="1"
           overflow="hidden"
           className={cn(getFeedbackStyle(feedback))}
+          id={cardId}
         >
           {options.map((optionItem) => {
             const currentItem = _state.find(


### PR DESCRIPTION
## What I did

It's now possibile to pass an `id` attribute to the `Card` component inside the `InputCheckboxGroup`


## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
