### PR TITLE
Fix overflow issue on long titles

### DIFF
--- a/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
+++ b/packages/app-elements/src/ui/atoms/PageHeading/PageHeading.tsx
@@ -106,7 +106,7 @@ const PageHeading = withSkeletonTemplate<PageHeadingProps>(
           </div>
         )}
         <div className="flex items-center justify-between">
-          <h1 className="font-semibold text-2xl md:text-title leading-title break-word">
+          <h1 className="font-semibold text-2xl md:text-title leading-title break-all">
             {title}
           </h1>
           {navigationButton == null && toolbar != null ? (

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageLayout.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`PageLayout > Should be rendered 1`] = `
         class="flex items-center justify-between"
       >
         <h1
-          class="font-semibold text-2xl md:text-title leading-title break-word"
+          class="font-semibold text-2xl md:text-title leading-title break-all"
         >
           Page title
         </h1>

--- a/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
+++ b/packages/app-elements/src/ui/composite/__snapshots__/PageSkeleton.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`PageSkeleton > Should be rendered 1`] = `
                 class="flex items-center justify-between"
               >
                 <h1
-                  class="font-semibold text-2xl md:text-title leading-title break-word"
+                  class="font-semibold text-2xl md:text-title leading-title break-all"
                 >
                   <span
                     class="select-none border-gray-50! pointer-events-none animate-pulse bg-gray-50! rounded text-transparent *:invisible object-out-of-bounds"

--- a/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
+++ b/packages/app-elements/src/ui/resources/ResourcePaymentMethod.tsx
@@ -147,7 +147,7 @@ export const ResourcePaymentMethod: FC<ResourcePaymentMethodProps> = ({
             {Object.entries(paymentResponse).map(([key, value]) => (
               <div key={key}>
                 <span className="font-semibold">{key}: </span>
-                <span className="font-medium break-words overflow-hidden">
+                <span className="font-medium break-all overflow-hidden">
                   {typeof value === "string" || typeof value === "number"
                     ? value
                     : typeof value === "boolean"


### PR DESCRIPTION
Closes [#610](https://github.com/commercelayer/issues-app/issues/610)


## What I did

Fixed `break-all` classname used in title to prevent overflow with long ids or to break long urls.
The issue was caused by old classnames that were not updated during TW4 migration.
