### PR TITLE
Use case insensitive in search

### DIFF
--- a/packages/app-elements/src/hooks/useEditTagsOverlay.tsx
+++ b/packages/app-elements/src/hooks/useEditTagsOverlay.tsx
@@ -207,7 +207,7 @@ export function useEditTagsOverlay(): TagsOverlayHook {
                     .list({
                       fields: ["id", "name"],
                       filters: {
-                        ...(!isEmpty(hint) && { name_cont: hint }),
+                        ...(!isEmpty(hint) && { name_i_cont: hint }),
                       },
                       pageSize: 25,
                     })

--- a/packages/app-elements/src/providers/TokenProvider/types.ts
+++ b/packages/app-elements/src/providers/TokenProvider/types.ts
@@ -1,4 +1,4 @@
-import type { ListableResourceType, ResourceTypeLock } from "@commercelayer/sdk"
+import type { ListableResourceType } from "@commercelayer/sdk"
 import type { ParsedScopes } from "#providers/TokenProvider/getInfoFromJwt"
 
 export type TokenProviderClAppSlug =

--- a/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
+++ b/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
@@ -150,7 +150,7 @@ export const HookedMarketWithCurrencySelector: FC<
                   .list({
                     pageSize: 25,
                     filters: {
-                      name_cont: hint,
+                      name_i_cont: hint,
                     },
                     fields: {
                       markets: ["name", "price_list"],

--- a/packages/app-elements/src/ui/forms/RuleEngine/InputResourceSelector.tsx
+++ b/packages/app-elements/src/ui/forms/RuleEngine/InputResourceSelector.tsx
@@ -99,7 +99,7 @@ function getParams({ value }: { value: string }): QueryParamsList<Tag> {
       name: "asc",
     },
     filters: {
-      name_cont: value,
+      name_i_cont: value,
     },
   }
 }


### PR DESCRIPTION
Related commercelayer/issues-app/issues/642

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Updated some components to force search case to be insensitive using the `i_cont` filter.

These are the file modified and a bit of context for them:
- `useEditTagsOverlay`: the modified search here is used to search for tags to be assigned to current resource
- `HookedMarketWithCurrencySelector`: this form component is mainly used in `dashboard` while assigning market / currency to `payment_methods`, `shipping_methods` and `sku_options`
- `InputResourceSelector`: this form component is used all along rule engine related `app-elements` components

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
