### PR TITLE
Add `checkboxPosition` prop to `InputCheckbox` and `InputCheckboxGroup`

### DIFF
--- a/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.test.tsx
@@ -71,4 +71,20 @@ describe("InputCheckbox", () => {
     fireEvent.click(label)
     expect(input.checked).toBe(false)
   })
+
+  test("Should render the checkbox before the content by default", () => {
+    const utils = render(<InputCheckbox>Check me</InputCheckbox>)
+    const label = utils.getByTestId("checkbox-label")
+    const input = utils.getByTestId("checkbox-input")
+    expect(label.firstElementChild).toBe(input)
+  })
+
+  test("Should render the checkbox after the content when position is right", () => {
+    const utils = render(
+      <InputCheckbox checkboxPosition="right">Check me</InputCheckbox>,
+    )
+    const label = utils.getByTestId("checkbox-label")
+    const input = utils.getByTestId("checkbox-input")
+    expect(label.lastElementChild).toBe(input)
+  })
 })

--- a/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckbox/InputCheckbox.tsx
@@ -20,6 +20,12 @@ export interface InputCheckboxProps
    */
   checkedElement?: JSX.Element
   children?: React.ReactNode
+  /**
+   * Position of the checkbox relative to the main content.
+   * When `right`, the checkbox is rendered after the content.
+   * @default 'left'
+   */
+  checkboxPosition?: "left" | "right"
 }
 
 export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
@@ -32,12 +38,37 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
       children,
       checkedElement,
       hideIconOnDesktop,
+      checkboxPosition = "left",
       ...rest
     },
     ref,
   ): JSX.Element => {
     const [checked, setChecked] = useState<boolean>(
       rest.defaultChecked ?? rest.checked ?? false,
+    )
+
+    const inputCheckbox = (
+      <input
+        type="checkbox"
+        onChangeCapture={(event) => {
+          setChecked(event.currentTarget.checked)
+          rest.onChangeCapture?.(event)
+        }}
+        onChange={(event) => {
+          setChecked(event.currentTarget.checked)
+          rest.onChange?.(event)
+        }}
+        data-testid="checkbox-input"
+        className={cn(
+          "w-5 h-5 text-primary focus:ring-primary",
+          "border! border-solid! border-gray-300! rounded-sm",
+          "[box-shadow:none]! checked:border-primary!",
+          { "cursor-pointer": rest.disabled !== true },
+          getFeedbackStyle(feedback),
+        )}
+        {...rest}
+        ref={ref}
+      />
     )
 
     return (
@@ -48,6 +79,7 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
       >
         <div className={cn("flex items-center w-full", className)}>
           {/** biome-ignore lint/a11y/useKeyWithClickEvents: I need to stop event propagation */}
+          {/** biome-ignore lint/a11y/noLabelWithoutControl: The input is present as variable, and always visible */}
           <label
             data-testid="checkbox-label"
             className={cn(
@@ -60,28 +92,7 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
               e.stopPropagation()
             }}
           >
-            <input
-              type="checkbox"
-              onChangeCapture={(event) => {
-                setChecked(event.currentTarget.checked)
-                rest.onChangeCapture?.(event)
-              }}
-              onChange={(event) => {
-                setChecked(event.currentTarget.checked)
-                rest.onChange?.(event)
-              }}
-              data-testid="checkbox-input"
-              className={cn(
-                "w-[20px] h-[20px] text-primary focus:ring-primary",
-                "border! border-solid! border-gray-300! rounded-sm",
-                "[box-shadow:none]! checked:border-primary!",
-                { "cursor-pointer": rest.disabled !== true },
-                getFeedbackStyle(feedback),
-              )}
-              {...rest}
-              ref={ref}
-            />
-
+            {checkboxPosition === "left" && inputCheckbox}
             {children != null || icon != null ? (
               <div className="flex items-center gap-4 flex-1">
                 {icon != null ? (
@@ -92,10 +103,18 @@ export const InputCheckbox = forwardRef<HTMLInputElement, InputCheckboxProps>(
                 <div className="flex-1 text-sm font-medium">{children}</div>
               </div>
             ) : null}
+            {checkboxPosition === "right" && inputCheckbox}
           </label>
         </div>
         {checkedElement != null && (rest.checked === true || checked) && (
-          <div className="my-2 ml-[18px] pl-4">{checkedElement}</div>
+          <div
+            className={cn("my-2", {
+              "ml-4.5 pl-4": checkboxPosition === "left",
+              "mr-4.5 pr-4": checkboxPosition === "right",
+            })}
+          >
+            {checkedElement}
+          </div>
         )}
       </InputWrapper>
     )

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.test.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.test.tsx
@@ -188,6 +188,30 @@ describe("InputCheckboxGroup with quantity", () => {
       { value: "BABYBIBXA19D9D000000XXXX", quantity: 5 },
     ])
   })
+
+  test("Should render the checkbox before the content by default", () => {
+    const { getAllByTestId } = render(
+      <InputCheckboxGroup options={options} onChange={() => {}} />,
+    )
+    getAllByTestId("checkbox-label").forEach((label) => {
+      const input = label.querySelector('[data-testid="checkbox-input"]')
+      expect(label.firstElementChild).toBe(input)
+    })
+  })
+
+  test("Should render the checkbox after the content when position is right", () => {
+    const { getAllByTestId } = render(
+      <InputCheckboxGroup
+        options={options}
+        onChange={() => {}}
+        checkboxPosition="right"
+      />,
+    )
+    getAllByTestId("checkbox-label").forEach((label) => {
+      const input = label.querySelector('[data-testid="checkbox-input"]')
+      expect(label.lastElementChild).toBe(input)
+    })
+  })
 })
 
 const optionsWithoutQuantity = options.map((option) => {

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroup.tsx
@@ -52,6 +52,12 @@ interface Props extends Pick<InputWrapperBaseProps, "feedback"> {
    * set a unique id for the card element, useful for testing or accessibility purposes
    **/
   cardId?: string
+  /**
+   * Position of the checkbox relative to each item's content.
+   * When `right`, the checkbox is rendered after the content.
+   * @default 'left'
+   */
+  checkboxPosition?: "left" | "right"
 }
 
 /**
@@ -72,6 +78,7 @@ export const InputCheckboxGroup = withSkeletonTemplate<Props>(
     isLoading,
     feedback,
     cardId,
+    checkboxPosition = "left",
   }) => {
     const [_state, dispatch] = useReducer(
       reducer,
@@ -134,6 +141,7 @@ export const InputCheckboxGroup = withSkeletonTemplate<Props>(
                 isLoading={isLoading}
                 checked={Boolean(currentItem?.isSelected)}
                 defaultQuantity={currentItem?.quantity}
+                checkboxPosition={checkboxPosition}
                 onChange={(value, newQty) => {
                   if (newQty != null) {
                     dispatch({

--- a/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroupItem.tsx
+++ b/packages/app-elements/src/ui/forms/InputCheckboxGroup/InputCheckboxGroupItem.tsx
@@ -1,3 +1,4 @@
+import cn from "classnames"
 import type { ComponentProps } from "react"
 import { withSkeletonTemplate } from "#ui/atoms/SkeletonTemplate"
 import { ListItem } from "#ui/composite/ListItem"
@@ -32,7 +33,9 @@ export interface InputCheckboxGroupOption
   }
 }
 
-export interface Props extends InputCheckboxGroupOption {
+export interface Props
+  extends InputCheckboxGroupOption,
+    Pick<InputCheckboxProps, "checkboxPosition"> {
   /**
    * Callback triggered when the user checks/unchecks an option or changes the quantity.
    * New quantity is returned only if `quantity` is part of the option (`InputCheckboxGroupOption`).
@@ -59,16 +62,17 @@ export const InputCheckboxGroupItem = withSkeletonTemplate<Props>(
     hideIconOnDesktop,
     checkedElement,
     icon,
+    checkboxPosition = "left",
   }) => {
     return (
-      // Ensure the hover effect applies to the entire row, including the checkedElement section if present
-      <div className="hover:bg-gray-50">
+      // Ensure the alternating and hover backgrounds apply to the entire row, including the checkedElement section if present
+      <div className="odd:bg-gray-50 hover:bg-gray-100">
         <ListItem
           alignItems="center"
           alignIcon="center"
           borderStyle="none"
           padding="none"
-          className="rounded flex items-center gap-3 py-1.5 px-2"
+          className="rounded flex items-center gap-3 py-1.5 px-2 hover:bg-gray-100"
           onClick={() => {
             onChange(value)
           }}
@@ -79,6 +83,7 @@ export const InputCheckboxGroupItem = withSkeletonTemplate<Props>(
             checked={checked}
             icon={icon}
             hideIconOnDesktop={hideIconOnDesktop}
+            checkboxPosition={checkboxPosition}
             onChange={() => {
               onChange(value)
             }}
@@ -109,7 +114,14 @@ export const InputCheckboxGroupItem = withSkeletonTemplate<Props>(
           )}
         </ListItem>
         {checkedElement != null && checked && (
-          <div className="pb-4 pr-3 pl-11">{checkedElement}</div>
+          <div
+            className={cn("pb-4", {
+              "pr-3 pl-11": checkboxPosition === "left",
+              "pl-3 pr-11": checkboxPosition === "right",
+            })}
+          >
+            {checkedElement}
+          </div>
         )}
       </div>
     )

--- a/packages/app-elements/src/ui/internals/FlexRow.tsx
+++ b/packages/app-elements/src/ui/internals/FlexRow.tsx
@@ -1,5 +1,5 @@
 import cn from "classnames"
-import { Children, type JSX, type ReactNode } from "react"
+import { Children, isValidElement, type JSX, type ReactNode } from "react"
 
 export type FlexRowAlignItems = "top" | "bottom" | "center"
 export interface FlexRowProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -30,16 +30,20 @@ function FlexRow({
       )}
       {...rest}
     >
-      {Children.map(children, (child, index) => (
-        <div
-          className={cn({
-            grow: !isLastOfMultipleChildren(index, childrenCount),
-            "text-right": isLastOfMultipleChildren(index, childrenCount),
-          })}
-        >
-          {child}
-        </div>
-      ))}
+      {Children.map(
+        children,
+        (child, index) =>
+          isValidElement(child) && (
+            <div
+              className={cn({
+                grow: !isLastOfMultipleChildren(index, childrenCount),
+                "text-right": isLastOfMultipleChildren(index, childrenCount),
+              })}
+            >
+              {child}
+            </div>
+          ),
+      )}
     </div>
   )
 }

--- a/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputCheckbox.stories.tsx
@@ -133,3 +133,39 @@ export const WithCheckedElement: StoryFn<typeof InputCheckbox> = (_args) => {
     </div>
   )
 }
+
+/**
+ * By setting the `checkboxPosition` prop to `right`, the checkbox is rendered after the main content.
+ */
+
+export const CheckboxOnRight: StoryFn<typeof InputCheckbox> = (_args) => {
+  return (
+    <div style={{ height: "300px" }}>
+      <InputCheckbox checkboxPosition="right">First checkbox</InputCheckbox>
+      <InputCheckbox
+        checkboxPosition="right"
+        defaultChecked
+        checkedElement={<Input />}
+      >
+        Set a name
+      </InputCheckbox>
+      <InputCheckbox
+        checkboxPosition="right"
+        checkedElement={
+          <InputSelect
+            onSelect={() => {}}
+            hint={{ text: "Select your preferred color." }}
+            initialValues={[
+              { label: "Red", value: "red" },
+              { label: "Green", value: "green" },
+              { label: "Blue", value: "blue" },
+            ]}
+          />
+        }
+      >
+        Preferred color
+      </InputCheckbox>
+      <InputCheckbox checkboxPosition="right">Last checkbox</InputCheckbox>
+    </div>
+  )
+}

--- a/packages/docs/src/stories/forms/ui/InputCheckboxGroup.stories.tsx
+++ b/packages/docs/src/stories/forms/ui/InputCheckboxGroup.stories.tsx
@@ -300,6 +300,68 @@ WithCheckedElement.args = {
   ],
 }
 
+/**
+ * By setting the `checkboxPosition` prop to `right`, the checkbox is rendered after each item's content.
+ */
+export const CheckboxOnRight = Template.bind({})
+CheckboxOnRight.args = {
+  title: "Items",
+  checkboxPosition: "right",
+  options: [
+    {
+      value: "adyen",
+      icon: (
+        <img
+          src="https://data.commercelayer.app/assets/images/icons/credit-cards/color/adyen.svg"
+          alt="Adyen Payment"
+          className="h-6"
+        />
+      ),
+      content: (
+        <div>
+          <Text size="small" tag="div" weight="semibold">
+            Adyen Payment
+          </Text>
+        </div>
+      ),
+    },
+    {
+      value: "giftcard",
+      icon: (
+        <img
+          src="https://data.commercelayer.app/assets/images/icons/credit-cards/color/giftcard.svg"
+          alt="Gift Card"
+          className="h-6"
+        />
+      ),
+      content: (
+        <div>
+          <Text size="small" tag="div" weight="semibold">
+            Gift Card
+          </Text>
+        </div>
+      ),
+    },
+    {
+      value: "Stripe",
+      icon: (
+        <img
+          src="https://data.commercelayer.app/assets/images/icons/credit-cards/color/stripe.svg"
+          alt="Stripe"
+          className="h-6"
+        />
+      ),
+      content: (
+        <div>
+          <Text size="small" tag="div" weight="semibold">
+            Stripe
+          </Text>
+        </div>
+      ),
+    },
+  ],
+}
+
 export const WithErrors = Template.bind({})
 WithErrors.args = {
   ...Default.args,


### PR DESCRIPTION
Related to commercelayer/issues-app#661

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "Related to #1000, Related to #1001"). -->

## What I did

- Add `checkboxPosition` (`'left' | 'right'`, default `'left'`) prop to `InputCheckbox`, rendering the checkbox after the content when `'right'`.
- Forward `checkboxPosition` through `InputCheckboxGroup` and `InputCheckboxGroupItem` to each item's checkbox.
- Mirror the `checkedElement` indentation to the correct side based on `checkboxPosition`.
- Add zebra striping (alternating `gray-50`/white rows) and a `gray-100` hover to `InputCheckboxGroup` items.
- [FIX] Skip invalid (non-element) children in `FlexRow` to avoid rendering empty wrappers.
- Add stories and tests covering the right-positioned checkbox.

<img width="681" height="200" alt="image" src="https://github.com/user-attachments/assets/5f703ee9-066f-4523-85d2-f52812461930" />

https://deploy-preview-1179--commercelayer-app-elements.netlify.app/?path=/docs/forms-ui-inputcheckboxgroup--docs#checkbox-on-right

## How to test

1. Open the deploy preview story: `Forms/ui/InputCheckboxGroup` → `CheckboxOnRight`.
2. Confirm the checkbox renders **after** each item's content (icon + label on the left, checkbox on the right).
3. Toggle an item that has a `checkedElement` and verify the revealed element is indented on the correct side (`pl-3 pr-11`).
4. Hover over rows and confirm the alternating `gray-50`/white striping and the `gray-100` hover background.
5. Open `Forms/ui/InputCheckbox` → `CheckboxOnRight` and repeat the checks for the standalone component, including the `checkedElement` cases.
6. Leave `checkboxPosition` unset and confirm the default `left` layout is unchanged.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
