### PR TITLE
Avoid resetting the `hasMorePages` flag when fetching new items in `HookedMarketWithCurrencySelector`

### DIFF
--- a/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
+++ b/packages/app-elements/src/ui/forms/MarketWithCurrencySelector/HookedMarketWithCurrencySelector.tsx
@@ -159,7 +159,6 @@ export const HookedMarketWithCurrencySelector: FC<
                     include: ["price_list"],
                   })
                   .then((res) => {
-                    setHasMorePages(res.meta.pageCount > 1)
                     return res.map((market) => ({
                       label: market.name,
                       value: market.id,


### PR DESCRIPTION
Related to commercelayer/issues-app#651


In HookedMarketWithCurrencySelector , `hasMorePages` flag was being set to false when fetching items with less that 25 results.
This was causing the component to re-render in not-async mode.