### PR TITLE
Update list item UI of `upcoming` stock transfer

### DIFF
--- a/packages/app-elements/src/dictionaries/stockTransfers.ts
+++ b/packages/app-elements/src/dictionaries/stockTransfers.ts
@@ -17,9 +17,8 @@ export function getStockTransferDisplayStatus(
     case "upcoming":
       return {
         label: t("resources.stock_transfers.attributes.status.upcoming"),
-        icon: "arrowUpRight",
-        color: "orange",
-        task: t("resources.stock_transfers.attributes.status.upcoming"),
+        icon: "arrowsLeftRight",
+        color: "white",
       }
 
     case "on_hold":

--- a/packages/app-elements/src/ui/resources/ResourceListItem/transformers/stockTransfers.tsx
+++ b/packages/app-elements/src/ui/resources/ResourceListItem/transformers/stockTransfers.tsx
@@ -1,6 +1,7 @@
 import type { StockTransfer } from "@commercelayer/sdk"
 import { getStockTransferDisplayStatus } from "#dictionaries/stockTransfers"
 import { formatDate } from "#helpers/date"
+import { RadialProgress } from "#ui/atoms/RadialProgress"
 import {
   ListItemDescription,
   ListItemIcon,
@@ -38,8 +39,11 @@ export const stockTransferToProps: ResourceToProps<StockTransfer> = ({
         additionalInfos={`${originStockLocationName} · ${destinationStockLocationName}`}
       />
     ),
-    icon: (
-      <ListItemIcon icon={displayStatus.icon} color={displayStatus.color} />
-    ),
+    icon:
+      resource.status === "upcoming" ? (
+        <RadialProgress icon={displayStatus.icon} />
+      ) : (
+        <ListItemIcon icon={displayStatus.icon} color={displayStatus.color} />
+      ),
   }
 }


### PR DESCRIPTION
Related commercelayer/issues-app/issues/649

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Updated UI of `stock_transfers` list item for status `upcoming` to be similar to pending orders.

<img width="600" src="https://github.com/user-attachments/assets/5f89fc5c-d543-4bce-a95c-32b114cbbcb6" />

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
