### PR TITLE
Mock rules JSON schema in tests and cancel state update on unmount

### DIFF
--- a/packages/app-elements/src/mocks/data/core_schemas.ts
+++ b/packages/app-elements/src/mocks/data/core_schemas.ts
@@ -1,0 +1,16 @@
+import { HttpResponse, http } from "msw"
+
+import orderRulesJsonSchema from "#ui/forms/RuleEngine/json_schema/order_rules.json"
+import priceRulesJsonSchema from "#ui/forms/RuleEngine/json_schema/price_rules.json"
+
+const orderRulesSchema = http.get(
+  `https://core.commercelayer.*/api/public/schemas/order_rules`,
+  async () => HttpResponse.json(orderRulesJsonSchema),
+)
+
+const priceRulesSchema = http.get(
+  `https://core.commercelayer.*/api/public/schemas/price_rules`,
+  async () => HttpResponse.json(priceRulesJsonSchema),
+)
+
+export default [orderRulesSchema, priceRulesSchema]

--- a/packages/app-elements/src/mocks/handlers.ts
+++ b/packages/app-elements/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from "msw"
 
 import corePublicResources from "./data/core_resources"
+import coreSchemas from "./data/core_schemas"
 import countries from "./data/countries"
 import customers from "./data/customers"
 import markets from "./data/markets"
@@ -107,6 +108,7 @@ export const handlers = [
   }),
 
   ...corePublicResources,
+  ...coreSchemas,
   ...customers,
   ...countries,
   ...markets,

--- a/packages/app-elements/src/mocks/setup.ts
+++ b/packages/app-elements/src/mocks/setup.ts
@@ -10,13 +10,6 @@ beforeAll(() => {
         return
       }
 
-      if (
-        url.href ===
-        "https://core.commercelayer.io/api/public/schemas/order_rules"
-      ) {
-        return
-      }
-
       // Otherwise, print a warning for any unhandled request.
       print.error()
     },

--- a/packages/app-elements/src/ui/forms/RuleEngine/RuleEngineComponent.tsx
+++ b/packages/app-elements/src/ui/forms/RuleEngine/RuleEngineComponent.tsx
@@ -93,13 +93,23 @@ export function RuleEngine(props: RuleEngineProps): React.JSX.Element {
 
   useEffect(
     function parseSchema() {
-      fetchJsonSchema(props.schemaType, domain).then((jsonSchema) => {
+      let cancelled = false
+
+      void fetchJsonSchema(props.schemaType, domain).then((jsonSchema) => {
+        if (cancelled) {
+          return
+        }
+
         const parsedOptionsConfig = parseOptionsFromSchema(
           jsonSchema as any,
           props.schemaType,
         )
         setOptionsConfig(parsedOptionsConfig)
       })
+
+      return () => {
+        cancelled = true
+      }
     },
     [domain],
   )


### PR DESCRIPTION
Closes #1187 

## Problem

`fetchJsonSchema` was performing a **real network request** to
`https://core.commercelayer.io/api/public/schemas/order_rules`: no MSW handler
existed, and that URL was explicitly excluded from the `onUnhandledRequest`
warning in `src/mocks/setup.ts`. Depending on network latency the promise could
resolve **after** the test file had finished, running `setOptionsConfig` against
an already torn-down jsdom environment.

## Changes

- **`src/mocks/data/core_schemas.ts`** (new): MSW handlers serving `order_rules`
  and `price_rules` from the local JSON files already present in
  `RuleEngine/json_schema/`, registered in `src/mocks/handlers.ts`. No more
  network calls in tests.
- **`src/mocks/setup.ts`**: removed the `onUnhandledRequest` bypass for that URL,
  so unmocked requests are reported again.
- **`RuleEngineComponent.tsx`**: the schema-parsing effect now returns a cleanup
  that sets a `cancelled` flag, preventing the state update after unmount. This
  is a general fix, relevant in production too on fast navigations.


## Extra
If we want to keep testing against real API data, we can add the following test

```
it.concurrent("local order_rules schema matches remote", async () => {
  const remote = await fetch("https://core.commercelayer.io/api/public/schemas/order_rules").then(r => r.json())
  expect(remote).toEqual(orderRulesJsonSchema)
})
```