### PR TITLE
Improve `CodeBlock` font sizes

### DIFF
--- a/packages/app-elements/src/ui/atoms/CodeBlock.tsx
+++ b/packages/app-elements/src/ui/atoms/CodeBlock.tsx
@@ -53,8 +53,10 @@ export const CodeBlock = withSkeletonTemplate<CodeBlockProps>(
         <div className="flex group w-full rounded bg-gray-50 in-[.overlay-container]:bg-gray-200">
           <div
             className={cn(
-              "flex flex-col w-full px-4 py-2.5 text-primary text-sm font-mono font-medium marker:font-semibold leading-5 border-none break-all",
-              typeof children !== "string" ? "whitespace-pre-wrap" : "",
+              "flex flex-col w-full px-4 py-2.5 text-primary font-mono font-medium marker:font-semibold leading-5 border-none break-all",
+              typeof children !== "string"
+                ? "whitespace-pre-wrap text-xs"
+                : "text-sm",
             )}
             data-testid="codeblock-content"
           >


### PR DESCRIPTION
Related commercelayer/issues-app/issues/430

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Improved font sizes of `CodeBlock` component to use a smaller (13px) font size when rendering JSON objects.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
